### PR TITLE
[lhotse][aistore] added support input_cfg.yaml directly from aistore bucket

### DIFF
--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -24,6 +24,7 @@ import omegaconf
 from lhotse import CutSet, Features, Recording
 from lhotse.array import Array, TemporalArray
 from lhotse.cut import Cut, MixedCut, PaddingCut
+from lhotse.serialization import load_yaml
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from nemo.collections.common.data.lhotse.nemo_adapters import (
@@ -346,8 +347,8 @@ def parse_and_combine_datasets(
     tarred_status = []
 
     if isinstance(config_list, (str, Path)):
-        # Resolve /path/to/input_cfg.yaml into config contents if needed.
-        config_list = OmegaConf.load(config_list)
+        # Resolve local filepath /path/to/input_cfg.yaml or remote url s3://bucket/path/to/input_cfg.yaml into config contents if needed.
+        config_list = load_yaml(config_list)
     assert len(config_list) > 0, "Empty group in dataset config list."
 
     for item in config_list:


### PR DESCRIPTION
```python
In [59]: from lhotse.serialization import load_yaml

In [60]: config_yaml_local = load_yaml("./train_input_cfg_audioCodec21fpsCausalDecoder_withTC_shardSize256_ais.yaml")

In [63]: config_yaml_local[0]
Out[63]:
{'type': 'lhotse_shar',
 'shar_path': {'cuts': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/cuts/cuts.{000000..001231}.jsonl.gz',
  'target_audio': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/target_audio/recording.{000000..001231}.tar',
  'context_audio': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/context_audio/recording.{000000..001231}.tar',
  'target_codes': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/codes_21fpsCausalDecoder/target_codes/codes.{000000..001231}.tar',
  'context_codes': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/codes_21fpsCausalDecoder/context_codes/codes.{000000..001231}.tar'},
 'weight': 0.05,
 'tags': {'tokenizer_names': ['english_phoneme']}}

In [67]: config_yaml = load_yaml("s3://data/TTS/lhotse_datasets_2505/en/train_input_cfg_audioCodec21fpsCausalDecoder_withTC_shardSize256_ais.yaml")

In [68]: config_yaml[0]
Out[68]:
{'type': 'lhotse_shar',
 'shar_path': {'cuts': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/cuts/cuts.{000000..001231}.jsonl.gz',
  'target_audio': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/target_audio/recording.{000000..001231}.tar',
  'context_audio': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/context_audio/recording.{000000..001231}.tar',
  'target_codes': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/codes_21fpsCausalDecoder/target_codes/codes.{000000..001231}.tar',
  'context_codes': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/codes_21fpsCausalDecoder/context_codes/codes.{000000..001231}.tar'},
 'weight': 0.05,
 'tags': {'tokenizer_names': ['english_phoneme']}}

In [75]: config_yaml_local == config_yaml
Out[75]: True
```