### PR TITLE
fix(ci): increase GPU speech unit test timeouts (TTS: 30 min, ASR: 60 min)

### DIFF
--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -55,6 +55,7 @@ jobs:
             timeout: 30
           - script: L0_Unit_Tests_GPU_TTS
             runner: ${{ inputs.runner }}
+            timeout: 30
           - script: L0_Unit_Tests_CPU_TTS
             runner: ${{ inputs.runner }}
             cpu-only: true

--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -48,7 +48,7 @@ jobs:
         include:
           - script: L0_Unit_Tests_GPU_ASR
             runner: ${{ inputs.runner }}
-            timeout: 30
+            timeout: 60
           - script: L0_Unit_Tests_CPU_ASR
             runner: ${{ inputs.runner }}
             cpu-only: true


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Two timeouts fixed in `cicd-main-speech.yml`:

**`L0_Unit_Tests_GPU_TTS`** — `timeout: 30`
The MagpieTTS inference tests load real checkpoints and run end-to-end inference, taking ~8–9 minutes each. With the default 10-minute per-attempt budget all 3 retries timed out consistently on both `main` and PRs.

**`L0_Unit_Tests_GPU_ASR`** — `timeout: 60`
The ASR test suite runs past the previous 30-minute per-attempt limit. A recent run took 61 minutes total (18:12 → 19:14), indicating two timed-out attempts followed by a successful third, wasting ~60 minutes of runner time. Raised to 60 minutes so a single attempt covers the full suite.

Example failing run: https://github.com/NVIDIA-NeMo/NeMo/actions/runs/25060055760/job/73434530111

</details>