### PR TITLE
Don't allow EOS until 4 frames have been generated

### DIFF
--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -726,9 +726,7 @@ class MagpieTTSModel(ModelPT):
             logits: (B, C, num_audio_tokens_per_codebook)
         """
         logits[
-            :,
-            :,
-            SpecialAudioToken.get_forbidden_tokens(self._codec_model.codebook_size, forbid_audio_eos=forbid_audio_eos),
+            :, :, SpecialAudioToken.get_forbidden_tokens(self._codec_model.codebook_size, forbid_audio_eos=forbid_audio_eos),
         ] = float('-inf')
         return logits
 
@@ -986,8 +984,14 @@ class MagpieTTSModel(ModelPT):
         return all_preds
 
     def sample_codes_from_logits(
-        self, all_code_logits_t, temperature=0.7, topk=80, unfinished_items={}, finished_items={}
-    , forbid_audio_eos=False):
+        self,
+        all_code_logits_t,
+        temperature=0.7,
+        topk=80,
+        unfinished_items={},
+        finished_items={},
+        forbid_audio_eos=False,
+    ):
         # all_code_logits_t: (B, num_codebooks * num_tokens_per_codebook), logits at a given timestep
         all_preds = [[] for _ in range(self.frame_stacking_factor)]
         for fs_index in range(self.frame_stacking_factor):

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -726,7 +726,9 @@ class MagpieTTSModel(ModelPT):
             logits: (B, C, num_audio_tokens_per_codebook)
         """
         logits[
-            :, :, SpecialAudioToken.get_forbidden_tokens(self._codec_model.codebook_size, forbid_audio_eos=forbid_audio_eos),
+            :,
+            :,
+            SpecialAudioToken.get_forbidden_tokens(self._codec_model.codebook_size, forbid_audio_eos=forbid_audio_eos),
         ] = float('-inf')
         return logits
 
@@ -922,7 +924,7 @@ class MagpieTTSModel(ModelPT):
         use_cfg=False,
         cfg_scale=1.0,
         use_kv_cache=True,
-        forbid_audio_eos=False
+        forbid_audio_eos=False,
     ):
         # dec_output: (B, E)
         self.local_transformer.reset_cache(use_cache=use_kv_cache)
@@ -950,7 +952,9 @@ class MagpieTTSModel(ModelPT):
                 codebook_logits[item_idx, :] = float('-inf')
                 codebook_logits[item_idx, self.audio_eos_id] = 0.0
 
-            codebook_logits = self.clear_forbidden_logits(codebook_logits.unsqueeze(1), forbid_audio_eos=forbid_audio_eos).squeeze(1)
+            codebook_logits = self.clear_forbidden_logits(
+                codebook_logits.unsqueeze(1), forbid_audio_eos=forbid_audio_eos
+            ).squeeze(1)
             codebook_logits_topk = torch.topk(codebook_logits, topk, dim=-1)[0]  # (B, topk)
             indices_to_remove = codebook_logits < codebook_logits_topk[:, -1].unsqueeze(
                 -1
@@ -1005,7 +1009,9 @@ class MagpieTTSModel(ModelPT):
                 for item_idx in finished_items:
                     codebook_logits[item_idx, :] = float('-inf')
                     codebook_logits[item_idx, self.audio_eos_id] = 0.0
-                codebook_logits = self.clear_forbidden_logits(codebook_logits.unsqueeze(1), forbid_audio_eos=forbid_audio_eos).squeeze(1)
+                codebook_logits = self.clear_forbidden_logits(
+                    codebook_logits.unsqueeze(1), forbid_audio_eos=forbid_audio_eos
+                ).squeeze(1)
                 codebook_logits_topk = torch.topk(codebook_logits, topk, dim=-1)[0]  # (B, topk)
                 indices_to_remove = codebook_logits < codebook_logits_topk[:, -1].unsqueeze(
                     -1
@@ -2211,7 +2217,7 @@ class MagpieTTSModel(ModelPT):
                 # Don't allow termination until we have generated at least `min_generated_frames` frames (rounded up to the nearest multiple of frame_stacking_factor)
                 forbid_audio_eos = idx * self.frame_stacking_factor < min_generated_frames
 
-                all_code_logits_t = all_code_logits[:, -1, :] # (B, num_codebooks * num_tokens_per_codebook)
+                all_code_logits_t = all_code_logits[:, -1, :]  # (B, num_codebooks * num_tokens_per_codebook)
                 if use_local_transformer_for_inference:
                     if self.local_transformer_type == LocalTransformerType.AR:
                         # Autoregressive sampling with local transformer
@@ -2224,7 +2230,7 @@ class MagpieTTSModel(ModelPT):
                             use_cfg=use_cfg,
                             cfg_scale=cfg_scale,
                             use_kv_cache=use_LT_kv_cache,
-                            forbid_audio_eos=forbid_audio_eos
+                            forbid_audio_eos=forbid_audio_eos,
                         )
                     elif self.local_transformer_type == LocalTransformerType.MASKGIT:
                         audio_codes_next = self.local_transformer_sample_maskgit(
@@ -2240,7 +2246,7 @@ class MagpieTTSModel(ModelPT):
                             fixed_schedule=maskgit_fixed_schedule,
                             dynamic_cfg_scale=maskgit_dynamic_cfg_scale,
                             sampling_type=maskgit_sampling_type,
-                            forbid_audio_eos=forbid_audio_eos
+                            forbid_audio_eos=forbid_audio_eos,
                         )
                     else:
                         raise ValueError(

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -2104,6 +2104,8 @@ class MagpieTTSModel(ModelPT):
         maskgit_sampling_type=None,
         ignore_finished_sentence_tracking=False,
         eos_detection_method="argmax_or_multinomial_any",
+        # setting this greater than 0 prevents rare cases of first-frame termination. Any number greater between 1 and 4 should work, but 4
+        # lines up with the codec's minimum frame requirement.
         min_generated_frames=4,
     ):
         eos_detection_method = EOSDetectionMethod(eos_detection_method)

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -2273,6 +2273,7 @@ class MagpieTTSModel(ModelPT):
                     unfinished_items = {k: v for k, v in unfinished_texts.items() if v}
 
                 # Don't allow termination until we have generated at least `min_generated_frames` frames (rounded up to the nearest multiple of frame_stacking_factor)
+                # This guards against rare cases of termination right at the start of generation.
                 forbid_audio_eos = idx * self.frame_stacking_factor < min_generated_frames
 
                 all_code_logits_t = all_code_logits[:, -1, :]  # (B, num_codebooks * num_tokens_per_codebook)

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -2102,9 +2102,9 @@ class MagpieTTSModel(ModelPT):
         maskgit_fixed_schedule=None,
         maskgit_dynamic_cfg_scale=False,
         maskgit_sampling_type=None,
-        min_generated_frames=4,
         ignore_finished_sentence_tracking=False,
         eos_detection_method="argmax_or_multinomial_any",
+        min_generated_frames=4,
     ):
         eos_detection_method = EOSDetectionMethod(eos_detection_method)
         with torch.no_grad():

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -2104,7 +2104,7 @@ class MagpieTTSModel(ModelPT):
         maskgit_sampling_type=None,
         ignore_finished_sentence_tracking=False,
         eos_detection_method="argmax_or_multinomial_any",
-        # setting this greater than 0 prevents rare cases of first-frame termination. Any number greater between 1 and 4 should work, but 4
+        # Setting this greater than 0 prevents rare cases of first-frame termination. Any number greater between 1 and 4 should work, but 4
         # lines up with the codec's minimum frame requirement.
         min_generated_frames=4,
     ):

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -293,6 +293,7 @@ def run_inference(
     log_exp_name=False,
     compute_fcd=False,
     violin_plot_metrics=['cer', 'pred_context_ssim'],
+    min_frames=0,
 ):
     # Load model
     if hparams_file is not None and checkpoint_file is not None:
@@ -358,7 +359,8 @@ def run_inference(
     checkpoint_name += (
         f"LT_{use_local_transformer}_"
         f"MaskGit_{maskgit_n_steps}_{maskgit_sampling_type}_{''.join([str(l) for l in maskgit_fixed_schedule]) if maskgit_fixed_schedule is not None else 'None'}_"
-        f"SV_{sv_model}"
+        f"SV_{sv_model}_"
+        f"MinFrames_{min_frames}"
     )
 
     dataset_meta_info = evalset_config.dataset_meta_info
@@ -488,6 +490,7 @@ def run_inference(
                     maskgit_noise_scale=maskgit_noise_scale,
                     maskgit_fixed_schedule=maskgit_fixed_schedule,
                     maskgit_sampling_type=maskgit_sampling_type,
+                    min_generated_frames=min_frames,
                 )
 
                 all_rtf_metrics.append(rtf_metrics)
@@ -675,6 +678,7 @@ def main():
         default=['cer', 'pred_context_ssim'],
         help="Which metrics to add the violin plot.",
     )
+    parser.add_argument('--min_frames', type=int, default=0, help="Minimum number of frames to generate")
     args = parser.parse_args()
 
     if args.datasets is None:
@@ -722,6 +726,7 @@ def main():
         log_exp_name=args.log_exp_name,
         compute_fcd=compute_fcd,
         violin_plot_metrics=args.violin_plot_metrics,
+        min_frames=args.min_frames,
     )
 
     # Mode 1: Run inference from provided hparams and checkpoint files

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -149,7 +149,7 @@ def create_violin_plots(metrics: List[dict], metric_keys: List[str], output_png:
         assert column in df
         # Create empty lists to store the parts objects for each DataFrame
         # Plot the violin plots for each DataFrame
-        axs[i].violinplot(df[column], showmedians=True, positions=[i], widths=0.5, showextrema=True)
+        axs[i].violinplot(df[column], showmedians=True, positions=[i], widths=0.5)
 
         axs[i].set_title(column)
         axs[i].set_xticks([i])
@@ -295,7 +295,6 @@ def run_inference(
     violin_plot_metrics=['cer', 'pred_context_ssim'],
     eos_detection_method=None,
     ignore_finished_sentence_tracking=False,
-    min_frames=0,
 ):
     # Load model
     if hparams_file is not None and checkpoint_file is not None:
@@ -364,7 +363,6 @@ def run_inference(
         f"SV_{sv_model}"
         f"EOS_{eos_detection_method}"
         f"IgnoreFST_{ignore_finished_sentence_tracking}"
-        f"MinFrames_{min_frames}"
     )
 
     dataset_meta_info = evalset_config.dataset_meta_info
@@ -496,7 +494,6 @@ def run_inference(
                     maskgit_sampling_type=maskgit_sampling_type,
                     ignore_finished_sentence_tracking=ignore_finished_sentence_tracking,
                     eos_detection_method=eos_detection_method,
-                    min_generated_frames=min_frames,
                 )
 
                 all_rtf_metrics.append(rtf_metrics)
@@ -698,7 +695,6 @@ def main():
         default=['cer', 'pred_context_ssim'],
         help="Which metrics to add the violin plot.",
     )
-    parser.add_argument('--min_frames', type=int, default=0, help="Minimum number of frames to generate")
     args = parser.parse_args()
 
     if args.datasets is None:
@@ -748,7 +744,6 @@ def main():
         violin_plot_metrics=args.violin_plot_metrics,
         eos_detection_method=args.eos_detection_method,
         ignore_finished_sentence_tracking=args.ignore_finished_sentence_tracking,
-        min_frames=args.min_frames,
     )
 
     # Mode 1: Run inference from provided hparams and checkpoint files

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -293,9 +293,9 @@ def run_inference(
     log_exp_name=False,
     compute_fcd=False,
     violin_plot_metrics=['cer', 'pred_context_ssim'],
-    min_frames=0,
     eos_detection_method=None,
     ignore_finished_sentence_tracking=False,
+    min_frames=0,
 ):
     # Load model
     if hparams_file is not None and checkpoint_file is not None:
@@ -362,6 +362,9 @@ def run_inference(
         f"LT_{use_local_transformer}_"
         f"MaskGit_{maskgit_n_steps}_{maskgit_sampling_type}_{''.join([str(l) for l in maskgit_fixed_schedule]) if maskgit_fixed_schedule is not None else 'None'}_"
         f"SV_{sv_model}"
+        f"EOS_{eos_detection_method}"
+        f"IgnoreFST_{ignore_finished_sentence_tracking}"
+        f"MinFrames_{min_frames}"
     )
 
     dataset_meta_info = evalset_config.dataset_meta_info
@@ -491,6 +494,9 @@ def run_inference(
                     maskgit_noise_scale=maskgit_noise_scale,
                     maskgit_fixed_schedule=maskgit_fixed_schedule,
                     maskgit_sampling_type=maskgit_sampling_type,
+                    ignore_finished_sentence_tracking=ignore_finished_sentence_tracking,
+                    eos_detection_method=eos_detection_method,
+                    min_frames=min_frames,
                 )
 
                 all_rtf_metrics.append(rtf_metrics)
@@ -740,6 +746,9 @@ def main():
         log_exp_name=args.log_exp_name,
         compute_fcd=compute_fcd,
         violin_plot_metrics=args.violin_plot_metrics,
+        eos_detection_method=args.eos_detection_method,
+        ignore_finished_sentence_tracking=args.ignore_finished_sentence_tracking,
+        min_frames=args.min_frames,
     )
 
     # Mode 1: Run inference from provided hparams and checkpoint files

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -149,7 +149,7 @@ def create_violin_plots(metrics: List[dict], metric_keys: List[str], output_png:
         assert column in df
         # Create empty lists to store the parts objects for each DataFrame
         # Plot the violin plots for each DataFrame
-        axs[i].violinplot(df[column], showmedians=True, positions=[i], widths=0.5)
+        axs[i].violinplot(df[column], showmedians=True, positions=[i], widths=0.5, showextrema=True)
 
         axs[i].set_title(column)
         axs[i].set_xticks([i])

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -496,7 +496,7 @@ def run_inference(
                     maskgit_sampling_type=maskgit_sampling_type,
                     ignore_finished_sentence_tracking=ignore_finished_sentence_tracking,
                     eos_detection_method=eos_detection_method,
-                    min_frames=min_frames,
+                    min_generated_frames=min_frames,
                 )
 
                 all_rtf_metrics.append(rtf_metrics)


### PR DESCRIPTION
**Problem:** We have observed a very rare but persistent issue where Magpie can generate a zero-length output (for a standard length input text). Here's what was happening: the EOS logit at the very first timestep would become very large for particular utterances after application of CFG. Interestingly, before CFG neither the conditional nor unconditional EOS logit was particularly large; but CFG amplified the difference between them which resultsed in the post-CFG EOS logit being the maximum among all logits.

**Fix:** In this PR we avoid this particular early termination issue by disallowing EOS in the first 4 timesteps, corresponding to about 186ms (with a 21.5 Hz codec). That helps the model avoid first-frame termination and it then actually generates the rest of the utterance correctly. The value of 4 steps was chosen because the codec requires a minimum of 4 frames to decode (albeit at a batch level). This way we sample those 4 steps rather than potentially force-replace them with zero-index tokens.

Note that I also examined the logits for an instance of _mid-sentence_ termination and the logits did not follow the pattern of EOS becoming large only after CFG in that case. So CFG doesn't appear to be at the root of all early-termination issues, just the start-of-utterance one.

(Still, it's probably worthwhile thinking about how to improve the underlying CFG mechanism; but for now we need to a safeguard so that these zero-length generations don't happen.)

I ran evaluations and got similar metrics with and without this constraint, which should kick in very rarely.
