### PR TITLE
[build] fix: restore nemo_automodel in requirements_speechlm2.txt

### DIFF
--- a/requirements/requirements_speechlm2.txt
+++ b/requirements/requirements_speechlm2.txt
@@ -1,5 +1,2 @@
-# nemo_automodel is also required at runtime but is pinned in
-# requirements/manifest.json (vcs-dependencies.nemo_automodel) and installed by
-# docker/common/install_dep.sh `extra` — direct git URL deps are rejected by
-# PyPI/TestPyPI (`400 Can't have direct dependency`) so it cannot live here.
+nemo_automodel
 flashoptim


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## What does this PR do?

Restores `nemo_automodel` in `requirements/requirements_speechlm2.txt` after it was unintentionally dropped in #15659.

## Why

#15659 removed the line

```
nemo_automodel @ git+https://github.com/NVIDIA-NeMo/Automodel.git@<sha>
```

to unblock PyPI/TestPyPI wheel publishing, which rejects direct URL / VCS deps with `400 Can't have direct dependency`. Removing the `nemo_automodel` entry entirely was an accident — the dep is still required at runtime for the speechlm2 extra and should be declared in the requirements file users look at.

## Fix

Re-add `nemo_automodel` as a plain PyPI dep (no `@ git+...` URL), so the wheel publish keeps working while the dependency is once again visible in the requirements file:

```diff
+nemo_automodel
 flashoptim
```

</details>
