### PR TITLE
ci(speech): split L0_Unit_Tests GPU/CPU ASR and CPU SpeechLM2 into parallel buckets

### DIFF
--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -61,10 +61,22 @@ jobs:
           - script: L0_Unit_Tests_GPU_ASR_5
             runner: ${{ inputs.runner }}
             timeout: 15
-          - script: L0_Unit_Tests_CPU_ASR
+          - script: L0_Unit_Tests_CPU_ASR_1
             runner: ${{ inputs.runner }}
             cpu-only: true
-            timeout: 30
+            timeout: 12
+          - script: L0_Unit_Tests_CPU_ASR_2
+            runner: ${{ inputs.runner }}
+            cpu-only: true
+            timeout: 12
+          - script: L0_Unit_Tests_CPU_ASR_3
+            runner: ${{ inputs.runner }}
+            cpu-only: true
+            timeout: 12
+          - script: L0_Unit_Tests_CPU_ASR_4
+            runner: ${{ inputs.runner }}
+            cpu-only: true
+            timeout: 12
           - script: L0_Unit_Tests_GPU_TTS
             runner: ${{ inputs.runner }}
             timeout: 30

--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -84,15 +84,22 @@ jobs:
             runner: ${{ inputs.runner }}
             cpu-only: true
             timeout: 12
+          - script: L0_Unit_Tests_CPU_ASR_6
+            runner: ${{ inputs.runner }}
+            cpu-only: true
+            timeout: 12
           - script: L0_Unit_Tests_GPU_TTS
             runner: ${{ inputs.runner }}
             timeout: 30
           - script: L0_Unit_Tests_CPU_TTS
             runner: ${{ inputs.runner }}
             cpu-only: true
-          - script: L0_Unit_Tests_GPU_Audio
+          - script: L0_Unit_Tests_GPU_Audio_1
             runner: ${{ inputs.runner }}
-            timeout: 20
+            timeout: 15
+          - script: L0_Unit_Tests_GPU_Audio_2
+            runner: ${{ inputs.runner }}
+            timeout: 15
           - script: L0_Unit_Tests_CPU_Audio
             runner: ${{ inputs.runner }}
             cpu-only: true

--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -81,10 +81,18 @@ jobs:
           - script: L0_Unit_Tests_GPU_SpeechLM2
             runner: ${{ inputs.runner }}
             timeout: 20
-          - script: L0_Unit_Tests_CPU_SpeechLM2
+          - script: L0_Unit_Tests_CPU_SpeechLM2_1
             runner: ${{ inputs.runner }}
             cpu-only: true
-            timeout: 20
+            timeout: 12
+          - script: L0_Unit_Tests_CPU_SpeechLM2_2
+            runner: ${{ inputs.runner }}
+            cpu-only: true
+            timeout: 12
+          - script: L0_Unit_Tests_CPU_SpeechLM2_3
+            runner: ${{ inputs.runner }}
+            cpu-only: true
+            timeout: 12
     needs: [build]
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.script }}

--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -119,6 +119,10 @@ jobs:
             runner: ${{ inputs.runner }}
             cpu-only: true
             timeout: 12
+          - script: L0_Unit_Tests_CPU_SpeechLM2_4
+            runner: ${{ inputs.runner }}
+            cpu-only: true
+            timeout: 12
     needs: [build]
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.script }}

--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -46,9 +46,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - script: L0_Unit_Tests_GPU_ASR
+          - script: L0_Unit_Tests_GPU_ASR_1
             runner: ${{ inputs.runner }}
-            timeout: 60
+            timeout: 15
+          - script: L0_Unit_Tests_GPU_ASR_2
+            runner: ${{ inputs.runner }}
+            timeout: 15
+          - script: L0_Unit_Tests_GPU_ASR_3
+            runner: ${{ inputs.runner }}
+            timeout: 15
+          - script: L0_Unit_Tests_GPU_ASR_4
+            runner: ${{ inputs.runner }}
+            timeout: 15
+          - script: L0_Unit_Tests_GPU_ASR_5
+            runner: ${{ inputs.runner }}
+            timeout: 15
           - script: L0_Unit_Tests_CPU_ASR
             runner: ${{ inputs.runner }}
             cpu-only: true

--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -61,6 +61,9 @@ jobs:
           - script: L0_Unit_Tests_GPU_ASR_5
             runner: ${{ inputs.runner }}
             timeout: 15
+          - script: L0_Unit_Tests_GPU_ASR_6
+            runner: ${{ inputs.runner }}
+            timeout: 15
           - script: L0_Unit_Tests_CPU_ASR_1
             runner: ${{ inputs.runner }}
             cpu-only: true
@@ -74,6 +77,10 @@ jobs:
             cpu-only: true
             timeout: 12
           - script: L0_Unit_Tests_CPU_ASR_4
+            runner: ${{ inputs.runner }}
+            cpu-only: true
+            timeout: 12
+          - script: L0_Unit_Tests_CPU_ASR_5
             runner: ${{ inputs.runner }}
             cpu-only: true
             timeout: 12

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -5,6 +5,7 @@ isort>5.1.0,<6.0.0
 parameterized
 pytest
 pytest-httpserver
+pytest-shard
 pytest-mock
 pytest-runner
 ruamel.yaml

--- a/tests/collections/asr/test_asr_parts_submodules_batchnorm.py
+++ b/tests/collections/asr/test_asr_parts_submodules_batchnorm.py
@@ -38,6 +38,7 @@ class TestFusedBatchNorm1d:
 
     @pytest.mark.unit
     def test_from_batchnorm(self):
+        torch.manual_seed(0)
         num_features = 10
 
         # construct batchnorm
@@ -49,15 +50,16 @@ class TestFusedBatchNorm1d:
         for _ in range(10):
             _ = bn(torch.rand(batch_size, num_features))
 
-        # test eval mode is equivalent
+        # test eval mode is equivalent; atol=1e-5 accounts for float32 rounding
+        # between fused (x*W+B) and standard ((x-mean)/std*w+b) formulations
         fused_bn = FusedBatchNorm1d.from_batchnorm(bn)
         bn.eval()
 
         sample_2d = torch.rand(batch_size, num_features)
-        assert torch.allclose(bn(sample_2d), fused_bn(sample_2d))
+        assert torch.allclose(bn(sample_2d), fused_bn(sample_2d), atol=1e-5)
 
         sample_3d = torch.rand(batch_size, num_features, 5)
-        assert torch.allclose(bn(sample_3d), fused_bn(sample_3d))
+        assert torch.allclose(bn(sample_3d), fused_bn(sample_3d), atol=1e-5)
 
 
 class TestReplaceBNWithFusedBN:

--- a/tests/collections/asr/test_asr_parts_submodules_batchnorm.py
+++ b/tests/collections/asr/test_asr_parts_submodules_batchnorm.py
@@ -38,7 +38,6 @@ class TestFusedBatchNorm1d:
 
     @pytest.mark.unit
     def test_from_batchnorm(self):
-        torch.manual_seed(0)
         num_features = 10
 
         # construct batchnorm
@@ -50,16 +49,15 @@ class TestFusedBatchNorm1d:
         for _ in range(10):
             _ = bn(torch.rand(batch_size, num_features))
 
-        # test eval mode is equivalent; atol=1e-5 accounts for float32 rounding
-        # between fused (x*W+B) and standard ((x-mean)/std*w+b) formulations
+        # test eval mode is equivalent
         fused_bn = FusedBatchNorm1d.from_batchnorm(bn)
         bn.eval()
 
         sample_2d = torch.rand(batch_size, num_features)
-        assert torch.allclose(bn(sample_2d), fused_bn(sample_2d), atol=1e-5)
+        assert torch.allclose(bn(sample_2d), fused_bn(sample_2d))
 
         sample_3d = torch.rand(batch_size, num_features, 5)
-        assert torch.allclose(bn(sample_3d), fused_bn(sample_3d), atol=1e-5)
+        assert torch.allclose(bn(sample_3d), fused_bn(sample_3d))
 
 
 class TestReplaceBNWithFusedBN:

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_1.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=0 --num-shards=5 \
+    --shard-id=0 --num-shards=6 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_1.sh
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/decoding/test_batched_beam_decoding.py \
-    tests/collections/asr/decoding/test_batched_beam_hyps.py \
-    tests/collections/asr/decoding/test_batched_hyps_and_alignments.py \
-    tests/collections/asr/decoding/test_streaming_buffer.py \
-    tests/collections/asr/decoding/test_timestamps.py \
+    tests/collections/asr \
+    --shard-id=0 --num-shards=4 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_1.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=0 --num-shards=4 \
+    --shard-id=0 --num-shards=5 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_1.sh
@@ -1,0 +1,20 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/decoding/test_batched_beam_decoding.py \
+    tests/collections/asr/decoding/test_batched_beam_hyps.py \
+    tests/collections/asr/decoding/test_batched_hyps_and_alignments.py \
+    tests/collections/asr/decoding/test_streaming_buffer.py \
+    tests/collections/asr/decoding/test_timestamps.py \
+    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_2.sh
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/confidence \
-    tests/collections/asr/test_asr_multitask_model_bpe.py \
+    tests/collections/asr \
+    --shard-id=1 --num-shards=4 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_2.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=1 --num-shards=4 \
+    --shard-id=1 --num-shards=5 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_2.sh
@@ -11,4 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest tests/collections/asr -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat
+CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/confidence \
+    tests/collections/asr/test_asr_multitask_model_bpe.py \
+    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_3.sh
@@ -1,0 +1,25 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/decoding/test_biasing_multi_model.py \
+    tests/collections/asr/decoding/test_ctc_decoding.py \
+    tests/collections/asr/decoding/test_cuda_graph_rnnt_greedy_decoding.py \
+    tests/collections/asr/decoding/test_multi_task_decoding.py \
+    tests/collections/asr/decoding/test_multi_task_streaming_decoding.py \
+    tests/collections/asr/decoding/test_rnnt_alignments.py \
+    tests/collections/asr/decoding/test_rnnt_decoding.py \
+    tests/collections/asr/decoding/test_streaming_decoding.py \
+    tests/collections/asr/mixins \
+    tests/collections/asr/test_asr_local_attn.py \
+    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_3.sh
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/decoding/test_biasing_multi_model.py \
-    tests/collections/asr/decoding/test_ctc_decoding.py \
-    tests/collections/asr/decoding/test_cuda_graph_rnnt_greedy_decoding.py \
-    tests/collections/asr/decoding/test_multi_task_decoding.py \
-    tests/collections/asr/decoding/test_multi_task_streaming_decoding.py \
-    tests/collections/asr/decoding/test_rnnt_alignments.py \
-    tests/collections/asr/decoding/test_rnnt_decoding.py \
-    tests/collections/asr/decoding/test_streaming_decoding.py \
-    tests/collections/asr/mixins \
-    tests/collections/asr/test_asr_local_attn.py \
+    tests/collections/asr \
+    --shard-id=2 --num-shards=4 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_3.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=2 --num-shards=4 \
+    --shard-id=2 --num-shards=5 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_3.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=2 --num-shards=5 \
+    --shard-id=2 --num-shards=6 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_4.sh
@@ -1,0 +1,52 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/inference \
+    tests/collections/asr/k2 \
+    tests/collections/asr/numba \
+    tests/collections/asr/test_asr_classification_model.py \
+    tests/collections/asr/test_asr_context_biasing.py \
+    tests/collections/asr/test_asr_ctc_encoder_model_bpe.py \
+    tests/collections/asr/test_asr_ctcencdec_model.py \
+    tests/collections/asr/test_asr_datasets.py \
+    tests/collections/asr/test_asr_eou.py \
+    tests/collections/asr/test_asr_exportables.py \
+    tests/collections/asr/test_asr_filterbankfeatures_seq_len.py \
+    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe.py \
+    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe_prompt.py \
+    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_char.py \
+    tests/collections/asr/test_asr_interctc_models.py \
+    tests/collections/asr/test_asr_lhotse_dataset.py \
+    tests/collections/asr/test_asr_lhotse_speaker_dataset.py \
+    tests/collections/asr/test_asr_metrics.py \
+    tests/collections/asr/test_asr_modules.py \
+    tests/collections/asr/test_asr_multitalker_models.py \
+    tests/collections/asr/test_asr_parts_submodules_batchnorm.py \
+    tests/collections/asr/test_asr_regression_model.py \
+    tests/collections/asr/test_asr_rnnt_encdec_model.py \
+    tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py \
+    tests/collections/asr/test_asr_samplers.py \
+    tests/collections/asr/test_asr_subsampling.py \
+    tests/collections/asr/test_boosting_tree.py \
+    tests/collections/asr/test_conformer_encoder.py \
+    tests/collections/asr/test_custom_tokenizer.py \
+    tests/collections/asr/test_jasper_block.py \
+    tests/collections/asr/test_label_datasets.py \
+    tests/collections/asr/test_ngram_lm.py \
+    tests/collections/asr/test_padding_and_batch_size_invariance.py \
+    tests/collections/asr/test_preprocessing_segment.py \
+    tests/collections/asr/test_ssl_models.py \
+    tests/collections/asr/test_text_to_text_dataset.py \
+    tests/collections/asr/utils \
+    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_4.sh
@@ -12,41 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/inference \
-    tests/collections/asr/k2 \
-    tests/collections/asr/numba \
-    tests/collections/asr/test_asr_classification_model.py \
-    tests/collections/asr/test_asr_context_biasing.py \
-    tests/collections/asr/test_asr_ctc_encoder_model_bpe.py \
-    tests/collections/asr/test_asr_ctcencdec_model.py \
-    tests/collections/asr/test_asr_datasets.py \
-    tests/collections/asr/test_asr_eou.py \
-    tests/collections/asr/test_asr_exportables.py \
-    tests/collections/asr/test_asr_filterbankfeatures_seq_len.py \
-    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe.py \
-    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe_prompt.py \
-    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_char.py \
-    tests/collections/asr/test_asr_interctc_models.py \
-    tests/collections/asr/test_asr_lhotse_dataset.py \
-    tests/collections/asr/test_asr_lhotse_speaker_dataset.py \
-    tests/collections/asr/test_asr_metrics.py \
-    tests/collections/asr/test_asr_modules.py \
-    tests/collections/asr/test_asr_multitalker_models.py \
-    tests/collections/asr/test_asr_parts_submodules_batchnorm.py \
-    tests/collections/asr/test_asr_regression_model.py \
-    tests/collections/asr/test_asr_rnnt_encdec_model.py \
-    tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py \
-    tests/collections/asr/test_asr_samplers.py \
-    tests/collections/asr/test_asr_subsampling.py \
-    tests/collections/asr/test_boosting_tree.py \
-    tests/collections/asr/test_conformer_encoder.py \
-    tests/collections/asr/test_custom_tokenizer.py \
-    tests/collections/asr/test_jasper_block.py \
-    tests/collections/asr/test_label_datasets.py \
-    tests/collections/asr/test_ngram_lm.py \
-    tests/collections/asr/test_padding_and_batch_size_invariance.py \
-    tests/collections/asr/test_preprocessing_segment.py \
-    tests/collections/asr/test_ssl_models.py \
-    tests/collections/asr/test_text_to_text_dataset.py \
-    tests/collections/asr/utils \
+    tests/collections/asr \
+    --shard-id=3 --num-shards=4 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_4.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=3 --num-shards=4 \
+    --shard-id=3 --num-shards=5 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_4.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=3 --num-shards=5 \
+    --shard-id=3 --num-shards=6 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_5.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_5.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=4 --num-shards=5 \
+    --shard-id=4 --num-shards=6 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_5.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_5.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=4 --num-shards=6 \
-    -m "not pleasefixme" --with_downloads
+    --shard-id=4 --num-shards=5 \
+    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_ASR_6.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_ASR_6.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=1 --num-shards=6 \
+    --shard-id=5 --num-shards=6 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_1.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/speechlm2 \
-    --shard-id=0 --num-shards=3 \
+    --shard-id=0 --num-shards=4 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_1.sh
@@ -12,5 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/speechlm2/test_salm_asr_decoder.py \
+    tests/collections/speechlm2 \
+    --shard-id=0 --num-shards=3 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_1.sh
@@ -11,4 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest tests/collections/speechlm2 -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat
+CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/speechlm2/test_salm_asr_decoder.py \
+    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_2.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/speechlm2 \
-    --shard-id=1 --num-shards=3 \
+    --shard-id=1 --num-shards=4 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_2.sh
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/speechlm2/test_duplex_eartts.py \
-    tests/collections/speechlm2/test_duplex_s2s.py \
-    tests/collections/speechlm2/test_duplex_s2s_speech_decoder.py \
-    tests/collections/speechlm2/test_duplex_stt.py \
+    tests/collections/speechlm2 \
+    --shard-id=1 --num-shards=3 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_2.sh
@@ -1,0 +1,19 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/speechlm2/test_duplex_eartts.py \
+    tests/collections/speechlm2/test_duplex_s2s.py \
+    tests/collections/speechlm2/test_duplex_s2s_speech_decoder.py \
+    tests/collections/speechlm2/test_duplex_stt.py \
+    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_3.sh
@@ -1,0 +1,35 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/speechlm2/test_audio_placeholders.py \
+    tests/collections/speechlm2/test_datamodule.py \
+    tests/collections/speechlm2/test_datamodule_parallel.py \
+    tests/collections/speechlm2/test_duplex_stt_dataset.py \
+    tests/collections/speechlm2/test_early_interruption.py \
+    tests/collections/speechlm2/test_force_align.py \
+    tests/collections/speechlm2/test_freezing_params.py \
+    tests/collections/speechlm2/test_init_from_checkpoint.py \
+    tests/collections/speechlm2/test_label_prep.py \
+    tests/collections/speechlm2/test_metrics.py \
+    tests/collections/speechlm2/test_nemotron_voicechat.py \
+    tests/collections/speechlm2/test_parallel.py \
+    tests/collections/speechlm2/test_role_swap.py \
+    tests/collections/speechlm2/test_salm_asr_decoder_multilayerproj.py \
+    tests/collections/speechlm2/test_salm_asr_decoder_qformer.py \
+    tests/collections/speechlm2/test_salm_automodel.py \
+    tests/collections/speechlm2/test_salm_automodel_lora.py \
+    tests/collections/speechlm2/test_salm_lora.py \
+    tests/collections/speechlm2/test_salm.py \
+    tests/collections/speechlm2/test_to_hf.py \
+    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_3.sh
@@ -12,24 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/speechlm2/test_audio_placeholders.py \
-    tests/collections/speechlm2/test_datamodule.py \
-    tests/collections/speechlm2/test_datamodule_parallel.py \
-    tests/collections/speechlm2/test_duplex_stt_dataset.py \
-    tests/collections/speechlm2/test_early_interruption.py \
-    tests/collections/speechlm2/test_force_align.py \
-    tests/collections/speechlm2/test_freezing_params.py \
-    tests/collections/speechlm2/test_init_from_checkpoint.py \
-    tests/collections/speechlm2/test_label_prep.py \
-    tests/collections/speechlm2/test_metrics.py \
-    tests/collections/speechlm2/test_nemotron_voicechat.py \
-    tests/collections/speechlm2/test_parallel.py \
-    tests/collections/speechlm2/test_role_swap.py \
-    tests/collections/speechlm2/test_salm_asr_decoder_multilayerproj.py \
-    tests/collections/speechlm2/test_salm_asr_decoder_qformer.py \
-    tests/collections/speechlm2/test_salm_automodel.py \
-    tests/collections/speechlm2/test_salm_automodel_lora.py \
-    tests/collections/speechlm2/test_salm_lora.py \
-    tests/collections/speechlm2/test_salm.py \
-    tests/collections/speechlm2/test_to_hf.py \
+    tests/collections/speechlm2 \
+    --shard-id=2 --num-shards=3 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_CPU_SpeechLM2_4.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/speechlm2 \
-    --shard-id=2 --num-shards=4 \
+    --shard-id=3 --num-shards=4 \
     -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/confidence \
     tests/collections/asr/decoding/test_batched_beam_decoding.py \
     tests/collections/asr/decoding/test_batched_beam_hyps.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/confidence \
     tests/collections/asr/decoding/test_batched_beam_decoding.py \
     tests/collections/asr/decoding/test_batched_beam_hyps.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/confidence \
-    tests/collections/asr/decoding/test_batched_beam_decoding.py \
-    tests/collections/asr/decoding/test_batched_beam_hyps.py \
-    tests/collections/asr/decoding/test_batched_hyps_and_alignments.py \
-    tests/collections/asr/decoding/test_biasing_multi_model.py \
-    tests/collections/asr/decoding/test_ctc_decoding.py \
-    tests/collections/asr/decoding/test_cuda_graph_rnnt_greedy_decoding.py \
-    tests/collections/asr/decoding/test_multi_task_decoding.py \
+    tests/collections/asr \
+    --shard-id=0 --num-shards=5 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/confidence \
     tests/collections/asr/decoding/test_batched_beam_decoding.py \
     tests/collections/asr/decoding/test_batched_beam_hyps.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
@@ -1,0 +1,23 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/confidence \
+    tests/collections/asr/decoding/test_batched_beam_decoding.py \
+    tests/collections/asr/decoding/test_batched_beam_hyps.py \
+    tests/collections/asr/decoding/test_batched_hyps_and_alignments.py \
+    tests/collections/asr/decoding/test_biasing_multi_model.py \
+    tests/collections/asr/decoding/test_ctc_decoding.py \
+    tests/collections/asr/decoding/test_cuda_graph_rnnt_greedy_decoding.py \
+    tests/collections/asr/decoding/test_multi_task_decoding.py \
+    -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_1.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=0 --num-shards=5 \
+    --shard-id=0 --num-shards=6 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/decoding/test_multi_task_streaming_decoding.py \
-    tests/collections/asr/decoding/test_rnnt_alignments.py \
-    tests/collections/asr/decoding/test_rnnt_decoding.py \
-    tests/collections/asr/decoding/test_streaming_buffer.py \
-    tests/collections/asr/decoding/test_streaming_decoding.py \
-    tests/collections/asr/inference \
-    tests/collections/asr/k2 \
-    tests/collections/asr/mixins \
+    tests/collections/asr \
+    --shard-id=1 --num-shards=5 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/decoding/test_multi_task_streaming_decoding.py \
     tests/collections/asr/decoding/test_rnnt_alignments.py \
     tests/collections/asr/decoding/test_rnnt_decoding.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/decoding/test_multi_task_streaming_decoding.py \
     tests/collections/asr/decoding/test_rnnt_alignments.py \
     tests/collections/asr/decoding/test_rnnt_decoding.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
@@ -1,0 +1,23 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/decoding/test_multi_task_streaming_decoding.py \
+    tests/collections/asr/decoding/test_rnnt_alignments.py \
+    tests/collections/asr/decoding/test_rnnt_decoding.py \
+    tests/collections/asr/decoding/test_streaming_buffer.py \
+    tests/collections/asr/decoding/test_streaming_decoding.py \
+    tests/collections/asr/inference \
+    tests/collections/asr/k2 \
+    tests/collections/asr/mixins \
+    -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=1 --num-shards=5 \
+    --shard-id=1 --num-shards=6 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_2.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/decoding/test_multi_task_streaming_decoding.py \
     tests/collections/asr/decoding/test_rnnt_alignments.py \
     tests/collections/asr/decoding/test_rnnt_decoding.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=2 --num-shards=5 \
+    --shard-id=2 --num-shards=6 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/numba \
     tests/collections/asr/test_asr_classification_model.py \
     tests/collections/asr/test_asr_context_biasing.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
@@ -1,0 +1,34 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/numba \
+    tests/collections/asr/test_asr_classification_model.py \
+    tests/collections/asr/test_asr_context_biasing.py \
+    tests/collections/asr/test_asr_ctc_encoder_model_bpe.py \
+    tests/collections/asr/test_asr_ctcencdec_model.py \
+    tests/collections/asr/test_asr_datasets.py \
+    tests/collections/asr/test_asr_eou.py \
+    tests/collections/asr/test_asr_exportables.py \
+    tests/collections/asr/test_asr_filterbankfeatures_seq_len.py \
+    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe.py \
+    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe_prompt.py \
+    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_char.py \
+    tests/collections/asr/test_asr_interctc_models.py \
+    tests/collections/asr/test_asr_lhotse_dataset.py \
+    tests/collections/asr/test_asr_lhotse_speaker_dataset.py \
+    tests/collections/asr/test_asr_local_attn.py \
+    tests/collections/asr/test_asr_metrics.py \
+    tests/collections/asr/test_asr_modules.py \
+    tests/collections/asr/test_asr_multitalker_models.py \
+    -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
@@ -12,23 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/numba \
-    tests/collections/asr/test_asr_classification_model.py \
-    tests/collections/asr/test_asr_context_biasing.py \
-    tests/collections/asr/test_asr_ctc_encoder_model_bpe.py \
-    tests/collections/asr/test_asr_ctcencdec_model.py \
-    tests/collections/asr/test_asr_datasets.py \
-    tests/collections/asr/test_asr_eou.py \
-    tests/collections/asr/test_asr_exportables.py \
-    tests/collections/asr/test_asr_filterbankfeatures_seq_len.py \
-    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe.py \
-    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe_prompt.py \
-    tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_char.py \
-    tests/collections/asr/test_asr_interctc_models.py \
-    tests/collections/asr/test_asr_lhotse_dataset.py \
-    tests/collections/asr/test_asr_lhotse_speaker_dataset.py \
-    tests/collections/asr/test_asr_local_attn.py \
-    tests/collections/asr/test_asr_metrics.py \
-    tests/collections/asr/test_asr_modules.py \
-    tests/collections/asr/test_asr_multitalker_models.py \
+    tests/collections/asr \
+    --shard-id=2 --num-shards=5 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/numba \
     tests/collections/asr/test_asr_classification_model.py \
     tests/collections/asr/test_asr_context_biasing.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_3.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/numba \
     tests/collections/asr/test_asr_classification_model.py \
     tests/collections/asr/test_asr_context_biasing.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
@@ -11,6 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/test_asr_multitask_model_bpe.py \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=3 --num-shards=5 \
+    --shard-id=3 --num-shards=6 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
@@ -11,6 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/test_asr_multitask_model_bpe.py \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
@@ -11,6 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/test_asr_multitask_model_bpe.py \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
@@ -12,5 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/test_asr_multitask_model_bpe.py \
+    tests/collections/asr \
+    --shard-id=3 --num-shards=5 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_4.sh
@@ -11,4 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest tests/collections/asr -m "not pleasefixme" --with_downloads
+NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/test_asr_multitask_model_bpe.py \
+    -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
@@ -12,21 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr/test_asr_parts_submodules_batchnorm.py \
-    tests/collections/asr/test_asr_regression_model.py \
-    tests/collections/asr/test_asr_rnnt_encdec_model.py \
-    tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py \
-    tests/collections/asr/test_asr_samplers.py \
-    tests/collections/asr/test_asr_subsampling.py \
-    tests/collections/asr/test_boosting_tree.py \
-    tests/collections/asr/test_conformer_encoder.py \
-    tests/collections/asr/test_custom_tokenizer.py \
-    tests/collections/asr/test_jasper_block.py \
-    tests/collections/asr/test_label_datasets.py \
-    tests/collections/asr/test_ngram_lm.py \
-    tests/collections/asr/test_padding_and_batch_size_invariance.py \
-    tests/collections/asr/test_preprocessing_segment.py \
-    tests/collections/asr/test_ssl_models.py \
-    tests/collections/asr/test_text_to_text_dataset.py \
-    tests/collections/asr/utils \
+    tests/collections/asr \
+    --shard-id=4 --num-shards=5 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/test_asr_parts_submodules_batchnorm.py \
     tests/collections/asr/test_asr_regression_model.py \
     tests/collections/asr/test_asr_rnnt_encdec_model.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+python -c "from nemo.collections.asr.models import ASRModel" && TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/test_asr_parts_submodules_batchnorm.py \
     tests/collections/asr/test_asr_regression_model.py \
     tests/collections/asr/test_asr_rnnt_encdec_model.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
@@ -1,0 +1,32 @@
+# Copyright (c) 2020-2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/asr/test_asr_parts_submodules_batchnorm.py \
+    tests/collections/asr/test_asr_regression_model.py \
+    tests/collections/asr/test_asr_rnnt_encdec_model.py \
+    tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py \
+    tests/collections/asr/test_asr_samplers.py \
+    tests/collections/asr/test_asr_subsampling.py \
+    tests/collections/asr/test_boosting_tree.py \
+    tests/collections/asr/test_conformer_encoder.py \
+    tests/collections/asr/test_custom_tokenizer.py \
+    tests/collections/asr/test_jasper_block.py \
+    tests/collections/asr/test_label_datasets.py \
+    tests/collections/asr/test_ngram_lm.py \
+    tests/collections/asr/test_padding_and_batch_size_invariance.py \
+    tests/collections/asr/test_preprocessing_segment.py \
+    tests/collections/asr/test_ssl_models.py \
+    tests/collections/asr/test_text_to_text_dataset.py \
+    tests/collections/asr/utils \
+    -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_5.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr/test_asr_parts_submodules_batchnorm.py \
     tests/collections/asr/test_asr_regression_model.py \
     tests/collections/asr/test_asr_rnnt_encdec_model.py \

--- a/tests/functional_tests/L0_Unit_Tests_GPU_ASR_6.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_ASR_6.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 python -c "from nemo.collections.asr.models import ASRModel" && NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
     tests/collections/asr \
-    --shard-id=4 --num-shards=6 \
+    --shard-id=5 --num-shards=6 \
     -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_Audio_1.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_Audio_1.sh
@@ -11,4 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest tests/collections/audio -m "not pleasefixme" --with_downloads
+NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/audio \
+    --shard-id=0 --num-shards=2 \
+    -m "not pleasefixme" --with_downloads

--- a/tests/functional_tests/L0_Unit_Tests_GPU_Audio_2.sh
+++ b/tests/functional_tests/L0_Unit_Tests_GPU_Audio_2.sh
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
-    tests/collections/asr \
-    --shard-id=1 --num-shards=6 \
-    -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat
+NEMO_NUMBA_MINVER=0.53 CUDA_VISIBLE_DEVICES=0 coverage run -a --data-file=/workspace/.coverage --source=/workspace/ -m pytest \
+    tests/collections/audio \
+    --shard-id=1 --num-shards=2 \
+    -m "not pleasefixme" --with_downloads


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Splits three monolithic L0 CI jobs into parallel buckets to reduce wall-clock time:

**`L0_Unit_Tests_GPU_ASR`** (was 40 min, timeout 60) → 5 parallel buckets (timeout 15 each):
- Bucket 1 (~8 min): `confidence/`, `decoding/test_batched_beam_decoding.py`, `test_batched_beam_hyps.py`, `test_batched_hyps_and_alignments.py`, `test_biasing_multi_model.py`, `test_ctc_decoding.py`, `test_cuda_graph_rnnt_greedy_decoding.py`, `test_multi_task_decoding.py`
- Bucket 2 (~8 min): `decoding/test_multi_task_streaming_decoding.py`, `test_rnnt_alignments.py`, `test_rnnt_decoding.py`, `test_streaming_buffer.py`, `test_streaming_decoding.py`, `inference/`, `k2/`, `mixins/`
- Bucket 3 (~11 min): `numba/`, `test_asr_classification_model.py` through `test_asr_multitalker_models.py`
- Bucket 4 (~11 min): `test_asr_multitask_model_bpe.py` alone
- Bucket 5 (~6 min): `test_asr_parts_submodules_batchnorm.py` through `utils/`

**`L0_Unit_Tests_CPU_SpeechLM2`** (was 17 min, timeout 20) → 4 parallel buckets (timeout 12 each):
- Bucket 1 (shard 0/4): `test_salm_asr_decoder.py` (dominant training_step test)
- Bucket 2 (shard 1/4): `test_duplex_eartts.py`, `test_duplex_s2s.py`, `test_duplex_s2s_speech_decoder.py`, `test_duplex_stt.py`
- Bucket 3 (shard 2/4): remaining test files (first half)
- Bucket 4 (shard 3/4): remaining test files (second half)

**`L0_Unit_Tests_CPU_ASR`** (was 30 min, timeout 30) → 4 parallel buckets (timeout 12 each):
- Bucket 1 (~8 min): `decoding/test_batched_beam_decoding.py` (375 s fixture setup) + small decoding tests
- Bucket 2 (~8 min): `confidence/` + `test_asr_multitask_model_bpe.py`
- Bucket 3 (~7 min): remaining decoding tests, `mixins/`, `test_asr_local_attn.py`
- Bucket 4 (~7 min): all remaining files (`numba/`, `inference/`, `k2/`, standalone test files, `utils/`)

</details>