### PR TITLE
Skip trt-llm and vllm install in install test

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -41,7 +41,7 @@ jobs:
             export NEMO_REPO
             export INSTALL_DIR=$(pwd)
 
-            bash docker/common/install_dep.sh --library all --mode install
+            bash docker/common/install_dep.sh --library "te,mcore,extra" --mode install
             pip install --no-cache-dir ".[all]"
           fi
 
@@ -78,7 +78,7 @@ jobs:
             pip install ".[all]"
           else
             export INSTALL_DIR=$(pwd)
-            bash docker/common/install_dep.sh --library all --mode install
+            bash docker/common/install_dep.sh --library "te,mcore,extra" --mode install
             pip install --no-cache-dir ".[all]"
           fi
 
@@ -115,7 +115,7 @@ jobs:
             pip install -vvv ".[all]"
           else
             export INSTALL_DIR=$(pwd)
-            bash docker/common/install_dep.sh --library all --mode install
+            bash docker/common/install_dep.sh --library "te,mcore,extra" --mode install
             pip install --no-cache-dir ".[all]"
           fi
 


### PR DESCRIPTION
# What does this PR do ?

Skip trt-llm and vllm install in install test

The install tests were failing on installing trt-llm, maybe hitting a rate limit with how large the repo is. Let's skip trt-llm and vllm since export-deploy really does not need to be tested in this repo anymore.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
