### PR TITLE
Support first last N layers in mxfp8

### DIFF
--- a/nemo/lightning/pytorch/plugins/mixed_precision.py
+++ b/nemo/lightning/pytorch/plugins/mixed_precision.py
@@ -70,6 +70,7 @@ class DtypeConfig:
     fp8: str = None
     fp8_recipe: str = "delayed"
     first_last_layers_bf16: bool = False
+    first_last_layers_mxfp8: bool = False
     fp8_margin: int = 0
     fp8_amax_history_len: int = 1
     fp8_amax_compute_algo: str = "most_recent"
@@ -86,6 +87,8 @@ class DtypeConfig:
     hysteresis: float = (None,)
     num_layers_at_start_in_bf16: int = 0
     num_layers_at_end_in_bf16: int = 0
+    num_layers_at_start_in_mxfp8: int = 0
+    num_layers_at_end_in_mxfp8: int = 0
     reuse_grad_buf_for_mxfp8_param_ag: bool = False
 
 
@@ -108,6 +111,7 @@ class MegatronMixedPrecision(Precision):
         fp8: str = None,
         fp8_recipe: str = "delayed",  # "tensorwise", "delayed", "mxfp8" (for Blackwell only)
         first_last_layers_bf16: bool = False,
+        first_last_layers_mxfp8: bool = False,
         fp8_margin: int = 0,
         fp8_amax_history_len: int = 1,
         fp8_amax_compute_algo: str = "most_recent",
@@ -123,6 +127,8 @@ class MegatronMixedPrecision(Precision):
         fp16_hysteresis: int = 2,
         num_layers_at_start_in_bf16: int = 0,
         num_layers_at_end_in_bf16: int = 0,
+        num_layers_at_start_in_mxfp8: int = 0,
+        num_layers_at_end_in_mxfp8: int = 0,
         reuse_grad_buf_for_mxfp8_param_ag: bool = False,
     ) -> None:
         if fp8_params is not None:
@@ -153,6 +159,7 @@ class MegatronMixedPrecision(Precision):
             fp8=fp8,
             fp8_recipe=fp8_recipe,
             first_last_layers_bf16=first_last_layers_bf16,
+            first_last_layers_mxfp8=first_last_layers_mxfp8,
             fp8_margin=fp8_margin,
             fp8_amax_history_len=fp8_amax_history_len,
             fp8_amax_compute_algo=fp8_amax_compute_algo,
@@ -163,6 +170,8 @@ class MegatronMixedPrecision(Precision):
             fp8_param_gather=fp8_param_gather,
             num_layers_at_start_in_bf16=num_layers_at_start_in_bf16,
             num_layers_at_end_in_bf16=num_layers_at_end_in_bf16,
+            num_layers_at_start_in_mxfp8=num_layers_at_start_in_mxfp8,
+            num_layers_at_end_in_mxfp8=num_layers_at_end_in_mxfp8,
             reuse_grad_buf_for_mxfp8_param_ag=reuse_grad_buf_for_mxfp8_param_ag,
             # fp16 loss scale
             loss_scale=fp16_loss_scale,


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Transformer engine now supports first last N layers in mxfp8. Add interface to enable this feature. This relies on this MCore MR: https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/merge_requests/3903

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
