### PR TITLE
Fix changelog build after repo transfer

### DIFF
--- a/.github/workflows/changelog-build.yml
+++ b/.github/workflows/changelog-build.yml
@@ -11,10 +11,13 @@ on:
         description: Release branch to build changelog on (e.g. `r2.1.0`)
         type: string
         required: true
-    
+
 jobs:
   changelog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4
@@ -33,7 +36,7 @@ jobs:
           # fromTag: Auto resolved from historical tag order (previous tag compared to current tag)
           # toTag: Current tag reference
           configuration: ".github/workflows/config/changelog-config.json"
-          owner: "NVIDIA"
+          owner: "NVIDIA-NeMo"
           repo: "NeMo"
           ignorePreReleases: "false"
           failOnError: "false"
@@ -41,7 +44,7 @@ jobs:
           toTag: ${{ inputs.release-branch }}
 
       - name: Update changelog file
-        env: 
+        env:
           RELEASE_BRANCH: ${{ inputs.release-branch }}
           CHANGELOG: ${{ steps.github_tag.outputs.changelog }}
         shell: bash -x -e -u -o pipefail {0}


### PR DESCRIPTION
# What does this PR do ?

Fix changelog build after repo transfer

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
