### PR TITLE
VoiceChat EA STT training reproducible features

### DIFF
--- a/examples/speechlm2/stt_duplex_train.py
+++ b/examples/speechlm2/stt_duplex_train.py
@@ -52,7 +52,7 @@ def train(cfg):
     with trainer.init_module():
         model = DuplexSTTModel(OmegaConf.to_container(cfg.model, resolve=True))
 
-    dataset = DuplexSTTDataset(
+    common_kwargs = dict(
         tokenizer=model.tokenizer,
         frame_length=cfg.data.frame_length,
         source_sample_rate=cfg.data.source_sample_rate,
@@ -62,7 +62,9 @@ def train(cfg):
         cfg=cfg.data,
         model_cfg=cfg.model,
     )
-    datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, dataset=dataset)
+    train_dataset = DuplexSTTDataset(**common_kwargs, is_training=True)
+    val_dataset = DuplexSTTDataset(**common_kwargs, is_training=False)
+    datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, train_dataset=train_dataset, val_dataset=val_dataset)
 
     trainer.fit(model, datamodule)
 

--- a/nemo/collections/speechlm2/data/datamodule.py
+++ b/nemo/collections/speechlm2/data/datamodule.py
@@ -53,12 +53,23 @@ class DataModule(LightningDataModule):
     Args:
         cfg: a DictConfig instance, typically corresponding to `data` namespace in YAML configs.
         tokenizer: a tokenizer instance, typically NeMo's AutoTokenizer wrapping HF's AutoTokenizer.
-        dataset: a torch.utils.data.Dataset instance, expected to define __getitem__ that accepts
+        train_dataset: a torch.utils.data.Dataset instance, expected to define __getitem__ that accepts
             a lhotse.CutSet. It converts metadata + raw data to a batch of PyTorch tensors.
             The data sampling is controlled by Lhotse samplers rather than the dataset.
+            Used for train_dataloader (is_training=True).
+        val_dataset: same contract as train_dataset, but for validation/test (is_training=False).
+            If None, falls back to train_dataset.
+        dataset: deprecated alias for train_dataset. Kept for backward compatibility.
     """
 
-    def __init__(self, cfg, tokenizer: TokenizerSpec, dataset: torch.utils.data.Dataset) -> None:
+    def __init__(
+        self,
+        cfg,
+        tokenizer: TokenizerSpec,
+        train_dataset: torch.utils.data.Dataset = None,
+        val_dataset: torch.utils.data.Dataset = None,
+        dataset: torch.utils.data.Dataset = None,
+    ) -> None:
         super().__init__()
         self.cfg = cfg
         with open_dict(self.cfg):
@@ -67,7 +78,19 @@ class DataModule(LightningDataModule):
                     getattr(self.cfg, k).force_finite = True
                     getattr(self.cfg, k).force_map_dataset = True
         self.tokenizer = tokenizer
-        self.dataset = dataset
+
+        if train_dataset is not None:
+            self.train_dataset = train_dataset
+        elif dataset is not None:
+            self.train_dataset = dataset
+        else:
+            raise ValueError("Either train_dataset or dataset must be provided.")
+
+        self.val_dataset = val_dataset if val_dataset is not None else self.train_dataset
+
+    @property
+    def dataset(self):
+        return self.train_dataset
 
     def train_dataloader(self):
         if "train_ds" not in self.cfg:
@@ -76,7 +99,7 @@ class DataModule(LightningDataModule):
             config=self.cfg.train_ds,
             global_rank=self._get_dp_rank(),
             world_size=self._get_world_size(),
-            dataset=FallbackDataset(self.dataset),
+            dataset=FallbackDataset(self.train_dataset),
             tokenizer=self.tokenizer,
         )
 
@@ -121,7 +144,7 @@ class DataModule(LightningDataModule):
                 config=cfg,
                 global_rank=self._get_dp_rank(),
                 world_size=self._get_world_size(),
-                dataset=self.dataset,
+                dataset=self.val_dataset,
                 tokenizer=self.tokenizer,
             )
 

--- a/nemo/collections/speechlm2/data/duplex_stt_dataset.py
+++ b/nemo/collections/speechlm2/data/duplex_stt_dataset.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import random
 import re
 
@@ -25,11 +26,17 @@ from nemo.collections.common.data.lhotse.text_adapters import Formattable
 from nemo.collections.common.tokenizers import TokenizerSpec
 from nemo.collections.speechlm2.data.force_align import ForceAligner
 from nemo.collections.speechlm2.data.s2s_dataset import _strip_timestamps
-from nemo.collections.speechlm2.data.utils import get_pad_id
+from nemo.collections.speechlm2.data.utils import (
+    MCQ_SYSTEM_PROMPT_NOTHINK,
+    MCQ_SYSTEM_PROMPT_THINK,
+    get_pad_id,
+    is_asr_cut,
+    is_mcq_cut_train,
+    is_mcq_cut_val,
+    normalize_numbers,
+)
 from nemo.collections.speechlm2.parts.augmentation import AudioAugmenter
 from nemo.utils import logging
-
-MCQ_VAL_PROMPT = "Answer the following multiple choice question with an explanation for the answer."
 
 
 class DuplexSTTDataset(torch.utils.data.Dataset):
@@ -76,6 +83,7 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
         aug_by_swap_role: bool = False,
         cfg: dict = None,
         model_cfg: dict = None,
+        is_training: bool = True,
     ):
         self.tokenizer = tokenizer
         self.frame_length = frame_length
@@ -83,6 +91,7 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
         self.input_roles = set(ifnone(input_roles, ["user"]))
         self.output_roles = set(ifnone(output_roles, ["agent"]))
         self.aug_by_swap_role = aug_by_swap_role
+        self.is_training = is_training
 
         self.word_align_position = cfg.get("word_align_position", "left") if cfg is not None else "left"
         self.predict_user_text = model_cfg.get("predict_user_text", False) if model_cfg is not None else False
@@ -91,7 +100,13 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
 
         self.prepend_word_space = cfg.get("prepend_word_space", True) if cfg is not None else True
         self.early_interruption_prob = cfg.get("early_interruption_prob", 0.0) if cfg is not None else 0.0
-        self.add_mcq_val_prompt = cfg.get("add_mcq_val_prompt", False) if cfg is not None else False
+        self.add_mcq_prompt = cfg.get("add_mcq_prompt", False) if cfg is not None else False
+
+        self.add_filler_response_for_asr = cfg.get("add_filler_response_for_asr", False) if cfg is not None else False
+        self.filler_response_delay = cfg.get("filler_response_delay", 0) if cfg is not None else 0
+        self.filler_responses = None
+
+        self.use_numbers_norm = model_cfg.get("use_numbers_norm", True) if model_cfg is not None else True
 
         self.cfg = cfg
         self.model_cfg = model_cfg
@@ -111,11 +126,80 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
 
         assert tokenizer.bos is not None, "BOS support in the tokenizer is required."
         assert tokenizer.eos is not None, "EOS support in the tokenizer is required."
+        
+        user_bos_token = '^'
+        user_eos_token = '$'
+        self.user_bos_id = self.tokenizer.text_to_ids(user_bos_token)[0]
+        self.user_eos_id = self.tokenizer.text_to_ids(user_eos_token)[0]
+        self.agent_bos_id = self.tokenizer.bos
+        self.agent_eos_id = self.tokenizer.eos
+        self.pad_id = get_pad_id(self.tokenizer)
 
     def _is_augmentation_task(self, task: str) -> bool:
         if self.cfg is not None and self.cfg.get('force_use_noise_augmentation', False):
             return True
         return task not in ('s2s_duplex_overlap_as_s2s_duplex', 'asr')
+
+    def _load_filler_responses(self):
+        if self.filler_responses is not None:
+            return
+        filler_response_file = self.cfg.get("filler_response_file", None)
+        if filler_response_file is None:
+            raise ValueError("filler_response_file must be specified when add_filler_response_for_asr is True")
+        with open(filler_response_file, 'r') as f:
+            self.filler_responses = json.load(f)["agent_responses"]
+        logging.info(f"Loaded {len(self.filler_responses)} filler responses from {filler_response_file}")
+
+    def _inject_filler_responses(self, target_tokens: torch.Tensor, target_token_lens: torch.Tensor) -> None:
+        """Inject random filler agent responses into target_tokens for ASR cuts.
+
+        For each sample, finds the existing agent BOS, clears it, then writes
+        [BOS filler_tok1 ... filler_tokN] at (old_bos_pos + filler_response_delay).
+        Truncates if the filler extends beyond the sequence length.
+        Updates target_token_lens based on filler duration_ms when available.
+        """
+        self._load_filler_responses()
+        bos_id = self.agent_bos_id
+        seq_len = target_tokens.shape[1]
+
+        for i in range(target_tokens.shape[0]):
+            bos_positions = (target_tokens[i] == bos_id).nonzero(as_tuple=True)[0]
+            if bos_positions.numel() == 0:
+                logging.warning(f"[_inject_filler] sample {i}: no BOS found, skipping")
+                continue
+
+            old_bos_pos = bos_positions[0].item()
+            target_tokens[i, old_bos_pos] = self.pad_id
+
+            insert_pos = old_bos_pos + self.filler_response_delay
+            if insert_pos >= seq_len:
+                logging.warning(
+                    f"[_inject_filler] sample {i}: insert_pos={insert_pos} >= seq_len={seq_len}, skipping"
+                )
+                continue
+
+            filler = random.choice(self.filler_responses)
+            filler_token_ids = self.tokenizer.text_to_ids(filler["text"])
+            turn_tokens = [bos_id] + filler_token_ids
+            turn_tensor = torch.tensor(turn_tokens, dtype=torch.long)
+
+            available = seq_len - insert_pos
+            if len(turn_tensor) > available:
+                logging.warning(
+                    f"[_inject_filler] sample {i}: truncating filler from {len(turn_tensor)} to {available} tokens"
+                )
+                turn_tensor = turn_tensor[:available]
+
+            target_tokens[i, insert_pos:insert_pos + len(turn_tensor)] = turn_tensor
+
+            filler_end = insert_pos + len(turn_tensor)
+            duration_ms = filler.get("duration_ms", None)
+            if duration_ms is not None:
+                duration_frames = max(1, int(duration_ms / (self.frame_length * 1000)))
+                duration_end = insert_pos + duration_frames
+            else: # fallback to filler end
+                duration_end = filler_end
+            target_token_lens[i] = min(max(duration_end, filler_end), seq_len)
 
     def _apply_early_interruption_augmentation(
         self,
@@ -127,11 +211,10 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
     ) -> None:
         """Simulate early interruption by randomly truncating an agent turn with overlap."""
         target_seq = target_tokens[batch_idx]
-        bos_id = self.tokenizer.bos
-        eos_id = self.tokenizer.eos
-        pad_id = get_pad_id(self.tokenizer)
-
-        overlap_tokens = self.cfg.get("early_interruption_overlap_tokens", 13) if self.cfg is not None else 13
+        bos_id = self.agent_bos_id
+        eos_id = self.agent_eos_id
+        pad_id = self.pad_id
+        overlap_tokens = self.cfg.get("early_interruption_overlap_tokens", 8) if self.cfg is not None else 8
 
         bos_positions = (target_seq == bos_id).nonzero(as_tuple=True)[0]
         eos_positions = (target_seq == eos_id).nonzero(as_tuple=True)[0]
@@ -216,9 +299,9 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
             "sample_id": ["empty_batch"],
             "source_audio": torch.zeros((1, 1000), dtype=torch.float32),
             "source_audio_lens": torch.tensor([1000], dtype=torch.long),
-            "target_tokens": torch.full((1, 50), get_pad_id(self.tokenizer), dtype=torch.long),
+            "target_tokens": torch.full((1, 50), self.pad_id, dtype=torch.long),
             "target_token_lens": torch.tensor([1], dtype=torch.long),
-            "source_tokens": torch.full((1, 50), get_pad_id(self.tokenizer), dtype=torch.long),
+            "source_tokens": torch.full((1, 50), self.pad_id, dtype=torch.long),
             "source_token_lens": torch.tensor([1], dtype=torch.long),
             "source_texts": [""],
             "target_texts": [""],
@@ -266,7 +349,12 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
                 all_cuts_combined = cuts
 
             prompt_tokens, prompt_token_lens = collate_system_prompt(
-                all_cuts_combined, self.tokenizer, add_mcq_val_prompt=self.add_mcq_val_prompt
+                all_cuts_combined,
+                self.tokenizer,
+                bos_id=self.agent_bos_id,
+                eos_id=self.agent_eos_id,
+                pad_id=self.pad_id,
+                add_mcq_prompt=self.add_mcq_prompt,
             )
             source_audio, source_audio_lens = collate_audio(all_cuts_combined.resample(self.source_sample_rate))
 
@@ -275,13 +363,20 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
                 self.tokenizer,
                 self.frame_length,
                 roles=self.output_roles,
-                bos_id=self.tokenizer.bos,
-                eos_id=self.tokenizer.eos,
+                bos_id=self.agent_bos_id,
+                eos_id=self.agent_eos_id,
+                pad_id=self.pad_id,
                 remove_timestamps=True,
+                skip_eos=True, # agent eos is placed when source tokens are collated
+                use_numbers_norm=self.use_numbers_norm,
             )
 
-            # Force align user text (runs in dataloader worker, overlapped with training)
-            if self.force_align_user_text and torch.is_grad_enabled():
+            # Inject filler agent responses for ASR cuts (training only)
+            if self.add_filler_response_for_asr and self.is_training and is_asr_cut(all_cuts_combined[0]):
+                self._inject_filler_responses(target_tokens, target_token_lens)
+
+            # Force align user text (runs in dataloader worker, training only)
+            if self.force_align_user_text and self.is_training:
                 all_cuts_combined = self.force_aligner.batch_force_align_user_audio(
                     all_cuts_combined, source_sample_rate=self.source_sample_rate
                 )
@@ -291,23 +386,27 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
                 self.tokenizer,
                 self.frame_length,
                 roles=self.input_roles,
-                bos_id=self.tokenizer.bos,
-                eos_id=self.tokenizer.eos,
+                bos_id=self.user_bos_id,
+                eos_id=self.agent_eos_id,
+                pad_id=self.pad_id,
                 word_align_position=self.word_align_position,
                 remove_timestamps=not self.predict_user_text,
                 prepend_word_space=self.prepend_word_space,
+                agent_token_channel=target_tokens,
+                agent_token_channel_lengths=target_token_lens.clone(),
+                agent_eos_id=self.agent_eos_id,
             )
 
-            # Audio augmentation (runs in dataloader workers for performance)
+            # Audio augmentation (runs in dataloader workers for performance, training only)
             if (
                 self.audio_augmenter is not None
-                and torch.is_grad_enabled()
+                and self.is_training
                 and self._is_augmentation_task(getattr(all_cuts_combined[0], 'task', 's2s_duplex'))
             ):
                 source_audio = self.audio_augmenter.augment_batch(self.cfg, source_audio, source_audio_lens)
 
-            # Early interruption augmentation
-            if self.early_interruption_prob > 0 and torch.is_grad_enabled():
+            # Early interruption augmentation (training only)
+            if self.early_interruption_prob > 0 and self.is_training:
                 for batch_idx in range(target_tokens.shape[0]):
                     if random.random() < self.early_interruption_prob:
                         self._apply_early_interruption_augmentation(
@@ -351,7 +450,7 @@ class DuplexSTTDataset(torch.utils.data.Dataset):
                 text_tokens.append(text_ids)
                 text_token_lens.append(text_ids.shape[0])
 
-            text_tokens = collate_vectors(text_tokens, padding_value=get_pad_id(self.tokenizer))
+            text_tokens = collate_vectors(text_tokens, padding_value=self.pad_id)
             text_token_lens = torch.tensor(text_token_lens, dtype=torch.long)
             text_data = {
                 "text_tokens": text_tokens,
@@ -497,13 +596,19 @@ def collate_token_channel(
     roles: set[str],
     bos_id: int = None,
     eos_id: int = None,
+    pad_id: int = None,
     word_align_position: str = 'left',
     remove_timestamps: bool = False,
     prepend_word_space: bool = True,
+    skip_eos: bool = False,
+    agent_token_channel: torch.Tensor = None,
+    agent_token_channel_lengths: torch.Tensor = None,
+    agent_eos_id: int = None,
+    use_numbers_norm: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    pad_id = get_pad_id(tokenizer)
-    tokens = [
-        _build_token_channel(
+    tokens = []
+    for cut_idx, c in enumerate(cuts):
+        token_seq = _build_token_channel(
             c,
             tokenizer=tokenizer,
             frame_length=frame_length,
@@ -514,9 +619,13 @@ def collate_token_channel(
             word_align_position=word_align_position,
             remove_timestamps=remove_timestamps,
             prepend_word_space=prepend_word_space,
+            skip_eos=skip_eos,
+            cut_agent_token_channel=agent_token_channel[cut_idx] if agent_token_channel is not None else None,
+            cut_agent_token_channel_length=agent_token_channel_lengths[cut_idx] if agent_token_channel_lengths is not None else None,
+            agent_eos_id=agent_eos_id,
+            use_numbers_norm=use_numbers_norm,
         )
-        for c in cuts
-    ]
+        tokens.append(token_seq)
     token_lens = torch.tensor([len(tt) for tt in tokens])
     tokens = collate_vectors(tokens, padding_value=pad_id)
     return tokens, token_lens
@@ -525,23 +634,37 @@ def collate_token_channel(
 def collate_system_prompt(
     cuts: CutSet,
     tokenizer: TokenizerSpec,
-    add_mcq_val_prompt: bool = False,
+    bos_id: int = None,
+    eos_id: int = None,
+    pad_id: int = None,
+    add_mcq_prompt: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Collate system prompts from cuts stored in cut.custom['system_prompt']."""
-    pad_id = get_pad_id(tokenizer)
+    """Collate system prompts from cuts.
+
+    Prompt selection priority:
+      1. Per-cut custom prompt (cut.custom['system_prompt'])
+      2. MCQ training cut -> THINK prompt for think-cuts, NOTHINK prompt for others
+      3. MCQ validation cut (when add_mcq_prompt=True) -> THINK prompt
+      4. No prompt (empty tensor)
+    """
     tokens = []
     for c in cuts:
+        prompt_text = None
+
         if c.custom and c.custom.get("system_prompt", None):
             prompt_text = c.custom["system_prompt"]
-        elif add_mcq_val_prompt:
-            prompt_text = MCQ_VAL_PROMPT
-        else:
-            prompt_text = None
+        elif add_mcq_prompt and is_mcq_cut_train(c):
+            if is_mcq_cut_train(c, check_think=True):
+                prompt_text = MCQ_SYSTEM_PROMPT_THINK
+            else:
+                prompt_text = MCQ_SYSTEM_PROMPT_NOTHINK
+        elif add_mcq_prompt and is_mcq_cut_val(c):
+            prompt_text = MCQ_SYSTEM_PROMPT_THINK
 
         if prompt_text:
             tokens.append(
                 torch.as_tensor(
-                    [tokenizer.bos] + tokenizer.text_to_ids(prompt_text) + [tokenizer.eos], dtype=torch.long
+                    [bos_id] + tokenizer.text_to_ids(prompt_text) + [eos_id], dtype=torch.long
                 )
             )
         else:
@@ -563,6 +686,12 @@ def _build_token_channel(
     word_align_position: str = 'left',
     remove_timestamps: bool = False,
     prepend_word_space: bool = True,
+    skip_eos: bool = False,
+    cut_agent_token_channel: torch.Tensor = None,
+    cut_agent_token_channel_length: torch.Tensor = None,
+    agent_eos_id: int = None,
+    eos_offset_frames: int = 8,
+    use_numbers_norm: bool = False,
 ) -> torch.Tensor:
     diagnostic = f"Extra info: {cut.id=}"
     if getattr(cut, "shard_origin", None) is not None:
@@ -581,17 +710,17 @@ def _build_token_channel(
             eospos = compute_num_frames(supervision.end, frame_length, cut.sampling_rate)
             available_frames_for_text = eospos - pos
 
-            text = supervision.text
-
             text_ids = torch.as_tensor(
                 [bos_id]
                 + _text_to_ids(
-                    text,
+                    supervision.text,
                     tokenizer,
                     available_frames_for_text=available_frames_for_text,
                     word_align_position=word_align_position,
                     remove_timestamps=remove_timestamps,
                     prepend_word_space=prepend_word_space,
+                    pad_id=pad_id,
+                    use_numbers_norm=use_numbers_norm,
                 )
             )
 
@@ -613,9 +742,21 @@ def _build_token_channel(
                 tokens[pos:endpos] = text_ids
             except Exception as e:
                 raise RuntimeError(f"{tokens.shape=} {pos=} {endpos=} {text_ids.shape=} {diagnostic}") from e
+            
+            if not skip_eos:
+                # place agent eos in the agent token channel
+                if cut_agent_token_channel is not None:
+                    assert agent_eos_id is not None, "Agent EOS ID is not set"
+                    user_bospos = compute_num_frames(supervision.start, frame_length, cut.sampling_rate)
+                    agent_eospos = user_bospos + eos_offset_frames
+                    if agent_eospos < cut_agent_token_channel_length.item():
+                        cut_agent_token_channel[agent_eospos] = agent_eos_id
+                    else:
+                        logging.warning(f"Agent EOS position {agent_eospos} is out of bounds for agent token channel {cut_agent_token_channel.shape}")
 
-            if eospos < len(tokens) and eos_id is not None:
-                tokens[eospos] = eos_id
+                # place user eos in the user token channel
+                if eospos < len(tokens) and eos_id is not None:
+                    tokens[eospos] = eos_id
 
     return tokens
 
@@ -628,8 +769,12 @@ def _text_to_ids(
     word_align_position='left',
     remove_timestamps=False,
     prepend_word_space=True,
+    pad_id: int = None,
+    use_numbers_norm: bool = False,
 ):
     if not remove_timestamps and re.compile(_TIMESTAMP_PATTERN_STR).search(text):
+        # Timestamp-aligned path: normalization is skipped because some expansions
+        # change word count (e.g. "$3.50" → 4 words), breaking word-to-timestamp pairing.
         text_ids = _text_with_timestamps_to_ids(
             text,
             tokenizer,
@@ -637,11 +782,14 @@ def _text_to_ids(
             available_frames_for_text,
             word_align_position,
             prepend_word_space=prepend_word_space,
+            pad_id=pad_id,
         )
     else:
         _TIMESTAMP_PATTERN = re.compile(_TIMESTAMP_PATTERN_STR)
         text = _TIMESTAMP_PATTERN.sub("", text)
         text = " ".join(text.strip().split())
+        if use_numbers_norm:
+            text = normalize_numbers(text)
         text_ids = tokenizer.text_to_ids(text)
     return text_ids
 
@@ -653,6 +801,7 @@ def _text_with_timestamps_to_ids(
     available_frames_for_text=None,
     word_align_position='left',
     prepend_word_space=True,
+    pad_id: int = None,
 ) -> list[int]:
     text_ids, start_times, end_times, word_lens = _extract_text_and_time_tokens(
         text,
@@ -667,7 +816,7 @@ def _text_with_timestamps_to_ids(
         end_times,
         available_frames_for_text,
         frame_rate=0.08,
-        pad_id=get_pad_id(tokenizer),
+        pad_id=pad_id,
         word_align_position=word_align_position,
     )
     return text_ids_with_timestamps

--- a/nemo/collections/speechlm2/data/utils.py
+++ b/nemo/collections/speechlm2/data/utils.py
@@ -11,7 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import inflect
+import re
 import warnings
+
+
+_inflect = inflect.engine()
+
+_COMMA_RE    = re.compile(r"([0-9][0-9,]+[0-9])")
+_DECIMAL_RE  = re.compile(r"\b([0-9]+)\.([0-9]+)\b")
+_DOLLARS_RE  = re.compile(r"\$([0-9,]+(?:\.[0-9]+)?)")
+_ORDINAL_RE  = re.compile(r"\b([0-9]+)(st|nd|rd|th)\b", re.IGNORECASE)
+_NUMBER_RE   = re.compile(r"\b[0-9]+\b")
+
+# Roman numerals: only real standalone uppercase numerals
+_ROMAN_RE = re.compile(r"(?<![A-Z])[IVXLCDM]{2,}(?![A-Z])")
+
+_ROMAN = {"I":1,"V":5,"X":10,"L":50,"C":100,"D":500,"M":1000}
 
 
 def get_pad_id(tokenizer) -> int:
@@ -25,3 +42,97 @@ def get_pad_id(tokenizer) -> int:
         "The text tokenizer has no <pad> or <unk> tokens available, using ID 0 for padding (this may lead to silent bugs)."
     )
     return 0
+
+
+# MCQ system prompt constants
+MCQ_SYSTEM_PROMPT_NOTHINK = "Answer the following multiple choice question."
+MCQ_SYSTEM_PROMPT_THINK = "Answer the following multiple choice question with an explanation for the answer."
+
+
+def is_mcq_cut_train(cut, check_think: bool = False) -> bool:
+    """Check if a cut is from MCQ training data based on shard_origin."""
+    shard_origin = getattr(cut, 'shard_origin', None)
+    if shard_origin is None:
+        return False
+    shard_origin = str(shard_origin)
+    return (
+        "MCQ_training" in shard_origin
+        and "singleQA" not in shard_origin
+        and (not check_think or "_think" in shard_origin)
+    )
+
+
+def is_mcq_cut_val(cut) -> bool:
+    """Check if a cut is from MCQ validation data based on shard_origin."""
+    shard_origin = getattr(cut, 'shard_origin', None)
+    if shard_origin is None:
+        return False
+    return any(pattern in str(shard_origin) for pattern in ("openbookqa", "mmsu", "bbh"))
+
+
+def is_asr_cut(cut) -> bool:
+    """Check if a cut is from ASR data based on task attribute or formatter."""
+    return (
+        getattr(cut, 'task', None) == 'asr'
+        or getattr(cut, 'formatter', None) == 'nemo_tarred_to_duplex'
+    )
+
+
+# --- Number normalization ---
+
+def _roman_to_int(s):
+    total = 0
+    prev = 0
+    for c in reversed(s):
+        val = _ROMAN[c]
+        total += -val if val < prev else val
+        prev = val
+    return total
+
+def _remove_commas(m):
+    return m.group(1).replace(",", "")
+
+
+def _expand_decimal(m):
+    return f"{_expand_number(int(m.group(1)))} point {_expand_digits(m.group(2))}"
+
+
+def _expand_digits(s):
+    return " ".join(_inflect.number_to_words(int(c)) for c in s)
+
+def _expand_dollars(m):
+    raw = m.group(1).replace(",", "")
+    parts = raw.split(".")
+
+    dollars = int(parts[0])
+    cents = int(parts[1]) if len(parts) > 1 else 0
+
+    out = []
+    if dollars:
+        out.append(f"{_expand_number(dollars)} {'dollar' if dollars == 1 else 'dollars'}")
+    if cents:
+        out.append(f"{_expand_number(cents)} {'cent' if cents == 1 else 'cents'}")
+    return " ".join(out) if out else "zero dollars"
+
+def _expand_ordinal(m):
+    n = int(m.group(1))
+    return _inflect.ordinal(_inflect.number_to_words(n))
+
+def _expand_roman(m):
+    return _inflect.number_to_words(_roman_to_int(m.group()))
+
+def _expand_number(num):
+    return _inflect.number_to_words(num, andword="")
+
+def normalize_numbers(text):
+    try:
+        text = re.sub(_COMMA_RE, _remove_commas, text)
+        text = re.sub(_ROMAN_RE, _expand_roman, text)
+        text = re.sub(_DOLLARS_RE, _expand_dollars, text)
+        text = re.sub(_DECIMAL_RE, _expand_decimal, text)
+        text = re.sub(_ORDINAL_RE, _expand_ordinal, text)
+        text = re.sub(_NUMBER_RE, lambda m: _expand_number(int(m.group())), text)
+        return text
+
+    except Exception:
+        return text   # fallback: return input unchanged

--- a/tests/collections/speechlm2/test_duplex_eos_placement.py
+++ b/tests/collections/speechlm2/test_duplex_eos_placement.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for agent EOS placement logic in DuplexSTTDataset.
+
+When source tokens are collated with agent_token_channel provided, the agent EOS
+should be placed in the agent (target) token channel at the correct position:
+user_turn_start + eos_offset_frames after each user turn.
+"""
+
+import os
+
+import pytest
+import torch
+from lhotse import CutSet, SupervisionSegment, compute_num_frames
+from lhotse.testing.dummies import dummy_cut, dummy_recording
+
+from nemo.collections.common.tokenizers import AutoTokenizer
+from nemo.collections.speechlm2.data.duplex_stt_dataset import (
+    DuplexSTTDataset,
+    collate_token_channel,
+)
+from nemo.collections.speechlm2.data.utils import get_pad_id
+
+SR = 16000
+FL = 0.08
+
+
+@pytest.fixture(scope="session")
+def tokenizer():
+    if os.path.exists("/home/TestData/speechlm/pretrained_models"):
+        model_path = "/home/TestData/speechlm/pretrained_models/TinyLlama--TinyLlama_v1.1"
+    else:
+        model_path = "TinyLlama/TinyLlama_v1.1"
+    return AutoTokenizer(model_path, use_fast=True)
+
+
+@pytest.fixture(scope="session")
+def single_turn_cuts():
+    """Single cut with one user turn and one agent turn."""
+    cut = dummy_cut(0, duration=2.0, recording=dummy_recording(0, duration=2.0, with_data=True))
+    cut.supervisions = [
+        SupervisionSegment(
+            id="user-0", recording_id=cut.recording_id, start=0.0, duration=0.5, text="hello", speaker="user"
+        ),
+        SupervisionSegment(
+            id="agent-0", recording_id=cut.recording_id, start=0.6, duration=0.5, text="hi there", speaker="assistant"
+        ),
+    ]
+    return CutSet([cut])
+
+
+@pytest.fixture(scope="session")
+def multi_turn_cuts():
+    """Single cut with two user turns and two agent turns."""
+    cut = dummy_cut(0, duration=4.0, recording=dummy_recording(0, duration=4.0, with_data=True))
+    cut.supervisions = [
+        SupervisionSegment(
+            id="user-0", recording_id=cut.recording_id, start=0.0, duration=0.5, text="hello", speaker="user"
+        ),
+        SupervisionSegment(
+            id="agent-0", recording_id=cut.recording_id, start=0.6, duration=0.5, text="hi", speaker="assistant"
+        ),
+        SupervisionSegment(
+            id="user-1", recording_id=cut.recording_id, start=1.5, duration=0.5, text="how are you", speaker="user"
+        ),
+        SupervisionSegment(
+            id="agent-1", recording_id=cut.recording_id, start=2.2, duration=0.5, text="good thanks", speaker="assistant"
+        ),
+    ]
+    return CutSet([cut])
+
+
+def test_agent_eos_placed_in_target_channel(tokenizer, single_turn_cuts):
+    """Agent EOS should be placed in target_tokens when source collate triggers it."""
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+    pad = get_pad_id(tokenizer)
+
+    # First, collate target tokens WITHOUT EOS (skip_eos=True)
+    target_tokens, target_token_lens = collate_token_channel(
+        single_turn_cuts,
+        tokenizer,
+        frame_length=FL,
+        roles={"assistant"},
+        bos_id=bos,
+        eos_id=eos,
+        pad_id=pad,
+        remove_timestamps=True,
+        skip_eos=True,
+    )
+
+    # Verify no EOS in target tokens yet
+    assert (target_tokens == eos).sum().item() == 0, "skip_eos=True should not place any EOS"
+
+    # Now collate source tokens, passing in the target channel for EOS placement
+    source_tokens, source_token_lens = collate_token_channel(
+        single_turn_cuts,
+        tokenizer,
+        frame_length=FL,
+        roles={"user"},
+        bos_id=bos,
+        eos_id=eos,
+        pad_id=pad,
+        remove_timestamps=True,
+        agent_token_channel=target_tokens,
+        agent_token_channel_lengths=target_token_lens.clone(),
+        agent_eos_id=eos,
+    )
+
+    # Agent EOS should now be placed in target_tokens
+    eos_positions = (target_tokens[0] == eos).nonzero(as_tuple=True)[0]
+    assert len(eos_positions) > 0, "Agent EOS should be placed in target_tokens after source collation"
+
+    # EOS should be at user_start + eos_offset_frames (default 8)
+    user_start_frame = compute_num_frames(0.0, FL, SR)  # = 0
+    expected_eos_pos = user_start_frame + 8
+    assert expected_eos_pos in eos_positions.tolist(), (
+        f"Agent EOS expected at frame {expected_eos_pos}, found at {eos_positions.tolist()}"
+    )
+
+
+def test_agent_eos_placed_for_each_user_turn(tokenizer, multi_turn_cuts):
+    """Each user turn should trigger an agent EOS placement in the target channel."""
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+    pad = get_pad_id(tokenizer)
+
+    target_tokens, target_token_lens = collate_token_channel(
+        multi_turn_cuts,
+        tokenizer,
+        frame_length=FL,
+        roles={"assistant"},
+        bos_id=bos,
+        eos_id=eos,
+        pad_id=pad,
+        remove_timestamps=True,
+        skip_eos=True,
+    )
+
+    source_tokens, source_token_lens = collate_token_channel(
+        multi_turn_cuts,
+        tokenizer,
+        frame_length=FL,
+        roles={"user"},
+        bos_id=bos,
+        eos_id=eos,
+        pad_id=pad,
+        remove_timestamps=True,
+        agent_token_channel=target_tokens,
+        agent_token_channel_lengths=target_token_lens.clone(),
+        agent_eos_id=eos,
+    )
+
+    eos_positions = (target_tokens[0] == eos).nonzero(as_tuple=True)[0].tolist()
+
+    # Two user turns → expect two agent EOS placements
+    user_turn_starts = [0.0, 1.5]
+    expected_eos_positions = [compute_num_frames(s, FL, SR) + 8 for s in user_turn_starts]
+    # Filter out positions that are out of bounds
+    expected_eos_positions = [p for p in expected_eos_positions if p < target_token_lens[0].item()]
+
+    for expected_pos in expected_eos_positions:
+        assert expected_pos in eos_positions, (
+            f"Agent EOS expected at frame {expected_pos} but not found. "
+            f"Actual EOS positions: {eos_positions}"
+        )
+
+
+def test_skip_eos_true_produces_no_eos_in_target(tokenizer, single_turn_cuts):
+    """When skip_eos=True and no agent_token_channel, target should have no EOS."""
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+    pad = get_pad_id(tokenizer)
+
+    target_tokens, _ = collate_token_channel(
+        single_turn_cuts,
+        tokenizer,
+        frame_length=FL,
+        roles={"assistant"},
+        bos_id=bos,
+        eos_id=eos,
+        pad_id=pad,
+        remove_timestamps=True,
+        skip_eos=True,
+    )
+
+    assert (target_tokens == eos).sum().item() == 0, "skip_eos=True should not place EOS"
+
+
+def test_skip_eos_false_places_eos_at_supervision_end(tokenizer, single_turn_cuts):
+    """When skip_eos=False (default), EOS should be at the supervision end frame."""
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+    pad = get_pad_id(tokenizer)
+
+    target_tokens, _ = collate_token_channel(
+        single_turn_cuts,
+        tokenizer,
+        frame_length=FL,
+        roles={"assistant"},
+        bos_id=bos,
+        eos_id=eos,
+        pad_id=pad,
+        remove_timestamps=True,
+        skip_eos=False,
+    )
+
+    # Agent turn: start=0.6, duration=0.5 → end=1.1
+    eos_frame = compute_num_frames(1.1, FL, SR)
+    total_frames = compute_num_frames(2.0, FL, SR)
+    if eos_frame < total_frames:
+        assert target_tokens[0, eos_frame].item() == eos, (
+            f"EOS expected at frame {eos_frame}, got token {target_tokens[0, eos_frame].item()}"
+        )
+
+
+def test_end_to_end_eos_in_dataset(tokenizer, single_turn_cuts):
+    """End-to-end test: DuplexSTTDataset should place agent EOS in target_tokens."""
+    dataset = DuplexSTTDataset(
+        tokenizer=tokenizer,
+        frame_length=FL,
+        source_sample_rate=SR,
+        input_roles=["user"],
+        output_roles=["assistant"],
+        cfg={"prepend_word_space": False},
+        model_cfg={"predict_user_text": False},
+        is_training=True,
+    )
+
+    batch = dataset[single_turn_cuts]
+    target_tokens = batch["audio_data"]["target_tokens"]
+    eos = tokenizer.eos
+
+    eos_positions = (target_tokens[0] == eos).nonzero(as_tuple=True)[0].tolist()
+    assert len(eos_positions) > 0, (
+        "Agent EOS should appear in target_tokens from end-to-end dataset output"
+    )

--- a/tests/collections/speechlm2/test_duplex_is_training_flag.py
+++ b/tests/collections/speechlm2/test_duplex_is_training_flag.py
@@ -1,0 +1,199 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the is_training flag in DuplexSTTDataset.
+
+Verifies that training-only augmentations (force alignment, audio augmentation,
+early interruption) are skipped when is_training=False.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import soundfile as sf
+import torch
+from lhotse import CutSet, SupervisionSegment
+from lhotse.testing.dummies import dummy_cut, dummy_recording
+
+from nemo.collections.common.tokenizers import AutoTokenizer
+from nemo.collections.speechlm2.data.duplex_stt_dataset import DuplexSTTDataset
+from nemo.collections.speechlm2.data.utils import get_pad_id
+
+SR = 16000
+FL = 0.08
+
+
+@pytest.fixture(scope="session")
+def tokenizer():
+    if os.path.exists("/home/TestData/speechlm/pretrained_models"):
+        model_path = "/home/TestData/speechlm/pretrained_models/TinyLlama--TinyLlama_v1.1"
+    else:
+        model_path = "TinyLlama/TinyLlama_v1.1"
+    return AutoTokenizer(model_path, use_fast=True)
+
+
+@pytest.fixture(scope="session")
+def cuts():
+    cut = dummy_cut(0, duration=2.0, recording=dummy_recording(0, duration=2.0, with_data=True))
+    cut.supervisions = [
+        SupervisionSegment(
+            id="s0-user", recording_id=cut.recording_id, start=0, duration=0.5, text="hello", speaker="user"
+        ),
+        SupervisionSegment(
+            id="s0-agent", recording_id=cut.recording_id, start=0.6, duration=0.5, text="hi there", speaker="assistant"
+        ),
+        SupervisionSegment(
+            id="s0-user2", recording_id=cut.recording_id, start=1.2, duration=0.3, text="thanks", speaker="user"
+        ),
+    ]
+    return CutSet([cut])
+
+
+def _make_dataset(tokenizer, is_training, cfg=None, model_cfg=None):
+    default_cfg = {"prepend_word_space": False, "early_interruption_prob": 0.0}
+    if cfg:
+        default_cfg.update(cfg)
+    default_model_cfg = {"predict_user_text": False, "force_align_user_text": False}
+    if model_cfg:
+        default_model_cfg.update(model_cfg)
+    return DuplexSTTDataset(
+        tokenizer=tokenizer,
+        frame_length=FL,
+        source_sample_rate=SR,
+        input_roles=["user"],
+        output_roles=["assistant"],
+        cfg=default_cfg,
+        model_cfg=default_model_cfg,
+        is_training=is_training,
+    )
+
+
+def test_is_training_default_is_true(tokenizer):
+    """Dataset defaults to is_training=True."""
+    ds = DuplexSTTDataset(
+        tokenizer=tokenizer,
+        frame_length=FL,
+        source_sample_rate=SR,
+    )
+    assert ds.is_training is True
+
+
+def test_is_training_false_skips_early_interruption(tokenizer, cuts):
+    """Early interruption augmentation should only run when is_training=True."""
+    cfg = {"prepend_word_space": False, "early_interruption_prob": 1.0, "early_interruption_overlap_tokens": 8}
+
+    train_ds = _make_dataset(tokenizer, is_training=True, cfg=cfg)
+    val_ds = _make_dataset(tokenizer, is_training=False, cfg=cfg)
+
+    train_batch = train_ds[cuts]
+    val_batch = val_ds[cuts]
+
+    train_targets = train_batch["audio_data"]["target_tokens"]
+    val_targets = val_batch["audio_data"]["target_tokens"]
+
+    # With early_interruption_prob=1.0 and is_training=True, targets should be modified.
+    # With is_training=False, targets should be unmodified (same as no augmentation).
+    no_aug_ds = _make_dataset(tokenizer, is_training=True, cfg={"prepend_word_space": False, "early_interruption_prob": 0.0})
+    no_aug_batch = no_aug_ds[cuts]
+    no_aug_targets = no_aug_batch["audio_data"]["target_tokens"]
+
+    assert torch.equal(val_targets, no_aug_targets), "Validation dataset should not apply early interruption"
+
+
+def test_is_training_false_skips_audio_augmentation(tokenizer, cuts, tmp_path):
+    """Audio augmentation should only run when is_training=True."""
+    from lhotse.dataset.collation import collate_audio
+
+    noise_dir = tmp_path / "noise" / "all"
+    noise_dir.mkdir(parents=True)
+    for i in range(3):
+        noise = np.random.randn(SR).astype(np.float32) * 0.01
+        sf.write(str(noise_dir / f"noise_{i}.wav"), noise, SR)
+
+    cfg = {
+        "prepend_word_space": False,
+        "use_noise_aug": True,
+        "noise_prob": 1.0,
+        "noise_aug_path": str(tmp_path / "noise"),
+        "noise_min_snr": 0,
+        "noise_max_snr": 0,
+    }
+
+    val_ds = _make_dataset(tokenizer, is_training=False, cfg=cfg)
+    assert val_ds.audio_augmenter is not None
+
+    original_audio, _ = collate_audio(cuts.resample(SR))
+    val_batch = val_ds[cuts]
+
+    assert torch.equal(val_batch["audio_data"]["source_audio"], original_audio), (
+        "Validation dataset should not apply audio augmentation"
+    )
+
+
+def test_is_training_true_applies_audio_augmentation(tokenizer, cuts, tmp_path):
+    """Audio augmentation should run when is_training=True."""
+    from lhotse.dataset.collation import collate_audio
+
+    noise_dir = tmp_path / "noise" / "all"
+    noise_dir.mkdir(parents=True)
+    for i in range(3):
+        noise = np.random.randn(SR).astype(np.float32) * 0.01
+        sf.write(str(noise_dir / f"noise_{i}.wav"), noise, SR)
+
+    cfg = {
+        "prepend_word_space": False,
+        "use_noise_aug": True,
+        "noise_prob": 1.0,
+        "noise_aug_path": str(tmp_path / "noise"),
+        "noise_min_snr": 0,
+        "noise_max_snr": 0,
+    }
+
+    train_ds = _make_dataset(tokenizer, is_training=True, cfg=cfg)
+    assert train_ds.audio_augmenter is not None
+
+    original_audio, _ = collate_audio(cuts.resample(SR))
+    train_batch = train_ds[cuts]
+
+    assert not torch.equal(train_batch["audio_data"]["source_audio"], original_audio), (
+        "Training dataset should apply audio augmentation"
+    )
+
+
+def test_is_training_false_skips_force_alignment(tokenizer, cuts):
+    """Force alignment should only run when is_training=True."""
+    model_cfg = {"predict_user_text": True, "force_align_user_text": True, "force_align_device": "cpu"}
+
+    val_ds = _make_dataset(tokenizer, is_training=False, model_cfg=model_cfg)
+
+    # Force aligner should be created but never called during validation
+    val_ds.force_aligner = MagicMock()
+    val_ds[cuts]
+    val_ds.force_aligner.batch_force_align_user_audio.assert_not_called()
+
+
+def test_is_training_true_calls_force_alignment(tokenizer, cuts):
+    """Force alignment should run when is_training=True."""
+    model_cfg = {"predict_user_text": True, "force_align_user_text": True, "force_align_device": "cpu"}
+
+    train_ds = _make_dataset(tokenizer, is_training=True, model_cfg=model_cfg)
+
+    # Mock the force aligner to avoid loading wav2vec2
+    train_ds.force_aligner = MagicMock()
+    train_ds.force_aligner.batch_force_align_user_audio.side_effect = lambda cuts, **kwargs: cuts
+    train_ds[cuts]
+    train_ds.force_aligner.batch_force_align_user_audio.assert_called_once()

--- a/tests/collections/speechlm2/test_duplex_stt_dataset.py
+++ b/tests/collections/speechlm2/test_duplex_stt_dataset.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import re
 
@@ -24,10 +25,15 @@ from lhotse.testing.dummies import dummy_cut, dummy_recording
 from nemo.collections.common.tokenizers import AutoTokenizer
 from nemo.collections.speechlm2.data.duplex_stt_dataset import (
     DuplexSTTDataset,
+    _text_to_ids,
     collate_system_prompt,
     collate_token_channel,
 )
-from nemo.collections.speechlm2.data.utils import get_pad_id
+from nemo.collections.speechlm2.data.utils import (
+    MCQ_SYSTEM_PROMPT_NOTHINK,
+    MCQ_SYSTEM_PROMPT_THINK,
+    get_pad_id,
+)
 
 SR = 16000
 FL = 0.08
@@ -96,13 +102,13 @@ def tokenizer():
 @pytest.fixture(scope="session")
 def cuts():
     """Two cuts: cut1 with plain text, cut2 with timestamped text and a system prompt."""
-    cut1 = dummy_cut(0, duration=1.0, recording=dummy_recording(0, duration=1.0, with_data=True))
+    cut1 = dummy_cut(0, duration=1.5, recording=dummy_recording(0, duration=1.5, with_data=True))
     cut1.supervisions = [
         SupervisionSegment(
             id="s0-user", recording_id=cut1.recording_id, start=0, duration=0.3, text="hi", speaker="user"
         ),
         SupervisionSegment(
-            id="s0-agent", recording_id=cut1.recording_id, start=0.4, duration=0.3, text="hello", speaker="assistant"
+            id="s0-agent", recording_id=cut1.recording_id, start=1.0, duration=0.3, text="hello", speaker="assistant"
         ),
     ]
 
@@ -119,7 +125,7 @@ def cuts():
         SupervisionSegment(
             id="s1-agent",
             recording_id=cut2.recording_id,
-            start=0.6,
+            start=0.8,
             duration=0.5,
             text="<|0|> good <|2|> <|2|> morning <|4|> <|4|> to <|5|> <|5|> you <|6|>",
             speaker="assistant",
@@ -151,11 +157,11 @@ def test_collate_audio(cuts):
     audio, audio_lens = collate_audio(cuts.resample(SR))
 
     assert audio.shape == (2, 32000)
-    assert audio_lens.tolist() == [16000, 32000]
+    assert audio_lens.tolist() == [24000, 32000]
     # Padding region for the shorter cut must be zero
-    assert (audio[0, 16000:] == 0).all(), "Audio padding should be zero"
+    assert (audio[0, 24000:] == 0).all(), "Audio padding should be zero"
     # Non-padding region should have non-zero data (random audio from dummy_recording)
-    assert (audio[0, :16000] != 0).any(), "Audio data should be non-zero"
+    assert (audio[0, :24000] != 0).any(), "Audio data should be non-zero"
     assert (audio[1, :32000] != 0).any(), "Audio data should be non-zero"
 
 
@@ -164,7 +170,7 @@ def test_collate_token_channel_target(cuts, tokenizer):
     pad = get_pad_id(tokenizer)
     bos = tokenizer.bos
     eos = tokenizer.eos
-    total1 = compute_num_frames(1.0, FL, SR)  # 13
+    total1 = compute_num_frames(1.5, FL, SR)  # 19
     total2 = compute_num_frames(2.0, FL, SR)  # 25
 
     target_tokens, target_token_lens = collate_token_channel(
@@ -174,26 +180,27 @@ def test_collate_token_channel_target(cuts, tokenizer):
         roles={"assistant"},
         bos_id=bos,
         eos_id=eos,
+        pad_id=pad,
         remove_timestamps=True,
     )
 
     assert target_token_lens.tolist() == [total1, total2]
 
     # fmt: off
-    # Cut 1: "hello"(22172) at frames 5–9, padded to 25
-    # Cut 2: "good morning to you"(1781,7250,304,366) at frames 8–14, "welcome"(12853) at frames 20–24
+    # Cut 1: "hello"(22172) at frames 13–16, padded to 25
+    # Cut 2: "good morning to you"(1781,7250,304,366) at frames 10–16, "welcome"(12853) at frames 20–24
     expected_target = torch.tensor([
-        [0, 0, 0, 0, 0, 1, 22172, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1781, 7250, 304, 366, 0, 2, 0, 0, 0, 0, 0, 1, 12853, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 22172, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1781, 7250, 304, 366, 0, 2, 0, 0, 0, 1, 12853, 0, 0, 0],
     ])
     # fmt: on
     assert torch.equal(target_tokens, expected_target)
 
     # Decode verification
-    _verify_supervision_tokens(target_tokens[0], 0.4, 0.3, "hello", tokenizer, pad, bos, eos, total1)
+    _verify_supervision_tokens(target_tokens[0], 1.0, 0.3, "hello", tokenizer, pad, bos, eos, total1)
     _verify_supervision_tokens(
         target_tokens[1],
-        0.6,
+        0.8,
         0.5,
         "<|0|> good <|2|> <|2|> morning <|4|> <|4|> to <|5|> <|5|> you <|6|>",
         tokenizer,
@@ -210,7 +217,7 @@ def test_collate_token_channel_source(cuts, tokenizer):
     pad = get_pad_id(tokenizer)
     bos = tokenizer.bos
     eos = tokenizer.eos
-    total1 = compute_num_frames(1.0, FL, SR)  # 13
+    total1 = compute_num_frames(1.5, FL, SR)  # 19
     total2 = compute_num_frames(2.0, FL, SR)  # 25
 
     source_tokens, source_token_lens = collate_token_channel(
@@ -220,6 +227,7 @@ def test_collate_token_channel_source(cuts, tokenizer):
         roles={"user"},
         bos_id=bos,
         eos_id=eos,
+        pad_id=pad,
         remove_timestamps=False,
         prepend_word_space=False,
     )
@@ -260,8 +268,13 @@ def test_collate_token_channel_source(cuts, tokenizer):
 
 def test_collate_system_prompt(cuts, tokenizer):
     """Test collate_system_prompt: cut1 has no prompt, cut2 has 'be helpful'."""
+    pad = get_pad_id(tokenizer)
+    bos = tokenizer.bos
+    eos = tokenizer.eos
 
-    prompt_tokens, prompt_token_lens = collate_system_prompt(cuts, tokenizer)
+    prompt_tokens, prompt_token_lens = collate_system_prompt(
+        cuts, tokenizer, bos_id=bos, eos_id=eos, pad_id=pad
+    )
 
     # fmt: off
     # cut1: no system_prompt → all pad, len=0
@@ -316,31 +329,39 @@ def test_duplex_stt_dataset(cuts, tokenizer):
     batch = dataset[cuts]
     ad = batch["audio_data"]
 
-    total1 = compute_num_frames(1.0, FL, SR)  # 13
+    total1 = compute_num_frames(1.5, FL, SR)  # 19
     total2 = compute_num_frames(2.0, FL, SR)  # 25
+
+    bos = dataset.agent_bos_id
+    eos = dataset.agent_eos_id
+    ubos = dataset.user_bos_id
+    p = dataset.pad_id
 
     # sample_id
     assert len(ad["sample_id"]) == 2
 
     # source_audio
     assert ad["source_audio"].shape == (2, 32000)
-    assert ad["source_audio_lens"].tolist() == [16000, 32000]
+    assert ad["source_audio_lens"].tolist() == [24000, 32000]
 
-    # target_tokens (remove_timestamps=True, same as unit test)
+    # target_tokens (remove_timestamps=True)
+    # Agent EOS is placed by the source channel at user_bospos + eos_offset_frames(=8).
+    # Cut1: user@0 → agent EOS@8, agent BOS@13.  Cut2: user@0 → EOS@8, agent BOS@10, user@15 → EOS@23.
     assert ad["target_token_lens"].tolist() == [total1, total2]
     # fmt: off
     assert torch.equal(ad["target_tokens"], torch.tensor([
-        [0, 0, 0, 0, 0, 1, 22172, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [0, 0, 0, 0, 0, 0, 0, 0, 1, 1781, 7250, 304, 366, 0, 2, 0, 0, 0, 0, 0, 1, 12853, 0, 0, 0],
+        [p, p, p, p, p, p, p, p, eos, p, p, p, p, bos, 22172, p, p, p, p, p, p, p, p, p, p],
+        [p, p, p, p, p, p, p, p, eos, p, bos, 1781, 7250, 304, 366, p, p, p, p, p, bos, 12853, p, eos, p],
     ]))
     # fmt: on
 
     # source_tokens (remove_timestamps=False via predict_user_text=True, timestamp-aligned)
+    # Uses user_bos_id (from '^' token) as BOS for user turns.
     assert ad["source_token_lens"].tolist() == [total1, total2]
     # fmt: off
     assert torch.equal(ad["source_tokens"], torch.tensor([
-        [1, 7251, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        [1, 1781, 0, 0, 7250, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 1, 3969, 0, 0, 2, 0, 0, 0, 0, 0],
+        [ubos, 7251, p, p, eos, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p, p],
+        [ubos, 1781, p, p, 7250, p, eos, p, p, p, p, p, p, p, p, ubos, 3969, p, p, eos, p, p, p, p, p],
     ]))
     # fmt: on
 
@@ -349,8 +370,8 @@ def test_duplex_stt_dataset(cuts, tokenizer):
     assert ad["prompt_token_lens"].tolist() == [0, 4]
     # fmt: off
     assert torch.equal(ad["prompt_tokens"], torch.tensor([
-        [0, 0, 0, 0],
-        [1, 367, 8444, 2],
+        [p, p, p, p],
+        [bos, 367, 8444, eos],
     ]))
     # fmt: on
 
@@ -366,8 +387,6 @@ def test_duplex_stt_dataset(cuts, tokenizer):
 
     # no text data (no Formattable cuts)
     assert batch["text_data"] is None
-
-    # source_audio is not augmented when augmenter is not configured (audio is unchanged from collate_audio)
 
 
 def test_duplex_stt_dataset_augmentation(cuts, tokenizer, tmp_path):
@@ -413,3 +432,271 @@ def test_duplex_stt_dataset_augmentation(cuts, tokenizer, tmp_path):
     assert "source_audio_aug" not in ad
     assert ad["source_audio"].shape == original_audio.shape
     assert not torch.equal(ad["source_audio"], original_audio)
+
+
+# ................... MCQ prompt selection ...........................................
+
+
+def _make_cut_with_shard_origin(shard_origin, system_prompt=None):
+    """Helper to create a cut with a given shard_origin attribute."""
+    cut = dummy_cut(0, duration=1.0, recording=dummy_recording(0, duration=1.0, with_data=True))
+    cut.supervisions = [
+        SupervisionSegment(id="s0", recording_id=cut.recording_id, start=0, duration=0.5, text="hi", speaker="user"),
+    ]
+    cut.shard_origin = shard_origin
+    if system_prompt:
+        cut.custom = {"system_prompt": system_prompt}
+    return cut
+
+
+def test_mcq_prompt_think_cut(tokenizer):
+    """MCQ training think-cut should get THINK prompt."""
+    pad = get_pad_id(tokenizer)
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+
+    cut = _make_cut_with_shard_origin("MCQ_training_think_v1")
+    prompt_tokens, prompt_token_lens = collate_system_prompt(
+        CutSet([cut]), tokenizer, bos_id=bos, eos_id=eos, pad_id=pad, add_mcq_prompt=True
+    )
+
+    assert prompt_token_lens[0].item() > 0
+    expected_ids = [bos] + tokenizer.text_to_ids(MCQ_SYSTEM_PROMPT_THINK) + [eos]
+    assert prompt_tokens[0].tolist()[:len(expected_ids)] == expected_ids
+
+
+def test_mcq_prompt_nothink_cut(tokenizer):
+    """MCQ training non-think cut should get NOTHINK prompt."""
+    pad = get_pad_id(tokenizer)
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+
+    cut = _make_cut_with_shard_origin("MCQ_training_v2")
+    prompt_tokens, prompt_token_lens = collate_system_prompt(
+        CutSet([cut]), tokenizer, bos_id=bos, eos_id=eos, pad_id=pad, add_mcq_prompt=True
+    )
+
+    assert prompt_token_lens[0].item() > 0
+    expected_ids = [bos] + tokenizer.text_to_ids(MCQ_SYSTEM_PROMPT_NOTHINK) + [eos]
+    assert prompt_tokens[0].tolist()[:len(expected_ids)] == expected_ids
+
+
+def test_mcq_prompt_singleqa_excluded(tokenizer):
+    """MCQ training singleQA cut should get no MCQ prompt."""
+    pad = get_pad_id(tokenizer)
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+
+    cut = _make_cut_with_shard_origin("MCQ_training_singleQA_v1")
+    prompt_tokens, prompt_token_lens = collate_system_prompt(
+        CutSet([cut]), tokenizer, bos_id=bos, eos_id=eos, pad_id=pad, add_mcq_prompt=True
+    )
+
+    assert prompt_token_lens[0].item() == 0
+
+
+def test_mcq_val_prompt_when_enabled(tokenizer):
+    """MCQ validation cut gets THINK prompt when add_mcq_prompt=True."""
+    pad = get_pad_id(tokenizer)
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+
+    cut = _make_cut_with_shard_origin("openbookqa_test")
+    prompt_tokens, prompt_token_lens = collate_system_prompt(
+        CutSet([cut]), tokenizer, bos_id=bos, eos_id=eos, pad_id=pad, add_mcq_prompt=True
+    )
+
+    assert prompt_token_lens[0].item() > 0
+    expected_ids = [bos] + tokenizer.text_to_ids(MCQ_SYSTEM_PROMPT_THINK) + [eos]
+    assert prompt_tokens[0].tolist()[:len(expected_ids)] == expected_ids
+
+
+def test_mcq_val_prompt_disabled_by_default(tokenizer):
+    """MCQ validation cut gets no prompt when add_mcq_prompt=False (default)."""
+    pad = get_pad_id(tokenizer)
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+
+    cut = _make_cut_with_shard_origin("openbookqa_test")
+    prompt_tokens, prompt_token_lens = collate_system_prompt(
+        CutSet([cut]), tokenizer, bos_id=bos, eos_id=eos, pad_id=pad
+    )
+
+    assert prompt_token_lens[0].item() == 0
+
+
+def test_custom_prompt_overrides_mcq(tokenizer):
+    """Per-cut custom system_prompt takes priority over MCQ logic."""
+    pad = get_pad_id(tokenizer)
+    bos = tokenizer.bos
+    eos = tokenizer.eos
+
+    cut = _make_cut_with_shard_origin("MCQ_training_think_v1", system_prompt="be concise")
+    prompt_tokens, prompt_token_lens = collate_system_prompt(
+        CutSet([cut]), tokenizer, bos_id=bos, eos_id=eos, pad_id=pad, add_mcq_prompt=True
+    )
+
+    expected_ids = [bos] + tokenizer.text_to_ids("be concise") + [eos]
+    assert prompt_tokens[0].tolist()[:len(expected_ids)] == expected_ids
+
+
+# ................... Filler response injection ...........................................
+
+
+def test_filler_response_injection(tokenizer, tmp_path):
+    """_inject_filler_responses should replace BOS and write filler tokens."""
+    filler_data = {"agent_responses": [{"text": "okay", "duration_ms": 500}]}
+    filler_file = tmp_path / "fillers.json"
+    filler_file.write_text(json.dumps(filler_data))
+
+    dataset = DuplexSTTDataset(
+        tokenizer=tokenizer,
+        frame_length=FL,
+        source_sample_rate=SR,
+        input_roles=["user"],
+        output_roles=["assistant"],
+        cfg={
+            "prepend_word_space": False,
+            "add_filler_response_for_asr": True,
+            "filler_response_file": str(filler_file),
+            "filler_response_delay": 2,
+        },
+        model_cfg={},
+        is_training=True,
+    )
+
+    bos = dataset.agent_bos_id
+    pad = dataset.pad_id
+    seq_len = 20
+
+    target_tokens = torch.full((1, seq_len), pad, dtype=torch.long)
+    target_tokens[0, 5] = bos  # original BOS at position 5
+    target_token_lens = torch.tensor([seq_len])
+
+    dataset._inject_filler_responses(target_tokens, target_token_lens)
+
+    # Original BOS at pos 5 should be cleared
+    assert target_tokens[0, 5].item() == pad
+
+    # Filler should be written at pos 5 + delay(2) = 7
+    insert_pos = 7
+    assert target_tokens[0, insert_pos].item() == bos, "Filler should start with BOS"
+
+    # Filler text "okay" tokens should follow BOS
+    filler_ids = tokenizer.text_to_ids("okay")
+    for j, fid in enumerate(filler_ids):
+        assert target_tokens[0, insert_pos + 1 + j].item() == fid
+
+    # target_token_lens should be updated based on duration_ms
+    duration_frames = max(1, int(500 / (FL * 1000)))
+    filler_end = insert_pos + 1 + len(filler_ids)
+    duration_end = insert_pos + duration_frames
+    expected_len = min(max(duration_end, filler_end), seq_len)
+    assert target_token_lens[0].item() == expected_len
+
+
+def test_filler_response_no_bos_skips(tokenizer, tmp_path):
+    """When target has no BOS, _inject_filler_responses should skip gracefully."""
+    filler_data = {"agent_responses": [{"text": "okay"}]}
+    filler_file = tmp_path / "fillers.json"
+    filler_file.write_text(json.dumps(filler_data))
+
+    dataset = DuplexSTTDataset(
+        tokenizer=tokenizer,
+        frame_length=FL,
+        source_sample_rate=SR,
+        cfg={
+            "add_filler_response_for_asr": True,
+            "filler_response_file": str(filler_file),
+            "filler_response_delay": 0,
+        },
+        model_cfg={},
+    )
+
+    pad = dataset.pad_id
+    target_tokens = torch.full((1, 10), pad, dtype=torch.long)
+    target_token_lens = torch.tensor([10])
+    original = target_tokens.clone()
+
+    dataset._inject_filler_responses(target_tokens, target_token_lens)
+
+    assert torch.equal(target_tokens, original), "Tokens should be unchanged when no BOS exists"
+
+
+def test_filler_response_truncation(tokenizer, tmp_path):
+    """Filler should be truncated when it exceeds available space."""
+    filler_data = {"agent_responses": [{"text": "this is a very long filler response sentence"}]}
+    filler_file = tmp_path / "fillers.json"
+    filler_file.write_text(json.dumps(filler_data))
+
+    dataset = DuplexSTTDataset(
+        tokenizer=tokenizer,
+        frame_length=FL,
+        source_sample_rate=SR,
+        cfg={
+            "add_filler_response_for_asr": True,
+            "filler_response_file": str(filler_file),
+            "filler_response_delay": 0,
+        },
+        model_cfg={},
+    )
+
+    bos = dataset.agent_bos_id
+    pad = dataset.pad_id
+    seq_len = 5  # very short sequence
+
+    target_tokens = torch.full((1, seq_len), pad, dtype=torch.long)
+    target_tokens[0, 0] = bos
+    target_token_lens = torch.tensor([seq_len])
+
+    dataset._inject_filler_responses(target_tokens, target_token_lens)
+
+    # Should not crash, filler gets truncated to fit
+    assert target_tokens[0, 0].item() == bos, "Truncated filler should still start with BOS"
+    assert target_token_lens[0].item() <= seq_len
+
+
+# ................... Timestamp safety for number normalization ........................
+
+
+def test_normalize_numbers_does_not_corrupt_timestamps(tokenizer):
+    """When remove_timestamps=True, timestamps should be stripped before normalization."""
+    pad = get_pad_id(tokenizer)
+    text = "<|0|> I have 3 cats <|5|>"
+
+    ids_with_norm = _text_to_ids(
+        text, tokenizer, remove_timestamps=True, pad_id=pad, use_numbers_norm=True
+    )
+    ids_without_norm = _text_to_ids(
+        text, tokenizer, remove_timestamps=True, pad_id=pad, use_numbers_norm=False
+    )
+
+    decoded_with = tokenizer.ids_to_text(ids_with_norm).strip()
+    decoded_without = tokenizer.ids_to_text(ids_without_norm).strip()
+
+    assert "three" in decoded_with, f"Numbers should be normalized: '{decoded_with}'"
+    assert "3" in decoded_without, f"Numbers should NOT be normalized: '{decoded_without}'"
+    # Neither should contain timestamp artifacts
+    assert "<|" not in decoded_with
+    assert "<|" not in decoded_without
+
+
+def test_normalize_numbers_skipped_on_timestamp_aligned_path(tokenizer):
+    """When remove_timestamps=False and text has timestamps, normalization is skipped."""
+    pad = get_pad_id(tokenizer)
+    text = "<|0|> buy <|2|> <|3|> 3 <|4|> <|5|> items <|7|>"
+
+    ids = _text_to_ids(
+        text, tokenizer, remove_timestamps=False, pad_id=pad,
+        available_frames_for_text=10, use_numbers_norm=True,
+    )
+
+    # On the timestamp-aligned path, normalization is skipped because some
+    # expansions change word count (e.g. "$3.50" → "three dollars fifty cents"),
+    # which would break the word-to-timestamp pairing.
+    assert isinstance(ids, list)
+    digit_ids = tokenizer.text_to_ids("3")
+    three_ids = tokenizer.text_to_ids("three")
+    flat_ids = [x for x in ids if x != pad]
+    assert any(d in flat_ids for d in digit_ids), "Digit '3' should remain as-is on timestamp path"
+    assert not any(t in flat_ids for t in three_ids), "Word 'three' should not appear on timestamp path"

--- a/tests/collections/speechlm2/test_duplex_utils.py
+++ b/tests/collections/speechlm2/test_duplex_utils.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for utility functions in nemo.collections.speechlm2.data.utils:
+  - normalize_numbers (and its sub-expanders)
+  - is_mcq_cut_train / is_mcq_cut_val / is_asr_cut
+"""
+
+import pytest
+
+from nemo.collections.speechlm2.data.utils import (
+    is_asr_cut,
+    is_mcq_cut_train,
+    is_mcq_cut_val,
+    normalize_numbers,
+)
+
+
+# ── normalize_numbers ────────────────────────────────────────────────────────
+
+
+class TestNormalizeNumbers:
+    def test_plain_number(self):
+        assert normalize_numbers("I have 3 cats") == "I have three cats"
+
+    def test_large_number(self):
+        result = normalize_numbers("There are 100 people")
+        assert "one hundred" in result
+
+    def test_comma_separated(self):
+        result = normalize_numbers("Population is 1,000,000")
+        assert "," not in result
+        assert "one million" in result
+
+    def test_dollars_whole(self):
+        result = normalize_numbers("It costs $5")
+        assert "five dollars" in result
+
+    def test_dollars_with_cents(self):
+        result = normalize_numbers("Price is $3.50")
+        assert "three dollars" in result
+        assert "fifty cents" in result
+
+    def test_dollars_zero(self):
+        result = normalize_numbers("$0.00")
+        assert "zero dollars" in result
+
+    def test_ordinal_1st(self):
+        result = normalize_numbers("He came 1st")
+        assert "first" in result
+
+    def test_ordinal_2nd(self):
+        result = normalize_numbers("She was 2nd")
+        assert "second" in result
+
+    def test_ordinal_3rd(self):
+        result = normalize_numbers("3rd place")
+        assert "third" in result
+
+    def test_ordinal_11th(self):
+        result = normalize_numbers("The 11th hour")
+        assert "eleventh" in result
+
+    def test_decimal(self):
+        result = normalize_numbers("Pi is 3.14")
+        assert "three point one four" in result
+
+    def test_roman_numeral(self):
+        result = normalize_numbers("World War II")
+        assert "two" in result
+        assert "II" not in result
+
+    def test_roman_numeral_iv(self):
+        result = normalize_numbers("Chapter IV")
+        assert "four" in result
+
+    def test_no_numbers(self):
+        assert normalize_numbers("hello world") == "hello world"
+
+    def test_empty_string(self):
+        assert normalize_numbers("") == ""
+
+    def test_mixed_text(self):
+        result = normalize_numbers("I bought 2 items for $10.50 on the 3rd")
+        assert "two" in result
+        assert "ten dollars" in result
+        assert "fifty cents" in result
+        assert "third" in result
+
+    def test_timestamp_tokens_not_present(self):
+        """normalize_numbers should NOT be called on text with timestamps,
+        but if it were, verify it doesn't crash."""
+        result = normalize_numbers("hello world")
+        assert result == "hello world"
+
+
+# ── Cut classifiers ──────────────────────────────────────────────────────────
+
+
+class _FakeCut:
+    """Minimal stand-in for a lhotse Cut with arbitrary attributes."""
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class TestIsMcqCutTrain:
+    def test_mcq_training_standard(self):
+        cut = _FakeCut(shard_origin="MCQ_training_v2")
+        assert is_mcq_cut_train(cut) is True
+
+    def test_mcq_training_think(self):
+        cut = _FakeCut(shard_origin="MCQ_training_think_v1")
+        assert is_mcq_cut_train(cut) is True
+        assert is_mcq_cut_train(cut, check_think=True) is True
+
+    def test_mcq_training_no_think_flag(self):
+        cut = _FakeCut(shard_origin="MCQ_training_v2")
+        assert is_mcq_cut_train(cut, check_think=True) is False
+
+    def test_singleqa_excluded(self):
+        cut = _FakeCut(shard_origin="MCQ_training_singleQA_v1")
+        assert is_mcq_cut_train(cut) is False
+
+    def test_no_shard_origin(self):
+        cut = _FakeCut()
+        assert is_mcq_cut_train(cut) is False
+
+    def test_unrelated_shard_origin(self):
+        cut = _FakeCut(shard_origin="asr_librispeech")
+        assert is_mcq_cut_train(cut) is False
+
+
+class TestIsMcqCutVal:
+    def test_openbookqa(self):
+        cut = _FakeCut(shard_origin="openbookqa_val")
+        assert is_mcq_cut_val(cut) is True
+
+    def test_mmsu(self):
+        cut = _FakeCut(shard_origin="mmsu_test")
+        assert is_mcq_cut_val(cut) is True
+
+    def test_bbh(self):
+        cut = _FakeCut(shard_origin="bbh_eval")
+        assert is_mcq_cut_val(cut) is True
+
+    def test_no_shard_origin(self):
+        cut = _FakeCut()
+        assert is_mcq_cut_val(cut) is False
+
+    def test_training_origin_not_val(self):
+        cut = _FakeCut(shard_origin="MCQ_training_v2")
+        assert is_mcq_cut_val(cut) is False
+
+
+class TestIsAsrCut:
+    def test_task_asr(self):
+        cut = _FakeCut(task="asr")
+        assert is_asr_cut(cut) is True
+
+    def test_formatter_nemo_tarred(self):
+        cut = _FakeCut(formatter="nemo_tarred_to_duplex")
+        assert is_asr_cut(cut) is True
+
+    def test_both_attributes(self):
+        cut = _FakeCut(task="asr", formatter="nemo_tarred_to_duplex")
+        assert is_asr_cut(cut) is True
+
+    def test_neither(self):
+        cut = _FakeCut(task="s2s_duplex")
+        assert is_asr_cut(cut) is False
+
+    def test_no_attributes(self):
+        cut = _FakeCut()
+        assert is_asr_cut(cut) is False


### PR DESCRIPTION
# What does this PR do ?

Adds following features to the dataset class to support VoiceChat EA STT training and fine-tuning
1. Correct agent EOS placement
2. Clean implementation of token IDs and update user BOS ID to match EA
3. MCQ system prompt, disabled by default
4. Filler responses for ASR training data, disabled by default 
5. Number normalization, enabled by default
6. Corresponding tests

Internal-access [document](https://docs.google.com/document/d/1CAmH8wcZAVFApuq31YOof4nPuFtawvsltvWfpRFhCHk/edit?usp=sharing) with training, inference recipes, and notes on parity.

**Collection**: speechlm2

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

**PR Type**:

- New Feature
- Bugfix

If you haven't finished some of the above items you can still open "Draft" PR.
