### PR TITLE
add torch profiler plugin and call it in profiler scripts

### DIFF
--- a/nemo/lightning/pytorch/callbacks/__init__.py
+++ b/nemo/lightning/pytorch/callbacks/__init__.py
@@ -27,7 +27,7 @@ from nemo.lightning.pytorch.callbacks.peft import PEFT
 from nemo.lightning.pytorch.callbacks.preemption import PreemptionCallback
 from nemo.lightning.pytorch.callbacks.progress_bar import MegatronProgressBar
 from nemo.lightning.pytorch.callbacks.progress_printer import ProgressPrinter
-from nemo.lightning.pytorch.callbacks.pytorch_profiler import PytorchProfilerCallback
+from nemo.lightning.pytorch.callbacks.pytorch_profiler import PytorchProfilerCallback, PyTorchProfilerCallback
 from nemo.lightning.pytorch.callbacks.runtime_estimator import RuntimeEstimator
 from nemo.lightning.pytorch.callbacks.speed_monitor import SpeedMonitor
 
@@ -38,6 +38,7 @@ __all__ = [
     "PEFT",
     "NsysCallback",
     "PytorchProfilerCallback",
+    "PyTorchProfilerCallback",
     "MegatronProgressBar",
     "ProgressPrinter",
     "PreemptionCallback",

--- a/nemo/lightning/pytorch/callbacks/pytorch_profiler.py
+++ b/nemo/lightning/pytorch/callbacks/pytorch_profiler.py
@@ -102,7 +102,9 @@ class PytorchProfilerCallback(Callback, IOMixin):
                 torch.profiler.ProfilerActivity.CPU,
                 torch.profiler.ProfilerActivity.CUDA,
             ],
-            "schedule": torch.profiler.schedule(wait=wait_steps, warmup=self.warmup_steps, active=self.active_steps, repeat=1),
+            "schedule": torch.profiler.schedule(
+                wait=wait_steps, warmup=self.warmup_steps, active=self.active_steps, repeat=1
+            ),
             "on_trace_ready": lambda prof: trace_handler(prof, self.chakra_device_trace_path),
             "execution_trace_observer": self.trace_observer,
         }
@@ -137,6 +139,7 @@ class PytorchProfilerCallback(Callback, IOMixin):
                 self.trace_observer.unregister_callback()
             except RuntimeError as e:
                 logging.warning(f"ExecutionTraceObserver cleanup failed: {e}")
+
 
 # Add an alias, ideally we want camelcase for PyTorch
 PyTorchProfilerCallback = PytorchProfilerCallback

--- a/nemo/lightning/pytorch/callbacks/pytorch_profiler.py
+++ b/nemo/lightning/pytorch/callbacks/pytorch_profiler.py
@@ -33,7 +33,7 @@ def trace_handler(prof, chakra_device_trace_path):
         chakra_device_trace_path: The path where the trace file will be saved.
     """
     rank = get_rank()
-    trace_file = chakra_device_trace_path / f"rank-{rank}.json"
+    trace_file = chakra_device_trace_path / f"rank-{rank}.json.gz"
     prof.export_chrome_trace(str(trace_file))
     logging.info(f"Kineto trace saved: {trace_file}")
 
@@ -52,6 +52,7 @@ class PytorchProfilerCallback(Callback, IOMixin):
         warmup_steps (int): Number of warmup steps before profiling starts.
         active_steps (int): Number of active profiling steps.
         trace_dir (str): Directory where traces will be saved.
+        collect_et (bool): Collect Execution Trace (host trace).
         profiler_kwargs (dict, optional): Additional keyword args to pass to torch.profiler.profile
     """
 
@@ -59,9 +60,9 @@ class PytorchProfilerCallback(Callback, IOMixin):
         self,
         start_step: int,
         end_step: int,
-        warmup_steps: int = 0,
-        active_steps: int = 1,
+        warmup_steps: int = 2,
         trace_dir: str = None,
+        collect_et: bool = False,
         profiler_kwargs: Optional[Dict[str, Any]] = None,
     ):
         if trace_dir is None:
@@ -79,23 +80,29 @@ class PytorchProfilerCallback(Callback, IOMixin):
         self.start_step = start_step
         self.end_step = end_step
         self.warmup_steps = warmup_steps
-        self.active_steps = active_steps
+        self.active_steps = max(self.end_step - self.start_step, 1)
+
+        wait_steps = max(self.start_step - self.warmup_steps, 0)
 
         self.trace_dir = Path(trace_dir)
         self.chakra_host_trace_path = self.trace_dir / "host"
-        self.chakra_device_trace_path = self.trace_dir / "device"
+        self.chakra_device_trace_path = self.trace_dir / "torch_profiler"
 
-        self.chakra_host_trace_path.mkdir(parents=True, exist_ok=True)
         self.chakra_device_trace_path.mkdir(parents=True, exist_ok=True)
 
-        self.trace_observer = torch.profiler.ExecutionTraceObserver()
+        self.trace_observer = None
+        if collect_et:
+            self.chakra_host_trace_path.mkdir(parents=True, exist_ok=True)
+            self.trace_observer = torch.profiler.ExecutionTraceObserver()
+            trace_file = self.chakra_host_trace_path / f"rank-{get_rank()}.json.gz"
+            self.trace_observer.register_callback(str(trace_file))
 
         base_kwargs = {
             "activities": [
                 torch.profiler.ProfilerActivity.CPU,
                 torch.profiler.ProfilerActivity.CUDA,
             ],
-            "schedule": torch.profiler.schedule(wait=0, warmup=self.warmup_steps, active=self.active_steps),
+            "schedule": torch.profiler.schedule(wait=wait_steps, warmup=self.warmup_steps, active=self.active_steps, repeat=1),
             "on_trace_ready": lambda prof: trace_handler(prof, self.chakra_device_trace_path),
             "execution_trace_observer": self.trace_observer,
         }
@@ -105,55 +112,34 @@ class PytorchProfilerCallback(Callback, IOMixin):
             base_kwargs.update(profiler_kwargs)
 
         self.profiler = torch.profiler.profile(**base_kwargs)
-        self.is_profiling = False
 
         logging.info(
-            "Chakra profiling initialized:\n"
+            "PyTorch profiling initialized:\n"
             f" - Start Step: {self.start_step}\n"
             f" - End Step: {self.end_step}\n"
             f" - Warmup Steps: {self.warmup_steps}\n"
             f" - Active Steps: {self.active_steps}\n"
             f" - Trace Directory: {self.trace_dir}\n"
+            f" - Collect Execution Trace: {collect_et}\n"
             f" - Extra profiler kwargs: {profiler_kwargs or {}}"
         )
 
-    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx: int) -> None:
-        """Chakra trace collection starts."""
-        if trainer.global_step == self.start_step:
-            if self.is_profiling:
-                logging.warning(
-                    f"Attempted to start Chakra profiler multiple times at step {trainer.global_step}. Skipping."
-                )
-                return
-
-            logging.info(f"====== Start Chakra profiling at global_step {trainer.global_step} ======")
-
-            trace_file = self.chakra_host_trace_path / f"rank-{get_rank()}.json"
-            self.trace_observer.register_callback(str(trace_file))
-
-            self.profiler.start()
-            self.is_profiling = True
-
-            logging.info("Chakra Profiler Started.\n")
-
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx: int) -> None:
         """Chakra trace collection ends."""
-        if self.is_profiling:
-            if trainer.global_step < self.end_step:
-                self.profiler.step()
-                logging.info(f"Profiler step executed at global_step {trainer.global_step}")
-            else:
-                logging.info(f"====== End Chakra profiling at global_step {trainer.global_step} ======")
-                self._stop_profiler()
+        # Step the profiler after each training batch
+        if self.profiler:
+            self.profiler.step()
 
-    def _stop_profiler(self):
-        if self.is_profiling:
-            logging.info("Stopping Chakra Profiler...")
-            self.profiler.stop()
-            self.is_profiling = False
+    def on_train_end(self, trainer, pl_module):
+        if self.profiler:
+            self.profiler.step()
 
+        if self.trace_observer:
             try:
                 logging.info("Unregistering ExecutionTraceObserver...")
                 self.trace_observer.unregister_callback()
             except RuntimeError as e:
                 logging.warning(f"ExecutionTraceObserver cleanup failed: {e}")
+
+# Add an alias, ideally we want camelcase for PyTorch
+PyTorchProfilerCallback = PytorchProfilerCallback

--- a/nemo/lightning/pytorch/callbacks/pytorch_profiler.py
+++ b/nemo/lightning/pytorch/callbacks/pytorch_profiler.py
@@ -131,9 +131,6 @@ class PytorchProfilerCallback(Callback, IOMixin):
             self.profiler.step()
 
     def on_train_end(self, trainer, pl_module):
-        if self.profiler:
-            self.profiler.step()
-
         if self.trace_observer:
             try:
                 logging.info("Unregistering ExecutionTraceObserver...")

--- a/nemo/lightning/run/plugins.py
+++ b/nemo/lightning/run/plugins.py
@@ -249,6 +249,7 @@ class PyTorchProfilerPlugin(run.Plugin):
     start_step: int
     end_step: int
     with_stack: bool = False
+    collect_et: bool = False
     profiler_kwargs: Optional[Dict[str, Any]] = None
 
     def setup(self, task: run.Partial | run.Script, executor: run.Executor):
@@ -259,6 +260,7 @@ class PyTorchProfilerPlugin(run.Plugin):
                 trace_dir=self.output_path,
                 start_step=self.start_step,
                 end_step=self.end_step,
+                collect_et=self.collect_et,
                 profiler_kwargs=self.profiler_kwargs,
             )
             callbacks: list[run.Config[Callback]] = [profiler_callback]  # type: ignore

--- a/nemo/lightning/run/plugins.py
+++ b/nemo/lightning/run/plugins.py
@@ -25,7 +25,12 @@ from lightning.pytorch import Callback
 from lightning.pytorch.loggers import WandbLogger
 from nemo_run.core.serialization.yaml import YamlSerializer
 
-from nemo.lightning.pytorch.callbacks import MemoryProfileCallback, NsysCallback, PreemptionCallback, PyTorchProfilerCallback
+from nemo.lightning.pytorch.callbacks import (
+    MemoryProfileCallback,
+    NsysCallback,
+    PreemptionCallback,
+    PyTorchProfilerCallback,
+)
 from nemo.lightning.pytorch.strategies.megatron_strategy import MegatronStrategy
 from nemo.utils import logging
 from nemo.utils.import_utils import safe_import
@@ -245,6 +250,7 @@ class PyTorchProfilerPlugin(run.Plugin):
         end_step (int): The step at which to end the nsys profiling.
         with_modules(bool) : show modules
     """
+
     output_path: str
     start_step: int
     end_step: int

--- a/nemo/lightning/run/plugins.py
+++ b/nemo/lightning/run/plugins.py
@@ -17,7 +17,7 @@ import os
 import signal
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Any, Callable, Dict, Optional
 
 import nemo_run as run
 import yaml
@@ -25,7 +25,7 @@ from lightning.pytorch import Callback
 from lightning.pytorch.loggers import WandbLogger
 from nemo_run.core.serialization.yaml import YamlSerializer
 
-from nemo.lightning.pytorch.callbacks import MemoryProfileCallback, NsysCallback, PreemptionCallback
+from nemo.lightning.pytorch.callbacks import MemoryProfileCallback, NsysCallback, PreemptionCallback, PyTorchProfilerCallback
 from nemo.lightning.pytorch.strategies.megatron_strategy import MegatronStrategy
 from nemo.utils import logging
 from nemo.utils.import_utils import safe_import
@@ -229,6 +229,39 @@ class MemoryProfilePlugin(run.Plugin):
                 ranks=self.ranks or [0],
             )
             callbacks: list[run.Config[Callback]] = [memprof_callback]  # type: ignore
+            _merge_callbacks(task, callbacks=callbacks)
+
+
+@dataclass(kw_only=True)
+class PyTorchProfilerPlugin(run.Plugin):
+    """
+    A plugin for torch profiling.
+
+    You can specify when to start and end the profiling, on which ranks to run the profiling,
+    and what to trace during profiling.
+
+    Args:
+        start_step (int): The step at which to start the nsys profiling.
+        end_step (int): The step at which to end the nsys profiling.
+        with_modules(bool) : show modules
+    """
+    output_path: str
+    start_step: int
+    end_step: int
+    with_stack: bool = False
+    profiler_kwargs: Optional[Dict[str, Any]] = None
+
+    def setup(self, task: run.Partial | run.Script, executor: run.Executor):
+        """Set up the torch profiling plugin."""
+        if isinstance(task, run.Partial):
+            profiler_callback = run.Config(
+                PyTorchProfilerCallback,
+                trace_dir=self.output_path,
+                start_step=self.start_step,
+                end_step=self.end_step,
+                profiler_kwargs=self.profiler_kwargs,
+            )
+            callbacks: list[run.Config[Callback]] = [profiler_callback]  # type: ignore
             _merge_callbacks(task, callbacks=callbacks)
 
 

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -169,6 +169,12 @@ def parse_cli_args():
         default=None,
     )
     parser.add_argument(
+        "-etp",
+        "--enable_torch_profiler",
+        help="Enable torch profiler. Disabled by default",
+        action="store_true",
+    )
+    parser.add_argument(
         "-tb",
         "--tensorboard",
         help="Enable tensorboard logging. Disabled by default",

--- a/scripts/performance/helpers.py
+++ b/scripts/performance/helpers.py
@@ -619,3 +619,28 @@ def build_perf_env_plugin(args, pp_size: int | None = None, user_buffer_registra
         gpu_sm100_or_newer=gpu_sm100_or_newer,
         user_buffer_registration=user_buf,
     )
+
+def build_torch_profiler_plugin(args):
+    """
+    Build a PyTorchProfilerPlugin with consistent defaults across scripts.
+    """
+    from nemo.lightning.run.plugins import PyTorchProfilerPlugin
+
+    enable_torch_profiler = args.enable_torch_profiler or os.environ.get('ENABLE_TORCH_PROFILER', '0') == '1'
+
+    if args.nsys_profile and enable_torch_profiler:
+        logging.warning("Cannot run both Nsys and PyTorch profiler at the same time.")
+        return None
+
+    if enable_torch_profiler:
+        start_iter = int(os.environ.get('TORCH_PROFILER_START_ITER', args.profiling_start_step))
+        end_iter = int(os.environ.get('TORCH_PROFILER_END_ITER', args.profiling_stop_step))
+        return PyTorchProfilerPlugin(
+            start_step=start_iter,
+            end_step=end_iter,
+            output_path=args.log_dir,  # a subdir torch_profiles will be created here.
+            profiler_kwargs={
+                "with_stack": os.environ.get('TORCH_PROFILER_WITH_STACK', '0') == '1',
+            }
+        )
+    return None

--- a/scripts/performance/helpers.py
+++ b/scripts/performance/helpers.py
@@ -401,9 +401,7 @@ def set_perf_optimization_configs(
         recipe.trainer.strategy.ddp.check_for_large_grads = False
         recipe.trainer.strategy.ddp.nccl_ub = bool(use_user_buffer_registration)
         recipe.trainer.strategy.ddp.fsdp_double_buffer = bool(use_fsdp_double_buffer)
-        recipe.trainer.strategy.ddp.keep_fp8_transpose_cache = bool(
-            keep_fsdp_fp8_transpose_cache
-        )
+        recipe.trainer.strategy.ddp.keep_fp8_transpose_cache = bool(keep_fsdp_fp8_transpose_cache)
 
     return recipe
 
@@ -619,6 +617,7 @@ def build_perf_env_plugin(args, pp_size: int | None = None, user_buffer_registra
         gpu_sm100_or_newer=gpu_sm100_or_newer,
         user_buffer_registration=user_buf,
     )
+
 
 def build_torch_profiler_plugin(args):
     """

--- a/scripts/performance/helpers.py
+++ b/scripts/performance/helpers.py
@@ -628,7 +628,7 @@ def build_torch_profiler_plugin(args):
 
     enable_torch_profiler = args.enable_torch_profiler or os.environ.get('ENABLE_TORCH_PROFILER', '0') == '1'
 
-    if args.nsys_profile and enable_torch_profiler:
+    if args.enable_nsys and enable_torch_profiler:
         logging.warning("Cannot run both Nsys and PyTorch profiler at the same time.")
         return None
 
@@ -641,6 +641,7 @@ def build_torch_profiler_plugin(args):
             output_path=args.log_dir,  # a subdir torch_profiles will be created here.
             profiler_kwargs={
                 "with_stack": os.environ.get('TORCH_PROFILER_WITH_STACK', '0') == '1',
-            }
+            },
+            collect_et=os.environ.get('TORCH_PROFILER_COLLECT_ET', '0') == '1',
         )
     return None

--- a/scripts/performance/llm/finetune_deepseek_v3.py
+++ b/scripts/performance/llm/finetune_deepseek_v3.py
@@ -26,7 +26,7 @@ from nemo.lightning.run.plugins import MemoryProfilePlugin, NsysPlugin
 
 from ..argument_parser import parse_additional_slurm_params, parse_cli_args
 from ..executors import slurm_executor
-from ..helpers import args_sanity_check, build_perf_env_plugin, get_user_configs, set_primary_perf_configs
+from ..helpers import args_sanity_check, build_perf_env_plugin, build_torch_profiler_plugin, get_user_configs, set_primary_perf_configs
 from ..utils import hf_tokenizer, import_ckpt_experiment, isfile_train_pack_metadata
 
 HF_MODEL_URI = "deepseek-ai/DeepSeek-V3-Base"
@@ -175,6 +175,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=10, end_step=12, gen_shape=True))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/finetune_deepseek_v3.py
+++ b/scripts/performance/llm/finetune_deepseek_v3.py
@@ -26,7 +26,13 @@ from nemo.lightning.run.plugins import MemoryProfilePlugin, NsysPlugin
 
 from ..argument_parser import parse_additional_slurm_params, parse_cli_args
 from ..executors import slurm_executor
-from ..helpers import args_sanity_check, build_perf_env_plugin, build_torch_profiler_plugin, get_user_configs, set_primary_perf_configs
+from ..helpers import (
+    args_sanity_check,
+    build_perf_env_plugin,
+    build_torch_profiler_plugin,
+    get_user_configs,
+    set_primary_perf_configs,
+)
 from ..utils import hf_tokenizer, import_ckpt_experiment, isfile_train_pack_metadata
 
 HF_MODEL_URI = "deepseek-ai/DeepSeek-V3-Base"

--- a/scripts/performance/llm/finetune_llama31_405b.py
+++ b/scripts/performance/llm/finetune_llama31_405b.py
@@ -29,6 +29,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -204,6 +205,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/finetune_llama3_70b.py
+++ b/scripts/performance/llm/finetune_llama3_70b.py
@@ -29,6 +29,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -213,6 +214,10 @@ if __name__ == "__main__":
                     nsys_gpu_metrics=args.profiling_gpu_metrics,
                 )
             )
+
+        if torch_profiler_plugin := build_torch_profiler_plugin(args):
+            plugins.append(torch_profiler_plugin)
+
         if args.enable_memory_profile:
             assert args.memory_profile_out_path is not None
             plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/finetune_llama3_8b.py
+++ b/scripts/performance/llm/finetune_llama3_8b.py
@@ -24,6 +24,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -149,6 +150,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/finetune_llama4_e128.py
+++ b/scripts/performance/llm/finetune_llama4_e128.py
@@ -25,6 +25,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -198,6 +199,9 @@ if __name__ == "__main__":
                     nsys_gpu_metrics=args.profiling_gpu_metrics,
                 )
             )
+
+        if torch_profiler_plugin := build_torch_profiler_plugin(args):
+            plugins.append(torch_profiler_plugin)
 
         executor = slurm_executor(
             args.gpu.lower(),

--- a/scripts/performance/llm/mlperf_lora_llama2_70b.py
+++ b/scripts/performance/llm/mlperf_lora_llama2_70b.py
@@ -28,7 +28,7 @@ from nemo.lightning.run.plugins import MemoryProfilePlugin, NsysPlugin
 
 from ..argument_parser import parse_additional_slurm_params, parse_cli_args
 from ..executors import slurm_executor
-from ..helpers import args_sanity_check, build_perf_env_plugin
+from ..helpers import args_sanity_check, build_perf_env_plugin, build_torch_profiler_plugin
 from ..utils import import_ckpt_experiment
 
 NUM_NODES = 1
@@ -353,6 +353,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=PP_SIZE)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_automodel_llama3_8b.py
+++ b/scripts/performance/llm/pretrain_automodel_llama3_8b.py
@@ -23,7 +23,7 @@ from nemo.lightning.run.plugins import MemoryProfilePlugin, NsysPlugin
 
 from ..argument_parser import parse_additional_slurm_params, parse_cli_args
 from ..executors import slurm_executor
-from ..helpers import args_sanity_check, build_perf_env_plugin, get_user_configs
+from ..helpers import args_sanity_check, build_perf_env_plugin, build_torch_profiler_plugin, get_user_configs
 
 SEQ_LENGTH = 2048
 NUM_GPUS_PER_NODE = 8
@@ -113,6 +113,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_deepseek_v3.py
+++ b/scripts/performance/llm/pretrain_deepseek_v3.py
@@ -29,6 +29,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -246,6 +247,9 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
 
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None

--- a/scripts/performance/llm/pretrain_gpt3_175b.py
+++ b/scripts/performance/llm/pretrain_gpt3_175b.py
@@ -33,6 +33,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -192,6 +193,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -56,6 +56,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_comm_overlap_callback_idx,
     get_user_configs,
     set_exp_logging_configs,
@@ -433,6 +434,9 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
 
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None

--- a/scripts/performance/llm/pretrain_llama31_405b.py
+++ b/scripts/performance/llm/pretrain_llama31_405b.py
@@ -34,6 +34,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -242,6 +243,9 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
 
     executor = slurm_executor(
         args.gpu.lower(),

--- a/scripts/performance/llm/pretrain_llama3_70b.py
+++ b/scripts/performance/llm/pretrain_llama3_70b.py
@@ -33,6 +33,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -227,6 +228,10 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_llama3_8b.py
+++ b/scripts/performance/llm/pretrain_llama3_8b.py
@@ -25,6 +25,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -195,6 +196,10 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_llama4_e128.py
+++ b/scripts/performance/llm/pretrain_llama4_e128.py
@@ -25,6 +25,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -167,6 +168,9 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
 
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None

--- a/scripts/performance/llm/pretrain_llama4_e16.py
+++ b/scripts/performance/llm/pretrain_llama4_e16.py
@@ -25,6 +25,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -144,6 +145,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=15, end_step=16, gen_shape=True))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_mixtral_8x22b.py
+++ b/scripts/performance/llm/pretrain_mixtral_8x22b.py
@@ -26,6 +26,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -164,6 +165,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_mixtral_8x7b.py
+++ b/scripts/performance/llm/pretrain_mixtral_8x7b.py
@@ -26,6 +26,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -132,6 +133,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_nemotron3_22b.py
+++ b/scripts/performance/llm/pretrain_nemotron3_22b.py
@@ -25,6 +25,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     logging,
     set_exp_logging_configs,
@@ -157,6 +158,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_nemotron3_8b.py
+++ b/scripts/performance/llm/pretrain_nemotron3_8b.py
@@ -25,6 +25,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     logging,
     set_exp_logging_configs,
@@ -126,6 +127,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_nemotron4_15b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_15b.py
@@ -29,6 +29,7 @@ from ..executors import runai_executor, slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     logging,
     set_exp_logging_configs,
@@ -220,8 +221,11 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
-        assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))
 
     with run.Experiment(exp_name) as exp:

--- a/scripts/performance/llm/pretrain_nemotron4_340b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_340b.py
@@ -32,6 +32,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     logging,
     set_exp_logging_configs,
@@ -211,6 +212,10 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_nemotronh_47b.py
+++ b/scripts/performance/llm/pretrain_nemotronh_47b.py
@@ -25,6 +25,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -156,6 +157,9 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
 
     with run.Experiment(exp_name) as exp:
         exp.add(

--- a/scripts/performance/llm/pretrain_nemotronh_56b.py
+++ b/scripts/performance/llm/pretrain_nemotronh_56b.py
@@ -26,6 +26,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -164,6 +165,9 @@ if __name__ == "__main__":
                 nsys_gpu_metrics=args.profiling_gpu_metrics,
             )
         )
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
 
     executor = slurm_executor(
         args.gpu.lower(),

--- a/scripts/performance/llm/pretrain_nemotronh_8b.py
+++ b/scripts/performance/llm/pretrain_nemotronh_8b.py
@@ -25,6 +25,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -156,6 +157,9 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
 
     with run.Experiment(exp_name) as exp:
         exp.add(

--- a/scripts/performance/llm/pretrain_qwen3_235b_a22b.py
+++ b/scripts/performance/llm/pretrain_qwen3_235b_a22b.py
@@ -26,6 +26,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -144,6 +145,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6, gen_shape=True))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/scripts/performance/llm/pretrain_qwen3_30b_a3b.py
+++ b/scripts/performance/llm/pretrain_qwen3_30b_a3b.py
@@ -26,6 +26,7 @@ from ..executors import slurm_executor
 from ..helpers import (
     args_sanity_check,
     build_perf_env_plugin,
+    build_torch_profiler_plugin,
     get_user_configs,
     set_exp_logging_configs,
     set_primary_perf_configs,
@@ -143,6 +144,10 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_nsys:
         plugins.append(NsysPlugin(start_step=5, end_step=6, gen_shape=True))
+
+    if torch_profiler_plugin := build_torch_profiler_plugin(args):
+        plugins.append(torch_profiler_plugin)
+
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None
         plugins.append(MemoryProfilePlugin(dir=args.memory_profile_out_path))

--- a/tests/collections/llm/llama3_pretraining.py
+++ b/tests/collections/llm/llama3_pretraining.py
@@ -154,7 +154,6 @@ def main():
             start_step=0,
             end_step=args.max_steps,
             warmup_steps=0,
-            active_steps=args.max_steps,
             trace_dir=trace_dir,
             profiler_kwargs={'with_stack': True},
         )
@@ -172,7 +171,7 @@ def main():
     if args.profiler:
         exp_path = os.path.join(args.experiment_dir, exp_name)
         trace_root = os.path.join(exp_path, "traces")
-        device_dir = os.path.join(trace_root, "device")
+        device_dir = os.path.join(trace_root, "torch_profiler")
         host_dir = os.path.join(trace_root, "host")
 
         assert os.path.isdir(device_dir), f"Missing device traces directory: {device_dir}"


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Adds a Torch profiler plugin and updates Torch profiler callback. Performance scripts update to have ready access to torch profiler now.

# Changelog
1. Update Torch profiler callbacks so we can optionally enable chakra execution trace. 
2. Add a Torch profiler NeMo Run plugin (see `nemo/lightning/run/plugins.py`).
3. Update performance scripts to include torch profiler plugin (see `nemo/scripts/performance/...`)

# Usage
We added a new nemo run plugin to add PyTorch profiling. 
One can add the plugin like
```python
plugins = []
...
plugins += PyTorchProfilerPlugin(
    start_step=start_iter,
    end_step=end_iter,
    output_path=log_dir,  # a subdir torch_profiles will be created here.
    profiler_kwargs={
        "with_stack": os.environ.get('TORCH_PROFILER_WITH_STACK', '0') == '1',
    }
)
...
with run.Experiment("llama3_8b_nsys_profiling") as exp:
    exp.add(
        recipe,
        executor=executor,
        plugins=plugins,
    )
    exp.run()
```
In the nemo performance scripts `scripts/performance`, you can use the following helper function
```python
    if torch_profiler_plugin := build_torch_profiler_plugin(args):
        plugins.append(torch_profiler_plugin)
```

## Sample output
In the logs we should the profiling configured as
```
[default0]:[NeMo I 2025-09-25 15:22:14 nemo_logging:393] PyTorch profiling initialized:
[default0]:     - Start Step: 36
[default0]:     - End Step: 40
[default0]:     - Warmup Steps: 2
[default0]:     - Active Steps: 4
[default0]:     - Trace Directory: /home/bcoutinho/nemo_experiments/torch_and_nsys
[default0]:     - Collect Execution Trace: False
[default0]:     - Extra profiler kwargs: {'with_stack': False}
```
After the correct iteration you will see logs dumped
```
[default0]:Training epoch 0, iteration 38/49 | lr: 2.335e-05 | global_batch_size: 32 | global_step: 38 | reduced_train_loss: 10.88 | train_step_timing in s: 3.106 | consumed_samples: 1248
[default0]:[NeMo I 2025-09-25 15:24:58 nemo_logging:393] Kineto trace saved: /home/bcoutinho/nemo_experiments/torch_and_nsys/torch_profiler/rank-0.json.gz
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [N/A] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
Tested using simple nemotron training script below.
```
def configure_recipe(nodes: int = 1, gpus_per_node: int = 2, add_torch_profiler = False):
    recipe = llm.nemotron3_4b.pretrain_recipe(
        dir="/checkpoints/nemotron", # Path to store checkpoints
        name="nemotron_pretraining",
        tensor_parallelism=2,
        num_nodes=nodes,
        num_gpus_per_node=gpus_per_node,
        max_steps=50, # Setting a small value for the quickstart
    )
    recipe.trainer.val_check_interval = 10000
    return recipe
    
def local_executor_torchrun(nodes: int = 1, devices: int = 2) -> run.LocalExecutor:
    # Env vars for jobs are configured here
    env_vars = {
        "TORCH_NCCL_AVOID_RECORD_STREAMS": "1",
        "NCCL_NVLS_ENABLE": "0",
        "NVTE_DP_AMAX_REDUCE_INTERVAL": "0",
        "NVTE_ASYNC_AMAX_REDUCTION": "1",
    }
    executor = run.LocalExecutor(ntasks_per_node=devices, launcher="torchrun", env_vars=env_vars)

    return executor
    
def run_pretraining(args):
    recipe = configure_recipe(add_torch_profiler=(not use_experiment_api))
    executor = local_executor_torchrun(nodes=recipe.trainer.num_nodes, devices=recipe.trainer.devices)

    plugins = []
    # if torch_profiler_plugin := build_torch_profiler_plugin_1(args):
    if torch_profiler_plugin := build_torch_profiler_plugin(args):
        plugins.append(torch_profiler_plugin)
        
    with run.Experiment("llama3_8b_nsys_profiling") as exp:
        exp.add(
            recipe,
            executor=executor,
            plugins=plugins,
        )
        exp.run()
```