### PR TITLE
Remove multilingual sentence piece tokenizer

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
@@ -121,9 +121,6 @@ model:
         tone_prefix: "#"
         ascii_letter_prefix: ""
         ascii_letter_case: "upper"
-    multilingual_sentencepiece:
-      _target_: AutoTokenizer
-      pretrained_model: "bert-base-multilingual-uncased"
 
   test_ds:
     dataset:

--- a/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
@@ -114,9 +114,6 @@ model:
         tone_prefix: "#"
         ascii_letter_prefix: ""
         ascii_letter_case: "upper"
-    multilingual_sentencepiece:
-      _target_: AutoTokenizer
-      pretrained_model: "bert-base-multilingual-uncased"
 
   train_ds:
     dataset:

--- a/scripts/magpietts/README_magpie_po.md
+++ b/scripts/magpietts/README_magpie_po.md
@@ -195,7 +195,6 @@ python examples/tts/magpietts.py \
 batch_size=2 \
 +init_from_ptl_ckpt="/mountdir/checkpoints/magpie_checkpoints/shared_char_ipa_epoch285.ckpt" \
 +mode="onlinepo_train" \
-~model.text_tokenizers.multilingual_sentencepiece \
 +model.text_tokenizers.chartokenizer._target_=AutoTokenizer \
 +model.text_tokenizers.chartokenizer.pretrained_model="google/byt5-small" \
 max_epochs=20 \

--- a/tests/functional_tests/L2_TTS_Fast_dev_runs_Magpietts_OnlinePO.sh
+++ b/tests/functional_tests/L2_TTS_Fast_dev_runs_Magpietts_OnlinePO.sh
@@ -14,7 +14,6 @@
 coverage run --branch -a --data-file=/workspace/.coverage --source=/workspace/nemo examples/tts/magpietts.py \
     --config-name magpietts_multilingual_v1 \
     +mode="onlinepo_train" \
-    ~model.text_tokenizers.multilingual_sentencepiece \
     +model.text_tokenizers.english_chartokenizer._target_=AutoTokenizer \
     +model.text_tokenizers.english_chartokenizer.pretrained_model="google/byt5-small" \
     +model.text_tokenizers.spanish_chartokenizer._target_=AutoTokenizer \


### PR DESCRIPTION
Removing multilingual sentence piece tokenizer since we never use it and always remove it in our training command.