### PR TITLE
[ci, build] fix: unblock testpypi publish — drop direct git URL dep, bump CI template to v0.94.1

### DIFF
--- a/.github/workflows/build-test-publish-wheel.yml
+++ b/.github/workflows/build-test-publish-wheel.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - main
       - "r[0-9]*"
+  workflow_dispatch:
 
 defaults:
   run:
@@ -26,7 +27,7 @@ defaults:
 
 jobs:
   build-test-publish-wheel:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.22.3
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_test_publish_wheel.yml@v0.94.1
     with:
       dry-run: true
       python-package: nemo

--- a/docker/common/install_dep.sh
+++ b/docker/common/install_dep.sh
@@ -300,10 +300,13 @@ vllm() {
 
 extra() {
   local mode="$1"
+  local AUTOMODEL_REPO=${AUTOMODEL_REPO:-$(cat "$CURR/requirements/manifest.json" | jq -r '."vcs-dependencies"."nemo_automodel".repo')}
+  local AUTOMODEL_TAG=${AUTOMODEL_TAG:-$(cat "$CURR/requirements/manifest.json" | jq -r '."vcs-dependencies"."nemo_automodel".ref')}
   DEPS=(
     "llama-index==0.10.43"                                                                     # incompatible with nvidia-pytriton
     "nemo_run"
     "nvidia-modelopt==0.37.0"                                                                  # We want a specific version of nvidia-modelopt
+    "nemo_automodel @ git+${AUTOMODEL_REPO}@${AUTOMODEL_TAG}"                                  # speechlm2 runtime dep; pinned via manifest.json (kept out of wheel metadata so PyPI publish accepts the wheel)
   )
   if [[ "${NVIDIA_PYTORCH_VERSION}" != "" ]]; then
     DEPS+=(

--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -16,6 +16,10 @@
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",
       "ref": "7965842954628b0b5456a2f7d59786d3dcd41647"
+    },
+    "nemo_automodel": {
+      "repo": "https://github.com/NVIDIA-NeMo/Automodel.git",
+      "ref": "9eccbb6102a260efd7cbdffa890fc57b94f94528"
     }
   },
   "pypi-dependencies": {}

--- a/requirements/requirements_speechlm2.txt
+++ b/requirements/requirements_speechlm2.txt
@@ -1,1 +1,5 @@
+# nemo_automodel is also required at runtime but is pinned in
+# requirements/manifest.json (vcs-dependencies.nemo_automodel) and installed by
+# docker/common/install_dep.sh `extra` — direct git URL deps are rejected by
+# PyPI/TestPyPI (`400 Can't have direct dependency`) so it cannot live here.
 flashoptim

--- a/requirements/requirements_speechlm2.txt
+++ b/requirements/requirements_speechlm2.txt
@@ -1,2 +1,1 @@
-nemo_automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@9eccbb6102a260efd7cbdffa890fc57b94f94528  # version with relaxed pytorch constraints
 flashoptim


### PR DESCRIPTION
<details><summary>Claude summary</summary>

The TestPyPI publish job has failed on every push to `main` since 2026-04-23 with `400 Bad Request` from `https://test.pypi.org/legacy/`.

**Cause.** PyPI/TestPyPI rejects any project whose metadata declares a direct URL/VCS dependency (PEP 508 `pkg @ <url>` form). `requirements/requirements_speechlm2.txt` (introduced 2026-04-23 in #15447) contained:

```
nemo_automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@9eccbb6102a260efd7cbdffa890fc57b94f94528
```

With `--verbose` enabled, TestPyPI surfaces the actual response:

```
400 Can't have direct dependency: nemo_automodel @ ...fa890fc57b94f94528 ; extra == "speechlm2-only"
```

**Fix.**

1. **Keep `nemo_automodel` as a tracked dependency, just not in the wheel metadata.** Remove the `nemo_automodel @ git+...` line from `requirements/requirements_speechlm2.txt` (which feeds `extras_require['speechlm2-only']` via `setup.py`, and is therefore baked into wheel metadata) and instead pin the commit in `requirements/manifest.json` alongside the other VCS deps.
2. **Override-install the pinned commit in the GitHub CI image.** `docker/common/install_dep.sh extra` (invoked by `docker/Dockerfile.ci`, which is what GitHub CI builds) reads the pinned ref from `manifest.json` and adds `nemo_automodel @ git+<repo>@<ref>` to its `pip install` step. Net effect: the published wheel has clean metadata, but every CI image still gets the exact same `nemo_automodel` commit.
3. **Surface future twine errors directly.** Bump `_build_test_publish_wheel` from `v0.22.3` → `v0.94.1` (the newer reusable workflow already passes `--verbose --skip-existing` to `twine upload`). Add `workflow_dispatch:` so the workflow can be triggered for testing without waiting on a push to `main`.

**Layout after this PR:**

| Where | What |
|------|------|
| `requirements/manifest.json` → `vcs-dependencies.nemo_automodel` | Pinned `repo` + `ref` (single source of truth) |
| `docker/common/install_dep.sh` → `extra()` | Reads manifest, override-installs `nemo_automodel @ git+<repo>@<ref>` |
| `requirements/requirements_speechlm2.txt` | `flashoptim` + a comment pointing to the manifest/install_dep entry |

**Verification.** Re-triggered on this branch via `workflow_dispatch`; all jobs green. `https://test.pypi.org/simple/nemo-toolkit/` now returns `200` (was `404`).

</details>
