### PR TITLE
[unittests] fixed bugs for sampling in cer, speaker similarity and validation status.

### DIFF
--- a/nemo/collections/common/data/lhotse/sampling.py
+++ b/nemo/collections/common/data/lhotse/sampling.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Any, Sequence
 
 import numpy as np
-from lhotse.cut import Cut
+from lhotse.cut import Cut, MonoCut
 from lhotse.dataset import SamplingConstraint, TokenConstraint
 from lhotse.dataset.sampling.dynamic_bucketing import FixedBucketBatchSizeConstraint
 from lhotse.utils import ifnone
@@ -271,7 +271,7 @@ class ValidationStatusFilter:
         self.keep = keep
 
     def __call__(self, example) -> bool:
-        if isinstance(example, Cut) and example.has_custom("validation_status") and example.validation_status != self.keep:
+        if isinstance(example, MonoCut) and example.has_custom("validation_status") and example.validation_status != self.keep:
             return False
         else:
             return True
@@ -286,7 +286,7 @@ class CERFilter:
         self.max_cer = ifnone(max_cer, float("inf"))
 
     def __call__(self, example) -> bool:
-        if isinstance(example, Cut) and len(example.supervisions) > 0 and example.supervisions[0].has_custom("cer"):
+        if isinstance(example, MonoCut) and len(example.supervisions) > 0 and example.supervisions[0].has_custom("cer"):
             return example.supervisions[0].cer <= self.max_cer
         else:
             return True
@@ -300,7 +300,7 @@ class ContextSpeakerSimilarityFilter:
         self.min_context_speaker_similarity = ifnone(min_context_speaker_similarity, -1)
 
     def __call__(self, example) -> bool:
-        if isinstance(example, Cut) and len(example.supervisions) > 0 and example.supervisions[0].has_custom("context_speaker_similarity"):
+        if isinstance(example, MonoCut) and len(example.supervisions) > 0 and example.supervisions[0].has_custom("context_speaker_similarity"):
             return example.supervisions[0].context_speaker_similarity >= self.min_context_speaker_similarity
         else:
             return True

--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -344,7 +344,6 @@ def test_dataloader_from_lhotse_cuts_cut_into_windows(cutset_path: Path):
     assert batches[4]["audio"].shape == (4, 8000)
     # exactly 20 cuts were used because we cut 10x 1s cuts into 20x 0.5s cuts
 
-@pytest.mark.pleasefixme
 def test_dataloader_from_lhotse_cuts_pad_min_duration(cutset_path: Path):
     config = OmegaConf.create(
         {
@@ -1938,7 +1937,6 @@ def test_multimodal_text_audio_dataloading_randomized_round_robin_strategy(
         assert torch.is_tensor(ex.answer_ids)
         assert torch.is_tensor(ex.mask)
 
-@pytest.mark.pleasefixme
 def test_dataloader_with_noise_nemo_json(cutset_path: Path, nemo_manifest_path: Path):
     config = OmegaConf.create(
         {
@@ -1967,7 +1965,6 @@ def test_dataloader_with_noise_nemo_json(cutset_path: Path, nemo_manifest_path: 
     assert isinstance(cut, MixedCut)
     assert -5.0 < cut.tracks[1].snr < 5.0
 
-@pytest.mark.pleasefixme
 def test_dataloader_with_noise_lhotse_jsonl(cutset_path: Path):
     config = OmegaConf.create(
         {
@@ -1996,7 +1993,6 @@ def test_dataloader_with_noise_lhotse_jsonl(cutset_path: Path):
     assert isinstance(cut, MixedCut)
     assert -5.0 < cut.tracks[1].snr < 5.0
 
-@pytest.mark.pleasefixme
 def test_dataloader_with_noise_nemo_tar(cutset_path: Path, nemo_tarred_manifest_path_multi: Path):
     noise_json, noise_tar = nemo_tarred_manifest_path_multi
     config = OmegaConf.create(


### PR DESCRIPTION
Previously, the unit tests were failed due to broad test cut examples were `MixCut`, while our three new sampler only applies to `MonoCut`.

*previously*
```
FAILED tests/collections/common/test_lhotse_dataloading.py::test_dataloader_from_lhotse_cuts_pad_min_duration - AssertionError: This MixedCut has 0 non-padding cuts with a custom attribute 'validation_status'. We currently don't support mixing custom attributes. Consider dropping the attribute on all but one of DataCuts. Problematic cut:
FAILED tests/collections/common/test_lhotse_dataloading.py::test_dataloader_with_noise_nemo_json - AssertionError: This MixedCut has 0 non-padding cuts with a custom attribute 'validation_status'. We currently don't support mixing custom attributes. Consider dropping the attribute on all but one of DataCuts. Problematic cut:
FAILED tests/collections/common/test_lhotse_dataloading.py::test_dataloader_with_noise_lhotse_jsonl - AssertionError: This MixedCut has 0 non-padding cuts with a custom attribute 'validation_status'. We currently don't support mixing custom attributes. Consider dropping the attribute on all but one of DataCuts. Problematic cut:
FAILED tests/collections/common/test_lhotse_dataloading.py::test_dataloader_with_noise_nemo_tar - AssertionError: This MixedCut has 0 non-padding cuts with a custom attribute 'validation_status'. We currently don't support mixing custom attributes. Consider dropping the attribute on all but one of DataCuts. Problematic cut:
========================= 4 failed, 45 passed, 14 warnings in 51.08s =======================
```

*After Fix*
```
========================= 49 passed, 14 warnings in 48.04s ==================================
```

related PR: https://github.com/NVIDIA-NeMo/NeMo/pull/14429



