### PR TITLE
imported get_moe_layer_wise_logging_tracker from megatron core moe_utils

### DIFF
--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -57,6 +57,7 @@ from megatron.core.optimizer import OptimizerConfig
 from megatron.core.transformer.transformer_config import TransformerConfig
 from torch import Tensor, nn
 from typing_extensions import override
+from megatron.core.transformer.moe.moe_utils import get_moe_layer_wise_logging_tracker
 
 from nemo.utils.model_utils import check_lib_version
 
@@ -1866,8 +1867,7 @@ def moe_loss_tracker_ctx():
 @torch.no_grad()
 def aggregate_moe_loss_stats(loss_scale=1.0):
     with moe_loss_tracker_ctx():
-        from megatron.core.transformer.moe.moe_utils import get_moe_layer_wise_logging_tracker
-
+        
         tracker = get_moe_layer_wise_logging_tracker()
         aux_losses = {k: v['values'].float() * loss_scale for k, v in tracker.items()}
         total_loss_dict = {}

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -54,10 +54,10 @@ from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel as McoreDDP
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
+from megatron.core.transformer.moe.moe_utils import get_moe_layer_wise_logging_tracker
 from megatron.core.transformer.transformer_config import TransformerConfig
 from torch import Tensor, nn
 from typing_extensions import override
-from megatron.core.transformer.moe.moe_utils import get_moe_layer_wise_logging_tracker
 
 from nemo.utils.model_utils import check_lib_version
 
@@ -1867,7 +1867,7 @@ def moe_loss_tracker_ctx():
 @torch.no_grad()
 def aggregate_moe_loss_stats(loss_scale=1.0):
     with moe_loss_tracker_ctx():
-        
+
         tracker = get_moe_layer_wise_logging_tracker()
         aux_losses = {k: v['values'].float() * loss_scale for k, v in tracker.items()}
         total_loss_dict = {}

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -1866,7 +1866,8 @@ def moe_loss_tracker_ctx():
 @torch.no_grad()
 def aggregate_moe_loss_stats(loss_scale=1.0):
     with moe_loss_tracker_ctx():
-        tracker = parallel_state.get_moe_layer_wise_logging_tracker()
+        from megatron.core.transformer.moe.moe_utils import get_moe_layer_wise_logging_tracker
+        tracker = get_moe_layer_wise_logging_tracker()
         aux_losses = {k: v['values'].float() * loss_scale for k, v in tracker.items()}
         total_loss_dict = {}
         for name, loss_list in aux_losses.items():

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -1867,6 +1867,7 @@ def moe_loss_tracker_ctx():
 def aggregate_moe_loss_stats(loss_scale=1.0):
     with moe_loss_tracker_ctx():
         from megatron.core.transformer.moe.moe_utils import get_moe_layer_wise_logging_tracker
+
         tracker = get_moe_layer_wise_logging_tracker()
         aux_losses = {k: v['values'].float() * loss_scale for k, v in tracker.items()}
         total_loss_dict = {}


### PR DESCRIPTION
# What does this PR do ?

Fixes the imports for function aggregate_moe_loss_stats




  
**PR Type**:
- [ ] Bugfix


## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue) 14692
