### PR TITLE
fix: Remove diskcache from requirements

### DIFF
--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -1,5 +1,4 @@
 braceexpand
-diskcache
 editdistance
 einops
 jiwer>=3.1.0,<4.0.0


### PR DESCRIPTION
# What does this PR do ?

fix: Remove diskcache from requirements

There's a CVE attached with this dependency with no fix so far.  It looks to be optional on our side, so let's remove it as a requirement.

https://github.com/NVIDIA-NeMo/NeMo/blob/fa59a8e9548889eaf4155fbb48d83a893d217433/nemo/collections/asr/inference/itn/inverse_normalizer.py#L42


**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
