### PR TITLE
[lhotse][aistore] added support input_cfg.yaml directly from aistore bucket

### DIFF
--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -345,11 +345,10 @@ def parse_and_combine_datasets(
 
     if isinstance(config_list, (str, Path)):
         # Resolve local filepath /path/to/input_cfg.yaml or remote url s3://bucket/path/to/input_cfg.yaml into config contents if needed.
-        config_list = load_yaml(config_list)
+        config_list = OmegaConf.create(load_yaml(config_list))
     assert len(config_list) > 0, "Empty group in dataset config list."
 
-    for item_dict in config_list:
-        item = OmegaConf.create(item_dict)
+    for item in config_list:
         # Check if we have any attributes that are propagated downwards to each item in the group.
         # If a key already exists in the item, it takes precedence (we will not overwrite);
         # otherwise we will assign it.

--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -348,8 +348,8 @@ def parse_and_combine_datasets(
         config_list = load_yaml(config_list)
     assert len(config_list) > 0, "Empty group in dataset config list."
 
-    for item in config_list:
-
+    for item_dict in config_list:
+        item = OmegaConf.create(item_dict)
         # Check if we have any attributes that are propagated downwards to each item in the group.
         # If a key already exists in the item, it takes precedence (we will not overwrite);
         # otherwise we will assign it.

--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -24,6 +24,7 @@ import omegaconf
 from lhotse import CutSet, Features, Recording
 from lhotse.array import Array, TemporalArray
 from lhotse.cut import Cut, MixedCut, PaddingCut
+from lhotse.serialization import load_yaml
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from nemo.collections.common.data.lhotse.nemo_adapters import (
@@ -343,8 +344,8 @@ def parse_and_combine_datasets(
     tarred_status = []
 
     if isinstance(config_list, (str, Path)):
-        # Resolve /path/to/input_cfg.yaml into config contents if needed.
-        config_list = OmegaConf.load(config_list)
+        # Resolve local filepath /path/to/input_cfg.yaml or remote url s3://bucket/path/to/input_cfg.yaml into config contents if needed.
+        config_list = load_yaml(config_list)
     assert len(config_list) > 0, "Empty group in dataset config list."
 
     for item in config_list:


### PR DESCRIPTION
This is the PR cherry-picked from https://github.com/NVIDIA-NeMo/NeMo/pull/14891

unified loading yaml config method with `load_yaml`, so that we can now support either local yaml config file path or remote aistore path.

```python
In [1]: from lhotse.serialization import load_yaml

In [2]: config_yaml_local = load_yaml("./train_input_cfg_audioCodec21fpsCausalDecoder_withTC_shardSize256_ais.yaml")

In [3]: config_yaml_local[0]
Out[3]:
{'type': 'lhotse_shar',
 'shar_path': {'cuts': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/cuts/cuts.{000000..001231}.jsonl.gz',
  'target_audio': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/target_audio/recording.{000000..001231}.tar',
  'context_audio': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/context_audio/recording.{000000..001231}.tar',
  'target_codes': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/codes_21fpsCausalDecoder/target_codes/codes.{000000..001231}.tar',
  'context_codes': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/codes_21fpsCausalDecoder/context_codes/codes.{000000..001231}.tar'},
 'weight': 0.05,
 'tags': {'tokenizer_names': ['english_phoneme']}}

In [4]: config_yaml_ais = load_yaml("s3://data/TTS/lhotse_datasets_2505/en/train_input_cfg_audioCodec21fpsCausalDecoder_withTC_shardSize256_ais.yaml")

In [5]: config_yaml_ais[0]
Out[5]:
{'type': 'lhotse_shar',
 'shar_path': {'cuts': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/cuts/cuts.{000000..001231}.jsonl.gz',
  'target_audio': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/target_audio/recording.{000000..001231}.tar',
  'context_audio': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/context_audio/recording.{000000..001231}.tar',
  'target_codes': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/codes_21fpsCausalDecoder/target_codes/codes.{000000..001231}.tar',
  'context_codes': 's3://data/TTS/lhotse_datasets_2505/en/hifitts/lhotse_shar_shuffle_shardSize256/codes_21fpsCausalDecoder/context_codes/codes.{000000..001231}.tar'},
 'weight': 0.05,
 'tags': {'tokenizer_names': ['english_phoneme']}}

In [6]: config_yaml_local == config_yaml_ais
Out[6]: True
```

**tested running through higher level api**
```python
In [1]: from nemo.collections.common.data.lhotse.cutset import read_dataset_config

In [2]: from omegaconf import OmegaConf

In [3]: from rich import print

In [4]: input_cfg = {"input_cfg": "s3://data/TTS/lhotse_datasets_2505/en/train_input_cfg_audioCodec21fpsCausalDecoder_withTC_shardSize256_ais.yaml"}

In [5]: config = OmegaConf.create(input_cfg)

In [6]: cuts, is_tarred = read_dataset_config(config)

In [7]: cuts
Out[7]: CutSet(len=<unknown>) [underlying data type: <class 'lhotse.lazy.LazyIteratorMultiplexer'>]

In [8]: first_cut = next(iter(cuts))

In [9]: first_cut
Out[9]: MonoCut(id='cut-rec-Lindy-44khz-WIZWIKI-LINDY_WIZWIKI_001635-0.00-4.48_repeat0_repeat0', start=0.0, duration=4.48, channel=0, supervisions=[SupervisionSegment(id='sup-rec-Lindy-44khz-WIZWIKI-LINDY_WIZWIKI_001635', recording_id='rec-Lindy-44khz-WIZWIKI-LINDY_WIZWIKI_001635', start=0.0, duration=4.48, channel=0, text='I love to light candles around the house — especially the scented Yankee Candle ones.', language='en', speaker='| Language:en Dataset:rivaLindyRodney Speaker:Lindy |', gender=None, custom={'emotion': 'other', 'context_speaker_similarity': 0.9083933234214783, 'context_audio_offset': 0.0, 'context_audio_duration': 10.84, 'context_audio_text': "Yeah I've heard that online gambling is legal in the Caribbean. It's almost taken on a legal landscape like offshore banking. Seems a bit too complex to navigate for my taste.", 'context_recording_id': 'rec-Lindy-44khz-WIZWIKI-LINDY_WIZWIKI_001761'}, alignment=None)], features=None, recording=Recording(id='rec-Lindy-44khz-WIZWIKI-LINDY_WIZWIKI_001635', sources=[AudioSource(type='file', channels=[0], source='/audio/Lindy/44khz/WIZWIKI/LINDY_WIZWIKI_001635.wav')], sampling_rate=44100, num_samples=197508, duration=4.478639455782313, channel_ids=[0], transforms=None), custom={'target_audio': Recording(id='cut-rec-Lindy-44khz-WIZWIKI-LINDY_WIZWIKI_001635-0.00-4.48', sources=[AudioSource(type='memory', channels=[0], source='<binary-data>')], sampling_rate=44100, num_samples=197568, duration=4.48, channel_ids=[0], transforms=None), 'context_audio': Recording(id='context_cut-rec-Lindy-44khz-WIZWIKI-LINDY_WIZWIKI_001761-0.00-10.84', sources=[AudioSource(type='memory', channels=[0], source='<binary-data>')], sampling_rate=44100, num_samples=478044, duration=10.84, channel_ids=[0], transforms=None), 'target_codes': TemporalArray(array=Array(storage_type='memory_npy', storage_path='', storage_key='<binary-data>', shape=[8, 97]), temporal_dim=-1, frame_shift=0.046511627906976744, start=0), 'context_codes': TemporalArray(array=Array(storage_type='memory_npy', storage_path='', storage_key='<binary-data>', shape=[8, 234]), temporal_dim=-1, frame_shift=0.046511627906976744, start=0), 'shard_origin': 's3://data/TTS/lhotse_datasets_2505/en/rivaLindyRodney/lhotse_shar_shuffle_shardSize256/cuts/cuts.000051.jsonl.gz', 'shar_epoch': 0, 'tokenizer_names': ['english_phoneme']})
```