### PR TITLE
Bug in MXFP8 recipe

### DIFF
--- a/nemo/collections/llm/recipes/precision/mixed_precision.py
+++ b/nemo/collections/llm/recipes/precision/mixed_precision.py
@@ -96,7 +96,7 @@ def bf16_with_mxfp8_mixed() -> run.Config[MegatronMixedPrecision]:
         run.Config[MegatronMixedPrecision]: Configuration for BF16 with MXFP8 mixed precision training
     """
     cfg = bf16_mixed()
-    cfg.fp8 = 'hybrid'
+    cfg.fp8 = 'e4m3'
     cfg.fp8_recipe = "mxfp8"
     cfg.fp8_param_gather = True
     cfg.reuse_grad_buf_for_mxfp8_param_ag = True
@@ -110,7 +110,7 @@ def fp16_with_mxfp8_mixed() -> run.Config[MegatronMixedPrecision]:
         run.Config[MegatronMixedPrecision]: Configuration for FP16 with MXFP8 mixed precision training
     """
     cfg = fp16_mixed()
-    cfg.fp8 = 'hybrid'
+    cfg.fp8 = 'e4m3'
     cfg.fp8_recipe = "mxfp8"
     cfg.fp8_param_gather = True
     cfg.reuse_grad_buf_for_mxfp8_param_ag = True

--- a/tests/collections/llm/recipes/test_mixed_precision.py
+++ b/tests/collections/llm/recipes/test_mixed_precision.py
@@ -84,7 +84,7 @@ def test_bf16_with_mxfp8_mixed_config():
     assert config.pipeline_dtype == torch.bfloat16
 
     # Check FP8 specific settings
-    assert config.fp8 == "hybrid"
+    assert config.fp8 == "e4m3"
     assert config.fp8_recipe == "mxfp8"
     assert config.fp8_param_gather is True
     assert config.reuse_grad_buf_for_mxfp8_param_ag is True
@@ -97,7 +97,7 @@ def test_fp16_with_mxfp8_mixed_config():
     assert config.pipeline_dtype == torch.half
 
     # Check FP8 specific settings
-    assert config.fp8 == "hybrid"
+    assert config.fp8 == "e4m3"
     assert config.fp8_recipe == "mxfp8"
     assert config.fp8_param_gather is True
     assert config.reuse_grad_buf_for_mxfp8_param_ag is True


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

This PR fixes a bug in MXFP8 recipe. For more details please see: [https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/638](https://github.com/NVIDIA-NeMo/Megatron-Bridge/pull/638)

**Collection**: Mixed Precision Recipes for model pre-training

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
