### PR TITLE
[Voice Agent] fix empty tools

### DIFF
--- a/nemo/agents/voice_agent/utils/tool_calling/mixins.py
+++ b/nemo/agents/voice_agent/utils/tool_calling/mixins.py
@@ -58,6 +58,8 @@ class ToolCallingMixin:
         Return a dictionary of available tools, where the key is the tool name and the value is the direct function.
         """
         tools = {}
+        if not hasattr(self, "direct_functions"):
+            return tools
         for function_name, function in self.direct_functions.items():
             tools[function_name] = function
         return tools


### PR DESCRIPTION
Fix empty tools breaking the `available_tools` property when accessed.