### PR TITLE
Improve NEST GPU Utilization 3/N

### DIFF
--- a/nemo/collections/asr/data/ssl_dataset.py
+++ b/nemo/collections/asr/data/ssl_dataset.py
@@ -43,6 +43,8 @@ class AudioNoiseItem:
     audio_len: Union[Tensor, None] = None
     noise: Union[Tensor, None] = None
     noise_len: Union[Tensor, None] = None
+    noisy_audio: Union[Tensor, None] = None
+    noisy_audio_len: Union[Tensor, None] = None
 
 
 @dataclass

--- a/nemo/collections/asr/data/ssl_dataset.py
+++ b/nemo/collections/asr/data/ssl_dataset.py
@@ -136,7 +136,6 @@ def _audio_noise_collate_fn(batch: List[AudioNoiseItem], batch_augmentor: Any = 
     else:
         output.noisy_audio = output.audio + output.noise
         output.noisy_audio_len = output.audio_len
-        output.noise, output.noise_len = None, None
 
     return output
 
@@ -466,7 +465,6 @@ class LhotseAudioNoiseDataset(torch.utils.data.Dataset):
         else:
             output.noisy_audio = output.audio + output.noise
             output.noisy_audio_len = output.audio_len
-            output.noise, output.noise_len = None, None
 
         return output
 

--- a/nemo/collections/asr/data/ssl_dataset.py
+++ b/nemo/collections/asr/data/ssl_dataset.py
@@ -43,8 +43,6 @@ class AudioNoiseItem:
     audio_len: Union[Tensor, None] = None
     noise: Union[Tensor, None] = None
     noise_len: Union[Tensor, None] = None
-    noisy_audio: Union[Tensor, None] = None
-    noisy_audio_len: Union[Tensor, None] = None
 
 
 @dataclass
@@ -103,12 +101,8 @@ def _audio_noise_collate_fn(batch: List[AudioNoiseItem], batch_augmentor: Any = 
     noises = [x.noise for x in batch]
     noise_lengths = [x.noise_len for x in batch]
 
-    noisy_audios = [x.noisy_audio for x in batch]
-    noisy_audio_lengths = [x.noisy_audio_len for x in batch]
-
     audio_signal_list = []
     noise_signal_list = []
-    noisy_audio_signal_list = []
     for i, audio in enumerate(audios):
         audio_len = audio.size(0)
         if audio_len < max_audio_len:
@@ -123,31 +117,26 @@ def _audio_noise_collate_fn(batch: List[AudioNoiseItem], batch_augmentor: Any = 
             noise = torch.nn.functional.pad(noise, pad)
         noise_signal_list.append(noise[:max_audio_len])
 
-        noisy_audio = noisy_audios[i]
-        noisy_audio_len = noisy_audio.size(0)
-        if noisy_audio_len < max_audio_len:
-            pad = (0, max_audio_len - noisy_audio_len)
-            noisy_audio = torch.nn.functional.pad(noisy_audio, pad)
-        noisy_audio_signal_list.append(noisy_audio[:max_audio_len])
-
     audio_signal = torch.stack(audio_signal_list).float()
     audio_lengths = torch.stack(audio_lengths).long()
     noise_signal = torch.stack(noise_signal_list).float()
     noise_lengths = torch.stack(noise_lengths).long()
-    noisy_audio_signal = torch.stack(noisy_audio_signal_list).float()
-    noisy_audio_lengths = torch.stack(noisy_audio_lengths).long()
 
     output = AudioNoiseBatch(
         audio=audio_signal,
         audio_len=audio_lengths,
         noise=noise_signal,
         noise_len=noise_lengths,
-        noisy_audio=noisy_audio_signal,
-        noisy_audio_len=noisy_audio_lengths,
+        noisy_audio=None,
+        noisy_audio_len=None,
     )
 
     if batch_augmentor is not None:
         output = batch_augmentor(output)
+    else:
+        output.noisy_audio = output.audio + output.noise
+        output.noisy_audio_len = output.audio_len
+        output.noise, output.noise_len = None, None
 
     return output
 
@@ -344,8 +333,6 @@ class AudioNoiseDataset(audio_to_text.AudioToCharDataset):
             audio_len=audio_len,
             noise=noise,
             noise_len=noise_len,
-            noisy_audio=audio + noise,
-            noisy_audio_len=audio_len,
         )
         return item
 
@@ -421,8 +408,6 @@ class TarredAudioNoiseDataset(audio_to_text.TarredAudioToCharDataset):
             audio_len=audio_len,
             noise=noise,
             noise_len=noise_len,
-            noisy_audio=audio + noise,
-            noisy_audio_len=audio_len,
         )
         return item
 
@@ -460,23 +445,30 @@ class LhotseAudioNoiseDataset(torch.utils.data.Dataset):
     def __getitem__(self, cuts):
 
         audios, audio_lens, cuts = self.load_audio(cuts)
-        sampled_noises = [sample_noise(self.noise_data, cut.sampling_rate, cut.num_samples) for cut in cuts]
-
-        sampled_noises, sampled_noises_lens = zip(*sampled_noises)
-        sampled_noises = torch.stack(sampled_noises).float()
-        sampled_noises_lens = torch.tensor(sampled_noises_lens).long()
+        if len(self.noise_data) > 0:
+            sampled_noises = [sample_noise(self.noise_data, cut.sampling_rate, cut.num_samples) for cut in cuts]
+            sampled_noises, sampled_noises_lens = zip(*sampled_noises)
+            sampled_noises = torch.stack(sampled_noises).float()
+            sampled_noises_lens = torch.tensor(sampled_noises_lens).long()
+        else:
+            sampled_noises = torch.zeros_like(audios)
+            sampled_noises_lens = audio_lens
 
         output = AudioNoiseBatch(
             audio=audios,
             audio_len=audio_lens,
             noise=sampled_noises,
             noise_len=sampled_noises_lens,
-            noisy_audio=audios + sampled_noises,
-            noisy_audio_len=audio_lens,
+            noisy_audio=None,
+            noisy_audio_len=None,
         )
 
         if self.batch_augmentor is not None:
             output = self.batch_augmentor(output)
+        else:
+            output.noisy_audio = output.audio + output.noise
+            output.noisy_audio_len = output.audio_len
+            output.noise, output.noise_len = None, None
 
         return output
 

--- a/nemo/collections/asr/data/ssl_dataset.py
+++ b/nemo/collections/asr/data/ssl_dataset.py
@@ -129,8 +129,6 @@ def _audio_noise_collate_fn(batch: List[AudioNoiseItem], batch_augmentor: Any = 
         audio_len=audio_lengths,
         noise=noise_signal,
         noise_len=noise_lengths,
-        noisy_audio=None,
-        noisy_audio_len=None,
     )
 
     if batch_augmentor is not None:
@@ -461,8 +459,6 @@ class LhotseAudioNoiseDataset(torch.utils.data.Dataset):
             audio_len=audio_lens,
             noise=sampled_noises,
             noise_len=sampled_noises_lens,
-            noisy_audio=None,
-            noisy_audio_len=None,
         )
 
         if self.batch_augmentor is not None:

--- a/nemo/collections/asr/models/ssl_models.py
+++ b/nemo/collections/asr/models/ssl_models.py
@@ -1018,6 +1018,8 @@ class EncDecDenoiseMaskedTokenPredModel(EncDecMaskedTokenPredModel):
         log_probs, encoded_len, masks, tokens = self.forward(
             input_signal=batch.audio,
             input_signal_length=batch.audio_len,
+            noise_signal=batch.noise,
+            noise_signal_length=batch.noise_len,
             noisy_input_signal=batch.noisy_audio,
             noisy_input_signal_length=batch.noisy_audio_len,
             apply_mask=True,

--- a/nemo/collections/asr/models/ssl_models.py
+++ b/nemo/collections/asr/models/ssl_models.py
@@ -1018,8 +1018,6 @@ class EncDecDenoiseMaskedTokenPredModel(EncDecMaskedTokenPredModel):
         log_probs, encoded_len, masks, tokens = self.forward(
             input_signal=batch.audio,
             input_signal_length=batch.audio_len,
-            noise_signal=batch.noise,
-            noise_signal_length=batch.noise_len,
             noisy_input_signal=batch.noisy_audio,
             noisy_input_signal_length=batch.noisy_audio_len,
             apply_mask=True,

--- a/nemo/collections/asr/modules/ssl_modules/augmentation.py
+++ b/nemo/collections/asr/modules/ssl_modules/augmentation.py
@@ -83,8 +83,6 @@ class SpeakerNoiseAugmentation(object):
 
         noise = batch.noise
         noise_len = batch.noise_len
-        noisy_audio = batch.noisy_audio
-        noisy_audio_len = batch.noisy_audio_len
         for i in range(batch_size):
             if np.random.rand() > self.prob:
                 continue
@@ -129,9 +127,6 @@ class SpeakerNoiseAugmentation(object):
             noise_signal = torch.zeros_like(audio_signal[i])
             noise_signal[mix_start_idx : mix_start_idx + mix_len] = mix_scale * noise_clip
 
-            # add noise to audio
-            noisy_audio[i] = audio_signal[i] + noise_signal
-            noisy_audio_len[i] = audio_lengths[i]
             noise[i] = noise_signal
             noise_len[i] = audio_lengths[i]
 
@@ -139,10 +134,10 @@ class SpeakerNoiseAugmentation(object):
             sample_id=batch.sample_id,
             audio=batch.audio,
             audio_len=batch.audio_len,
-            noise=noise,
-            noise_len=noise_len,
-            noisy_audio=noisy_audio,
-            noisy_audio_len=noisy_audio_len,
+            noise=None,
+            noise_len=None,
+            noisy_audio=batch.audio + noise,
+            noisy_audio_len=noise_len,
         )
 
 
@@ -184,8 +179,6 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
 
         noise = batch.noise
         noise_len = batch.noise_len
-        noisy_audio = batch.noisy_audio
-        noisy_audio_len = batch.noisy_audio_len
         for i in range(batch_size):
             if np.random.rand() > self.prob:
                 continue
@@ -232,10 +225,6 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
 
             # get the residual signal to be added to original audio
             noise_signal = mix_scale * noise_signal
-
-            # add noise to audio
-            noisy_audio[i] = audio_signal[i] + noise_signal
-            noisy_audio_len[i] = audio_lengths[i]
             noise[i] = noise_signal
             noise_len[i] = audio_lengths[i]
 
@@ -243,10 +232,10 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
             sample_id=batch.sample_id,
             audio=batch.audio,
             audio_len=batch.audio_len,
-            noise=noise,
-            noise_len=noise_len,
-            noisy_audio=noisy_audio,
-            noisy_audio_len=noisy_audio_len,
+            noise=None,
+            noise_len=None,
+            noisy_audio=batch.audio + noise,
+            noisy_audio_len=noise_len,
         )
 
     def get_noise_segments(self, batch_idx, batch, segment_lens, num_speakers, mode):

--- a/nemo/collections/asr/modules/ssl_modules/augmentation.py
+++ b/nemo/collections/asr/modules/ssl_modules/augmentation.py
@@ -135,6 +135,8 @@ class SpeakerNoiseAugmentation(object):
             sample_id=batch.sample_id,
             audio=batch.audio,
             audio_len=batch.audio_len,
+            noise=noise,
+            noise_len=noise_len,
             noisy_audio=batch.audio + noise,
             noisy_audio_len=noise_len,
         )
@@ -231,6 +233,8 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
             sample_id=batch.sample_id,
             audio=batch.audio,
             audio_len=batch.audio_len,
+            noise=noise,
+            noise_len=noise_len,
             noisy_audio=batch.audio + noise,
             noisy_audio_len=noise_len,
         )

--- a/nemo/collections/asr/modules/ssl_modules/augmentation.py
+++ b/nemo/collections/asr/modules/ssl_modules/augmentation.py
@@ -135,8 +135,6 @@ class SpeakerNoiseAugmentation(object):
             sample_id=batch.sample_id,
             audio=batch.audio,
             audio_len=batch.audio_len,
-            noise=None,
-            noise_len=None,
             noisy_audio=batch.audio + noise,
             noisy_audio_len=noise_len,
         )
@@ -233,8 +231,6 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
             sample_id=batch.sample_id,
             audio=batch.audio,
             audio_len=batch.audio_len,
-            noise=None,
-            noise_len=None,
             noisy_audio=batch.audio + noise,
             noisy_audio_len=noise_len,
         )

--- a/nemo/collections/asr/modules/ssl_modules/augmentation.py
+++ b/nemo/collections/asr/modules/ssl_modules/augmentation.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import math
+import random
+from collections import Counter
 
-import numpy as np
 import torch
 
 from nemo.collections.asr.data.ssl_dataset import AudioNoiseBatch
@@ -84,26 +85,26 @@ class SpeakerNoiseAugmentation(object):
         noise = batch.noise
         noise_len = batch.noise_len
         for i in range(batch_size):
-            if np.random.rand() > self.prob:
+            if random.random() > self.prob:
                 continue
 
             # randomly select the length of mixing segment
             if 0 <= self.min_mix_rate < self.max_mix_rate <= 1:
-                mix_len = np.random.randint(
+                mix_len = random.randint(
                     int(audio_lengths[i] * self.min_mix_rate), int(audio_lengths[i] * self.max_mix_rate)
                 )
             else:
                 mix_len = max(1, int(audio_lengths[i] * self.min_mix_rate))
 
             # randomly select position to start the mixing
-            mix_start_idx = np.random.randint(audio_lengths[i] - mix_len)
+            mix_start_idx = random.randint(0, audio_lengths[i] - mix_len)
 
             # randomly select the energy ratio between speech and noise
-            if np.random.rand() < self.noise_ratio or batch_size == 1:
-                energy_ratio = np.random.uniform(self.min_r_noise, self.max_r_noise)
+            if random.random() < self.noise_ratio or batch_size == 1:
+                energy_ratio = random.uniform(self.min_r_noise, self.max_r_noise)
             else:
-                energy_ratio = np.random.uniform(self.min_r_speech, self.max_r_speech)
-                j = np.random.choice([x for x in range(batch_size) if x != i])
+                energy_ratio = random.uniform(self.min_r_speech, self.max_r_speech)
+                j = random.choice([x for x in range(batch_size) if x != i])
                 noise[i] = audio_signal[j].clone()
                 noise_len[i] = audio_lengths[j]
 
@@ -115,7 +116,7 @@ class SpeakerNoiseAugmentation(object):
                 noise_len[i] = mix_len
             else:
                 # randomly select a segment of noise
-                noise_start_idx = np.random.randint(noise_len[i] - mix_len)
+                noise_start_idx = random.randint(0, noise_len[i] - mix_len)
 
             # calculate the scale factor for noise
             audio_energy = torch.sum(audio_signal[i, : audio_lengths[i]] ** 2) / audio_lengths[i]
@@ -180,31 +181,31 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
         noise = batch.noise
         noise_len = batch.noise_len
         for i in range(batch_size):
-            if np.random.rand() > self.prob:
+            if random.random() > self.prob:
                 continue
 
             # randomly select the length of mixing segment
             if 0 <= self.min_mix_rate < self.max_mix_rate <= 1:
-                mix_rate = np.random.uniform(self.min_mix_rate, self.max_mix_rate)
+                mix_rate = random.uniform(self.min_mix_rate, self.max_mix_rate)
             else:
                 mix_rate = self.min_mix_rate
             mix_len = max(1, int(audio_lengths[i] * mix_rate))
 
             # randomly select the number of segments
-            num_segments = np.random.randint(self.min_num_segments, self.max_num_segments + 1)
-            num_speakers = np.random.randint(self.min_num_speakers, self.max_num_speakers + 1)
+            num_segments = random.randint(self.min_num_segments, self.max_num_segments + 1)
+            num_speakers = random.randint(self.min_num_speakers, self.max_num_speakers + 1)
             num_speakers = min(num_speakers, batch_size)
 
             # randomly chunk mix_len into num_segments
-            segment_lens = np.random.multinomial(mix_len, [1 / num_segments] * num_segments)
+            segment_lens = list(Counter(random.choices(range(num_segments), k=mix_len)).values())
 
             # randomly select the energy ratio between speech and noise
-            if np.random.rand() < self.noise_ratio or batch_size == 1:
+            if random.random() < self.noise_ratio or batch_size == 1:
                 mode = "noise"
-                energy_ratio = np.random.uniform(self.min_r_noise, self.max_r_noise)
+                energy_ratio = random.uniform(self.min_r_noise, self.max_r_noise)
             else:
                 mode = "speech"
-                energy_ratio = np.random.uniform(self.min_r_speech, self.max_r_speech)
+                energy_ratio = random.uniform(self.min_r_speech, self.max_r_speech)
 
             noise_segments = self.get_noise_segments(i, batch, segment_lens, num_speakers, mode)
             noise_signal = torch.zeros_like(audio_signal[i])
@@ -213,7 +214,7 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
             for j in range(num_segments):
                 start_idx = min_start_idx
                 if min_start_idx < max_start_idx:
-                    start_idx = np.random.randint(min_start_idx, max_start_idx)
+                    start_idx = random.randint(min_start_idx, max_start_idx)
                 noise_signal[start_idx : start_idx + segment_lens[j]] = noise_segments[j]
                 min_start_idx = start_idx + segment_lens[j]
                 max_start_idx += segment_lens[j]
@@ -260,7 +261,7 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
             raise ValueError(f"mode must be either 'noise' or 'speech', got: {mode}")
 
         speaker_candidates = [x for x in range(batch_size) if x != batch_idx]
-        speaker_candidates = np.random.choice(speaker_candidates, min(num_speakers, batch_size - 1), replace=False)
+        speaker_candidates = random.sample(speaker_candidates, k=min(num_speakers, batch_size - 1))
         sid = 0
         for seg_len in segment_lens:
             bid = speaker_candidates[sid]
@@ -269,11 +270,11 @@ class MultiSpeakerNoiseAugmentation(SpeakerNoiseAugmentation):
                     self.repeat_noise(audio_signal[bid], audio_lengths[bid], seg_len), seg_len
                 )
             else:
-                start_idx = np.random.randint(audio_lengths[bid] - seg_len) if audio_lengths[bid] > seg_len else 0
+                start_idx = random.randint(0, audio_lengths[bid] - seg_len) if audio_lengths[bid] > seg_len else 0
                 audio_segment = audio_signal[bid][start_idx : start_idx + seg_len].clone()
             noise_segments.append(audio_segment)
             sid += 1
             if sid >= len(speaker_candidates):
-                sid = np.random.randint(len(speaker_candidates))
+                sid = random.randint(0, len(speaker_candidates))
 
         return noise_segments


### PR DESCRIPTION
This PR is among a series aimed to improve the training speed and GPU utilization of NEST models https://github.com/NVIDIA/NeMo/issues/13619

This PR mainly focuses on removing redundant operations from the dataloader and increasing its effeciency by removing unused instances of `noisy_audio` tensors, this tensor is basically unused everywhere except the forward pass, but it's recomputed in many places although it will be overwritten later, so we only compute it once at the end when all the noise related sampling is finalized.

The noise tensor is also removed from the final result that gets passed to the training process, since it's an unused argument, this tensor is redundant and the IPC overhead of moving it to the training process is not justifiable (assuming 128 batch size and 20s samples, this tensor is 160MB)

the second change is using the random stdlib instead of numpy, all the operations are faster than their numpy counterparts except for `np.random.multinomial`

# Results
Tests were made to compare main branch with this PR to train two models with L and XL presets, wandb graphs are smoothed with gaussian=10
<img width="1460" height="845" alt="{05E97233-0C8E-45ED-BEC9-9CB40296D1D9}" src="https://github.com/user-attachments/assets/b1319413-8aea-48fb-9ee0-80488b549cea" />

The XL model finished the same number of steps less time

<img width="1465" height="844" alt="{6059702C-9C24-47A2-8AB3-4789F0A746D5}" src="https://github.com/user-attachments/assets/2c6682be-c90d-47b0-997e-186750ce0ecc" />
The large model shows slightly higher GPU utilization but finished the same number of steps in the same amount of time

I'd say that these results are inconclusive and require further testing but i don't have the compute budget to run them,
for future work, profiling showed that most of the training loop time is spent in the masking and tokenization, so these areas for improvement

cc @pzelasko @stevehuang52 