### PR TITLE
Fix clustering eigen

### DIFF
--- a/nemo/collections/asr/parts/utils/offline_clustering.py
+++ b/nemo/collections/asr/parts/utils/offline_clustering.py
@@ -150,7 +150,13 @@ def kmeans_plusplus_torch(
 
     centers = torch.zeros(n_clusters, n_features, dtype=X.dtype)
     center_id = torch.randint(0, n_samples, (1,)).long()
-    indices = torch.full([n_clusters,], -1, dtype=torch.int)
+    indices = torch.full(
+        [
+            n_clusters,
+        ],
+        -1,
+        dtype=torch.int,
+    )
 
     centers[0] = X[center_id].squeeze(0)
     indices[0] = center_id.squeeze(0)
@@ -551,12 +557,12 @@ def eigDecompose(laplacian: torch.Tensor, cuda: bool, device: torch.device) -> T
     else:
         laplacian = laplacian.float().to(torch.device('cpu'))
 
-    #The next line crashed sometimes during diatization
-    #Error: "linalg.eigh: Argument 8 has illegal value."
-    #This happens with torch 2.6 but not 2.3
-    #lambdas, diffusion_map = eigh(laplacian)
+    # The next line crashed sometimes during diatization
+    # Error: "linalg.eigh: Argument 8 has illegal value."
+    # This happens with torch 2.6 but not 2.3
+    # lambdas, diffusion_map = eigh(laplacian)
 
-    #The next fix ensure square, hermitian/symmetric inputs with correct layout
+    # The next fix ensure square, hermitian/symmetric inputs with correct layout
     lambdas, diffusion_map = torch.linalg.eigh(
         laplacian.to(torch.float64).clone().contiguous(),  # sane dtype & layout
         UPLO="L",  # tell the backend which triangle is valid
@@ -997,8 +1003,12 @@ class NMESC:
         est_spk_n_dict: Dict[int, torch.Tensor] = {}
         self.p_value_list = self.getPvalueList()
         p_volume = self.p_value_list.shape[0]
-        eig_ratio_list = torch.zeros(p_volume,)
-        est_num_of_spk_list = torch.zeros(p_volume,)
+        eig_ratio_list = torch.zeros(
+            p_volume,
+        )
+        est_num_of_spk_list = torch.zeros(
+            p_volume,
+        )
 
         if self.parallelism:
             futures: List[torch.jit.Future[torch.Tensor]] = []

--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -7,6 +7,7 @@ lhotse>=1.31.1
 # Align with upstream PyTorch requirements
 librosa>=0.10.1
 marshmallow
+megatron-core
 optuna
 packaging
 pyannote.core


### PR DESCRIPTION
In some cases offline diarization crashes with the next error:

`RuntimeError: false INTERNAL ASSERT FAILED at "/pytorch/aten/src/ATen/native/BatchLinearAlgebra.cpp":1601, please report a bug to PyTorch. linalg.eigh: Argument 8 has illegal value. Most certainly there is a bug in the implementation calling the backend library.`

I noticed this happens with torch 2.6 but doesn't happen with torch 2.3.

This is a fix to avoid this error, making sure that the input matrix for the eigen decomposition has the right shape.

Also adding megatron-core dependency
