### PR TITLE
Fix(ExpManager): Resolve MLflow run_name duplicate argument error

### DIFF
--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -1277,6 +1277,10 @@ def configure_loggers(
         logging.info("WandBLogger has been set up")
 
     if create_mlflow_logger:
+        # Fix: Convert DictConfig to dict and remove run_name to avoid duplicate kwarg
+        if hasattr(mlflow_kwargs, '_metadata'):  # Check if it's a DictConfig
+            mlflow_kwargs = OmegaConf.to_container(mlflow_kwargs, resolve=True)
+        mlflow_kwargs.pop('run_name', None)
         mlflow_logger = MLFlowLogger(run_name=version, **mlflow_kwargs)
 
         logger_list.append(mlflow_logger)


### PR DESCRIPTION
What does this PR do ?
This PR resolves a TypeError in 
exp_manager
 when initializing the MLFlowLogger. The error occurs because MLFlowLogger is called with an explicit run_name=version argument while **mlflow_kwargs (serialized from a DictConfig schema) also contains a default run_name: None field, leading to a "multiple values for keyword argument" conflict.

Collection: Core / Utils

Changelog
Modified 
nemo/utils/exp_manager.py
 to convert mlflow_kwargs to a native dictionary and pop('run_name') before passing it to the MLFlowLogger constructor.
Usage
no changes

exp_manager:
  create_mlflow_logger: true
  mlflow_logger_kwargs:
    experiment_name: my_experiment
    tracking_uri: file://./mlruns
GitHub Actions CI
The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.

Before your PR is "Ready for review"
Pre checks:

 Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
 Did you write any new necessary tests? (Benign fix to logging initialization)
 Did you add or update any necessary documentation?
 Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
 Reviewer: Does the PR have correct import guards for all optional libraries? (MLflow is optional but already handled by existing imports)
PR Type:

 New Feature
 Bugfix
 Documentation
Who can review?
@titu1994, @ericharper

Additional Information
Related to reported issues with MLflow integration in NeMo 2.x where Hydra schemas serialize default None values into keyword arguments.