### PR TITLE
fix(asr): ensure non-ASCII characters are written correctly in JSON

### DIFF
--- a/nemo/collections/asr/parts/mixins/diarization.py
+++ b/nemo/collections/asr/parts/mixins/diarization.py
@@ -405,9 +405,11 @@ class SpkDiarizationMixin(ABC):
             for audio_file in audio_files:
                 if isinstance(audio_file, str):
                     entry = {'audio_filepath': audio_file, 'duration': 100000, 'text': ''}
-                    fp.write(json.dumps(entry) + '\n')
+                    fp.write(json.dumps(entry, ensure_ascii=False) + '
+')
                 elif isinstance(audio_file, dict):
-                    fp.write(json.dumps(audio_file) + '\n')
+                    fp.write(json.dumps(audio_file, ensure_ascii=False) + '
+')
                 else:
                     raise ValueError(
                         f"Input `audio` is of type {type(audio_file)}. "

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -704,9 +704,9 @@ class ASRTranscriptionMixin(TranscriptionMixin):
             for audio_file in audio_files:
                 if isinstance(audio_file, str):
                     entry = {'audio_filepath': audio_file, 'duration': 100000, 'text': ''}
-                    fp.write(json.dumps(entry) + '\n')
+                    fp.write(json.dumps(entry, ensure_ascii=False) + '\n')
                 elif isinstance(audio_file, dict):
-                    fp.write(json.dumps(audio_file) + '\n')
+                    fp.write(json.dumps(audio_file, ensure_ascii=False) + '\n')
                 else:
                     raise ValueError(
                         f"Input `audio` is of type {type(audio_file)}. "

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -474,7 +474,7 @@ def write_transcription(
                         item['pred_lang_chars'] = transcription.langs_chars
                     if not cfg.decoding.beam.return_best_hypothesis:
                         item['beams'] = beams[idx]
-                f.write(json.dumps(item) + "\n")
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
         else:
             with open(cfg.dataset_manifest, 'r', encoding='utf-8') as fr:
                 for idx, line in enumerate(fr):
@@ -503,7 +503,7 @@ def write_transcription(
 
                         if not cfg.decoding.beam.return_best_hypothesis:
                             item['beams'] = beams[idx]
-                    f.write(json.dumps(item) + "\n")
+                    f.write(json.dumps(item, ensure_ascii=False) + "\n")
 
     return cfg.output_filename, pred_text_attr_name
 
@@ -594,7 +594,7 @@ def compute_metrics_per_sample(
     if output_manifest_path is not None:
         with open(output_manifest_path, 'w') as output:
             for sample in samples_with_metrics:
-                line = json.dumps(sample)
+                line = json.dumps(sample, ensure_ascii=False)
                 output.writelines(f'{line}\n')
         logging.info(f'Output manifest saved: {output_manifest_path}')
 


### PR DESCRIPTION
- Add `ensure_ascii=False` parameter when writing JSON data in diarization and transcription mixins
- Update `write_transcription` and `compute_metrics_per_sample` functions to handle non-ASCII characters


- Related to #14502
