### PR TITLE
Update Black version to 25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ skip_string_normalization = true
 # major year version is stable, see details in
 # https://black.readthedocs.io/en/stable/the_black_code_style/index.html
 # `required_version` is necessary for consistency (other `black` versions will fail to reformat files)
-required_version = "24"
+required_version = "25"
 target-version = ['py310', 'py311', 'py312']
 extend-exclude = '''
 # A regex preceded with ^/ will apply only to files and directories


### PR DESCRIPTION
The existing version 24 is no longer supported by VsCode and Cursor black plugins which makes it harder to format the files before submitting PRs.

Tested the updated version on a couple already-formatted files and formatting did not change, so this shouldn't cause major diffs.