### PR TITLE
ci: switch formatting CI to check-only and enable pre-commit hooks

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,41 +1,25 @@
-name: Isort and Black Formatting
-# Incrementally reformat only changed files with black, all files with isort
-#
-# Replaces pre-commit.ci, since it reformats all the files.
-# See issue https://github.com/pre-commit-ci/issues/issues/90
-#
-# The action requires a custom token to trigger workflow after pushing reformatted files back to the branch.
-# `secrets.GITHUB_TOKEN` can be used instead, but this will result
-# in not running necessary checks after reformatting, which is undesirable.
-# For details see https://github.com/orgs/community/discussions/25702
+name: Isort and Black Formatting Check
+# Check that changed files are formatted with black and isort.
+# Fails if any file needs reformatting — run `pre-commit run --all-files` locally to fix.
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - "**.py"
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
 
 defaults:
   run:
     shell: bash -x -e -u -o pipefail {0}
 
 jobs:
-  reformat_with_isort_and_black:
+  check_isort_and_black:
     runs-on: ubuntu-latest
     permissions:
-      # write permissions required to commit changes
-      contents: write
+      contents: read
     steps:
       - name: Checkout branch
         uses: actions/checkout@v6
-        with:
-          # setup repository and ref for PRs, see
-          # https://github.com/EndBug/add-and-commit?tab=readme-ov-file#working-with-prs
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
-          # custom token is required to trigger actions after reformatting + pushing
-          token: ${{ secrets.NEMO_REFORMAT_TOKEN }}
-          fetch-depth: 0
 
       - name: Get changed files
         id: changed-files
@@ -53,8 +37,8 @@ jobs:
         uses: psf/black@stable
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
-          options: "--verbose"
-          # apply only to changed files (pass explicitly the files)
+          options: "--check --verbose"
+          # check only changed files (pass explicitly the files)
           src: "${{ steps.changed-files.outputs.all_changed_files }}"
           version: "~= 24.3"
 
@@ -63,11 +47,4 @@ jobs:
         if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         with:
           isort-version: "5.13.2"
-          # reformat all files with isort – safe since the whole repo is already reformatted
-          configuration: ""
-
-      - uses: EndBug/add-and-commit@v9
-        # Commit changes. Nothing is committed if no changes.
-        with:
-          message: Apply isort and black reformatting
-          commit: --signoff
+          configuration: "--check-only --diff"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,6 @@ ci:
   autofix_prs: true
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
   autoupdate_schedule: quarterly
-  # skip all hooks that can change the files, use GitHub Action "code-formatting.yml" for this
-  skip: [black,isort]
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -45,8 +43,3 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
-        # It is recommended to specify the latest version of Python
-        # supported by your project here, or alternatively use
-        # pre-commit's default_language_version, see
-        # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10


### PR DESCRIPTION
## Summary
- **Formatting workflow** (`code-formatting.yml`) now runs black and isort in check-only mode — it fails the CI check instead of auto-fixing and pushing commits back to the PR branch
- **Pre-commit hooks** for black and isort are now enabled locally (previously skipped via `skip: [black,isort]`), so developers catch formatting issues before committing
- Removed the hardcoded `language_version: python3.10` pin from the black pre-commit hook (uses `default_language_version: python3` instead)

## Test plan
- [x] Verified `pre-commit run black` passes on correctly formatted files
- [x] Verified `pre-commit run isort` passes on correctly formatted files
- [x] Verified both hooks catch and fix misformatted staged files (report `Failed` + auto-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)