### PR TITLE
Use lhotse dataloader for ASR models to support in-manifest channel selection for multichannel recordings

### DIFF
--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -251,7 +251,7 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
                 )
 
             if new_tokenizer_type.lower() not in ('bpe', 'wpe'):
-                raise ValueError(f'New tokenizer type must be either `bpe` or `wpe`')
+                raise ValueError(f'New tokenizer type must be either `bpe` or `wpe`, got {new_tokenizer_type}')
 
             tokenizer_cfg = OmegaConf.create({'dir': new_tokenizer_dir, 'type': new_tokenizer_type})
 

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -190,6 +190,7 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
             batch_size = min(config['batch_size'], len(config['paths2audio_files']))
 
         dl_config = {
+            'use_lhotse': True,
             'manifest_filepath': manifest_filepath,
             'sample_rate': self.preprocessor._sample_rate,
             'batch_size': batch_size,

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
@@ -293,7 +293,7 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
                 )
 
             if new_tokenizer_type.lower() not in ('bpe', 'wpe'):
-                raise ValueError(f'New tokenizer type must be either `bpe` or `wpe`')
+                raise ValueError(f'New tokenizer type must be either `bpe` or `wpe`, got {new_tokenizer_type}')
 
             tokenizer_cfg = OmegaConf.create({'dir': new_tokenizer_dir, 'type': new_tokenizer_type})
 

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
@@ -233,6 +233,7 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
             batch_size = min(config['batch_size'], len(config['paths2audio_files']))
 
         dl_config = {
+            'use_lhotse': True,
             'manifest_filepath': manifest_filepath,
             'sample_rate': self.preprocessor._sample_rate,
             'batch_size': batch_size,

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -599,6 +599,7 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
             batch_size = min(config['batch_size'], len(config['paths2audio_files']))
 
         dl_config = {
+            'use_lhotse': True,
             'manifest_filepath': manifest_filepath,
             'sample_rate': self.preprocessor._sample_rate,
             'batch_size': batch_size,

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -380,7 +380,7 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
                 )
 
             if new_tokenizer_type.lower() not in ('bpe', 'wpe'):
-                raise ValueError(f'New tokenizer type must be either `bpe` or `wpe`')
+                raise ValueError(f'New tokenizer type must be either `bpe` or `wpe`, got {new_tokenizer_type}')
 
             tokenizer_cfg = OmegaConf.create({'dir': new_tokenizer_dir, 'type': new_tokenizer_type})
 


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Switches the following ASR models to use lhotse for dataloading when transcribing audio data

```
EncDecRNNTBPEModel
EncDecHybridRNNTCTCBPEModel
EncDecCTCModelBPE
```
Same as `EncDecMultiTaskModel` (Canary): https://github.com/NVIDIA/NeMo/blob/449b7df1b88f7e6cbd8eb62a3300b60c8f565645/nemo/collections/asr/models/aed_multitask_models.py#L1108

This allows to use multichannel channel selectors in CTC, RNNT and Hybrid RNNT-CTC models. 

Resolves https://github.com/NVIDIA/NeMo/issues/14415

**Collection**: ASR

# Changelog

- make `EncDecRNNTBPEModel` use lhotse dataloader when transcribing
- make `EncDecHybridRNNTCTCBPEModel` use lhotse dataloader when transcribing
- make `EncDecCTCModelBPE` use lhotse dataloader when transcribing

# Usage

```python
python examples/asr/transcribe_speech.py \
    pretrained_name="stt_en_fastconformer_hybrid_large_pc" \
    dataset_manifest=./mc_manifest.json \
    gt_lang_attr_name=source_lang \
    channel_selector=${CHANNEL_SELECTOR} \
    presort_manifest=false
```
where `mc_manifest.json` looks like this
```
{"audio_filepath": "./audio/mc_00.wav", "reference_channel": 0, "duration": null, "text_ch0": "lorem ipsum", "taskname": "asr", "source_lang": "en", "target_lang": "en", "pnc": "no", "answer": "na"}
{"audio_filepath": "./audio/mc_01.wav", "reference_channel": 1, "duration": null, "text_ch0": "ipsum lorem", "taskname": "asr", "source_lang": "en", "target_lang": "en", "pnc": "no", "answer": "na"}
```
and `./audio/mc_00.wav` and `./audio/mc_01.wav` are multichannel recordings 

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ x ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to https://github.com/NVIDIA/NeMo/issues/8728
- Related to https://github.com/NVIDIA/NeMo/issues/14415
