### PR TITLE
ci: onboard copy-pr-bot

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,3 @@
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Adds `.github/copy-pr-bot.yaml` to enable the copy-pr-bot for NeMo. The bot mirrors each PR to a `pull-request/<number>` branch, which is the pattern used across other NVIDIA-NeMo repos (Automodel, Megatron-Bridge).

The corresponding workflow changes to switch the CI trigger from `types: [labeled]` to `push: branches: pull-request/[0-9]+` will land in #15620.

</details>
