### PR TITLE
Address problems where sometimes in 1m dataset there are very large m…

### DIFF
--- a/nemo/collections/llm/gpt/data/megatron/hyena/evo2_dataset.py
+++ b/nemo/collections/llm/gpt/data/megatron/hyena/evo2_dataset.py
@@ -33,6 +33,7 @@ class Evo2Dataset(GPTDataset):
     RESET_PAD_EOD_MASK: bool = True  # If set, unset the mask for [pad] and [eod] tokens (matches Evo2 paper).
     # Valid DNA tokens: A, C, G, T, U, W, S, M, K, R, Y, B, D, H, V, N, -,  (both uppercase and lowercase and
     #   degenerate bases and RNA)
+    MAX_TAG_LEN = 2048
 
     VALID_DNA_AND_DEGENERATE: ClassVar[set[int]] = {
         45,
@@ -95,6 +96,7 @@ class Evo2Dataset(GPTDataset):
             self.TAG_BOUNDS,
             self.TAG_CHARS,
             self.config.tokenizer.eod if self.config.tokenizer is not None else self.DEFAULT_EOD,
+            self.MAX_TAG_LEN,
         )
         databatch["loss_mask"] = loss_mask * phylotag_mask
         if self.TO_UPPER_TOKENS:
@@ -116,6 +118,7 @@ class Evo2Dataset(GPTDataset):
         terminal_tag_char: int,  # e.g. ASCII for '|'
         other_tag_chars: set[int],  # e.g. {95, 59, 32} for '_', ';', space
         eod_token_id: int,  # e.g. 0
+        max_tag_len: int,
     ) -> torch.Tensor:
         """
         Creates a binary mask for sequences containing phylogenetic tags and DNA.
@@ -182,7 +185,6 @@ class Evo2Dataset(GPTDataset):
         if not batched:
             tokenized_sequence = tokenized_sequence.unsqueeze(0)
         batch_size, seq_len = tokenized_sequence.shape
-        first_taxonomy_prefix_token: int = 100
 
         valid_dna_or_control_tensor = torch.tensor(
             list(Evo2Dataset.VALID_DNA_AND_DEGENERATE | set(Evo2Dataset.CONTROL_TAGS)), device=device, dtype=dtype
@@ -206,8 +208,8 @@ class Evo2Dataset(GPTDataset):
             pipe_pos = (seg_seq == terminal_tag_char).nonzero(as_tuple=True)[0].cpu().tolist()
             if len(pipe_pos) == 0:
                 # If no pipe exists and any token is a known tag char or not valid DNA,
-                # mask the entire segment.
-                if not region_all_valid_or_control(seg_seq):
+                # mask the entire segment, unless it is longer than the maximum tag len.
+                if len(seg_seq) < max_tag_len and not region_all_valid_or_control(seg_seq):
                     seg_mask.zero_()
                 return seg_mask
 
@@ -217,35 +219,52 @@ class Evo2Dataset(GPTDataset):
             # Does tag start before the first pipe? This determines the starting state of our state machine.
             first_pipe = pipe_pos[0]
             if first_pipe >= 0 and first_pipe < seg_len - 1:
-                # fastest check is to look at the first token after the pipe, if it is a 'd' then the
+                # fastest check is to look at the first token after the pipe, if it is a '*_' then the
                 # tag starts _after_ the pipe, otherwise it starts before.
-                next_tok = seg_seq[first_pipe + 1].item()
-                if next_tok == first_taxonomy_prefix_token:
-                    # 'd' character for domain, which is the first part of a phylo tag.
-                    # tag starts after the pipe.
+                if len(seg_seq) > first_pipe + 2:
+                    first_tok = seg_seq[first_pipe + 1].item()
+                    next_tok = seg_seq[first_pipe + 2].item()
+                    if next_tok == 95 or first_tok == 59:  # ord('_') = 95, ord(';') = 59
+                        # the syntax is [tag char]_ or a missing segment would start with ;
+                        is_tag = False
+                    else:
+                        # tag starts before the pipe.
+                        is_tag = True
+                elif len(seg_seq) > first_pipe + 1:
+                    next_tok = seg_seq[first_pipe + 1].item()
+                    # Much weaker signal since these are sometimes degenerate bases, but at least the length
+                    #  check later will prevent overmasking.
+                    if next_tok in {68, 100, 82, 114, 59}:  # D,d,R,r for domain or realm (viruses) or missing ;
+                        is_tag = False
+                    else:
+                        is_tag = True
+                elif first_pipe >= max_tag_len or region_all_valid_or_control(seg_seq[:first_pipe]):
                     is_tag = False
                 else:
-                    # tag starts before the pipe.
                     is_tag = True
             else:
                 # The sequence ends with a pipe, so just check everything before the pipe and return the seg mask
                 assert first_pipe == seg_len - 1
                 # The sequence ends with a pipe, so just check everything before the pipe.
-                if region_all_valid_or_control(seg_seq[:first_pipe]):
+                if first_pipe >= max_tag_len or region_all_valid_or_control(seg_seq[:first_pipe]):
                     return seg_mask  # Pipe pos has already been masked
                 else:
                     seg_mask[:first_pipe] = 0
                     return seg_mask
             start = 0
             for end in pipe_pos:
-                if is_tag:
+                seg_len = end - start
+                if is_tag and seg_len < max_tag_len:  # Prefer faulty tag mask logic over masking entire seqs
                     seg_mask[start:end] = 0
+                elif seg_len >= max_tag_len:
+                    is_tag = not is_tag  # Flip the state machine because the is_tag label was for a very long region
                 else:
                     pass
                 is_tag = not is_tag  # Flip the state machine.
                 start = end + 1  # position after the pipe
             # Process the last segment after the last pipe.
-            if is_tag:
+            seg_len = len(seg_mask) - start
+            if is_tag and seg_len < max_tag_len:  # Prefer faulty tag mask logic over overmasking
                 seg_mask[start:] = 0
             return seg_mask
 


### PR DESCRIPTION
## Description
Add a MAX_TAG_LEN field to handle the case where some unknown pattern is encountered in the data that leads to huge swaths of DNA being masked. Prefer to leave a potential tag unmasked than mask a huge amount of DNA. Non-ACGT characters are still individually masked as before. This addresses divide by zero encountered in num_tokens in megatron context parallelism when training at 1m context length and CP=2.

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
