### PR TITLE
ci: Major refactor of release-workflows

### DIFF
--- a/.github/workflows/config/changelog-config.json
+++ b/.github/workflows/config/changelog-config.json
@@ -1,134 +1,205 @@
 {
     "categories": [
-      {
-        "title": "## ASR\n\n<details><summary>Changelog</summary>",
-        "labels": ["asr"],
-        "exclude_labels": ["cherry-pick"]
-      },
-      {
-        "title": "</details>\n\n## TTS\n\n<details><summary>Changelog</summary>",
-        "labels": ["tts"],
-        "exclude_labels": ["cherry-pick"]
-      },
-      {
-        "title": "</details>\n\n## NLP / NMT\n\n<details><summary>Changelog</summary>",
-        "labels": ["nlp", "nmt", "megatron"],
-        "exclude_labels": ["cherry-pick"]
-      },
-      {
-        "title": "</details>\n\n## Text Normalization / Inverse Text Normalization\n\n<details><summary>Changelog</summary>",
-        "labels": ["tn", "itn"],
-        "exclude_labels": ["cherry-pick"]
-      },
-      {
-        "title": "</details>\n\n## NeMo Tools\n\n<details><summary>Changelog</summary>",
-        "labels": ["tools"],
-        "exclude_labels": ["cherry-pick"]
-      },
-      {
-        "title": "</details>\n\n## Export\n\n<details><summary>Changelog</summary>",
-        "labels": ["export"],
-        "exclude_labels": ["cherry-pick"]
-      },
-      {
-        "title": "</details>\n\n## Documentation\n\n<details><summary>Changelog</summary>",
-        "labels": ["docs"],
-        "exclude_labels": ["cherry-pick"]
-      },
-      {
-        "title": "</details>\n\n## Bugfixes\n\n<details><summary>Changelog</summary>",
-        "labels": ["bug"],
-        "exclude_labels": ["cherry-pick"]
-      },
-      {
-        "title": "</details>\n\n## Cherrypick\n\n<details><summary>Changelog</summary>",
-        "labels": ["cherry-pick"],
-        "exclude_labels": ["cherry-pick"]
-      }
+        {
+            "title": "## ASR\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "asr"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        },
+        {
+            "title": "</details>\n\n## TTS\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "tts"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        },
+        {
+            "title": "</details>\n\n## NLP / NMT\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "nlp",
+                "nmt",
+                "megatron"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        },
+        {
+            "title": "</details>\n\n## Text Normalization / Inverse Text Normalization\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "tn",
+                "itn"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        },
+        {
+            "title": "</details>\n\n## NeMo Tools\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "tools"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        },
+        {
+            "title": "</details>\n\n## Export\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "export"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        },
+        {
+            "title": "</details>\n\n## Documentation\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "docs"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        },
+        {
+            "title": "</details>\n\n## Bugfixes\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "bug"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        },
+        {
+            "title": "</details>\n\n## Cherrypick\n\n<details><summary>Changelog</summary>",
+            "labels": [
+                "cherry-pick"
+            ],
+            "exclude_labels": [
+                "cherry-pick"
+            ]
+        }
     ],
     "ignore_labels": [
-      "ignore"
+        "ignore"
     ],
     "sort": "ASC",
     "template": "\n${{CHANGELOG}}</details>\n\n## Uncategorized:\n\n<details><summary>Changelog</summary>\n\n${{UNCATEGORIZED}}\n</details>\n",
     "pr_template": "- ${{TITLE}} by @${{AUTHOR}} :: PR: #${{NUMBER}}",
     "empty_template": "${{OWNER}}\n${{REPO}}\n${{FROM_TAG}}\n${{TO_TAG}}",
     "label_extractor": [
-      {
-        "pattern": "(.*tts.*)|(.*g2p.*)",
-        "target": "tts",
-        "flags": "gimu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*asr.*)|(.*ctc.*)|(.*rnnt.*)|(.*transducer.*)|(.*dali.*)|(.*k2.*)",
-        "target": "asr",
-        "flags": "gimu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*nlp.*)|(.*punctuation.*)|(.*capitalization.*)|(.*entity.*)|(.*glue.*)|(.*entity.*)|(.*retrieval.*)|(.*entity.*)|(.*intent.*)|(.*slot.*)|(.*entity.*)|(.*language.*)|(.*qa.*)|(.*token class.*)|(.*text class.*)",
-        "target": "nlp",
-        "flags": "gimu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*nmt.*)|(.*bignlp.*)|(.*megatron.*)|(.*machine.*)|(.*translation.*)|(.*gpt.*)",
-        "target": "nmt",
-        "flags": "gimu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*tn.*)|(.*itn.*)|(.*text norm.*)",
-        "target": "tn",
-        "flags": "gimu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*sde.*)|(.*ctc segment.*)",
-        "target": "tools",
-        "flags": "gimu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*trt.*)|(.*onnx.*)|(.*export.*)",
-        "target": "export",
-        "flags": "gimu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*\\[x\\] Documentation.*)",
-        "target": "docs",
-        "flags": "gmu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*\\[x\\] Bugfix.*)|(.*patch.*)",
-        "target": "bug",
-        "flags": "gmu",
-        "on_property": ["title", "body"]
-      },
-      {
-        "pattern": "(.*cherry-pick.*)|(.*cherrypick.*)",
-        "target": "cherrypick",
-        "flags": "gimu",
-        "on_property": ["title", "body"]
-      }
+        {
+            "pattern": "(.*tts.*)|(.*g2p.*)",
+            "target": "tts",
+            "flags": "gimu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*asr.*)|(.*ctc.*)|(.*rnnt.*)|(.*transducer.*)|(.*dali.*)|(.*k2.*)",
+            "target": "asr",
+            "flags": "gimu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*nlp.*)|(.*punctuation.*)|(.*capitalization.*)|(.*entity.*)|(.*glue.*)|(.*entity.*)|(.*retrieval.*)|(.*entity.*)|(.*intent.*)|(.*slot.*)|(.*entity.*)|(.*language.*)|(.*qa.*)|(.*token class.*)|(.*text class.*)",
+            "target": "nlp",
+            "flags": "gimu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*nmt.*)|(.*bignlp.*)|(.*megatron.*)|(.*machine.*)|(.*translation.*)|(.*gpt.*)",
+            "target": "nmt",
+            "flags": "gimu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*tn.*)|(.*itn.*)|(.*text norm.*)",
+            "target": "tn",
+            "flags": "gimu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*sde.*)|(.*ctc segment.*)",
+            "target": "tools",
+            "flags": "gimu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*trt.*)|(.*onnx.*)|(.*export.*)",
+            "target": "export",
+            "flags": "gimu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*\\[x\\] Documentation.*)",
+            "target": "docs",
+            "flags": "gmu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*\\[x\\] Bugfix.*)|(.*patch.*)",
+            "target": "bug",
+            "flags": "gmu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        },
+        {
+            "pattern": "(.*cherry-pick.*)|(.*cherrypick.*)",
+            "target": "cherrypick",
+            "flags": "gimu",
+            "on_property": [
+                "title",
+                "body"
+            ]
+        }
     ],
     "duplicate_filter": {
-      "pattern": ".+",
-      "on_property": "title",
-      "method": "match"
+        "pattern": ".+",
+        "on_property": "title",
+        "method": "match"
     },
     "transformers": [
+        {
+            "pattern": "^cp:\\s*`(.+?)`\\s*into\\s*\\S+",
+            "target": "$1"
+        }
     ],
     "max_tags_to_fetch": 100,
     "max_pull_requests": 500,
     "max_back_track_time_days": 365,
-    "exclude_merge_branches": [
-    ],
+    "exclude_merge_branches": [],
     "tag_resolver": {
-      "method": "semver"
+        "method": "semver"
     }
 }
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,13 +77,9 @@ jobs:
   release:
     needs: [pre-flight]
     if: |
-      !cancelled()
-      && (needs.pre-flight.result == 'success' || needs.pre-flight.result == 'skipped')
-      && (
-        github.event_name == 'workflow_dispatch'
-        || !(needs.pre-flight.outputs.docs_only == 'true'
-             || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-      )
+      !cancelled() && !failure()
+      && !(needs.pre-flight.outputs.docs_only == 'true'
+           || needs.pre-flight.outputs.is_deployment_workflow == 'true')
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,13 +112,7 @@ jobs:
 
   release-summary:
     needs: [pre-flight, release]
-    if: |
-      (
-        needs.pre-flight.outputs.docs_only == 'true'
-        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
-        || always()
-      )
-      && !cancelled()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Result

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
+  pre-flight:
+    if: github.event_name != 'workflow_dispatch'
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.94.1
+
   release:
-    if: ${{ !cancelled() }}
+    needs: [pre-flight]
+    if: |
+      !cancelled()
+      && (needs.pre-flight.result == 'success' || needs.pre-flight.result == 'skipped')
+      && (
+        github.event_name == 'workflow_dispatch'
+        || !(needs.pre-flight.outputs.docs_only == 'true'
+             || needs.pre-flight.outputs.is_deployment_workflow == 'true')
+      )
     uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@f5224c1bd6206ba3b26dd7a91c970a3902711b8f
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
@@ -105,8 +117,14 @@ jobs:
       S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
   release-summary:
-    needs: [release]
-    if: always() && !cancelled()
+    needs: [pre-flight, release]
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || always()
+      )
+      && !cancelled()
     runs-on: ubuntu-latest
     steps:
       - name: Result

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,6 @@ jobs:
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
     secrets: inherit
-      S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
   release-summary:
     needs: [pre-flight, release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@b8fdc579e96fba4e59a24507a7be1643c74c7585
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@8b6828043ea50a4328ce259018ab1a82d91bd29c
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@d2f3dd32aad11b7034f3f1821174556507d61670
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@64293f6d11ccd1a14a8d23c403761a543b4c21f9
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ concurrency:
 jobs:
   release:
     if: ${{ !cancelled() }}
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@2f00056b5f23aa546dd2587652b63dc359e94317
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@f5224c1bd6206ba3b26dd7a91c970a3902711b8f
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo
@@ -81,6 +81,7 @@ jobs:
       validate-only: ${{ github.event_name != 'workflow_dispatch' }}
       dry-run: ${{ inputs.dry-run || false }}
       wheel-content-ignore: "W002,W004,W005,W009"
+      skip-check-manifest: true
       version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
       create-gh-release: ${{ inputs.create-gh-release || true }}
       app-id: ${{ vars.BOT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@64293f6d11ccd1a14a8d23c403761a543b4c21f9
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       !cancelled() && !failure()
       && !(needs.pre-flight.outputs.docs_only == 'true'
            || needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.0.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.2.0
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo
@@ -98,6 +98,8 @@ jobs:
       docs-target-path: nemo
       docs-directory: docs/source
       docs-requirements-file: requirements/requirements_docs.txt
+      docs-sync-all: true
+      docs-no-extras: "--no-extra cu12"
       publish-as-latest: true
       run-on-version-tag-only: ${{ github.ref_name != 'main' }}
       docs-skip-linkcheck: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@8b6828043ea50a4328ce259018ab1a82d91bd29c
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@b57ebf9bc8e9f7e60cd84f196e0afc8f774a3045
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,6 @@ jobs:
       docs-target-path: nemo
       docs-directory: docs/source
       docs-requirements-file: requirements/requirements_docs.txt
-      sync-all: true
-      no-extras: "--no-extra cu12"
       publish-as-latest: true
       run-on-version-tag-only: ${{ github.ref_name != 'main' }}
       docs-skip-linkcheck: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@43d259e5b5f0a6cb4c14eefa04738a5bdf316fe1
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@d2f3dd32aad11b7034f3f1821174556507d61670
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo
@@ -108,18 +108,7 @@ jobs:
       docs-skip-linkcheck: true
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
-    secrets:
-      TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-      TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      BOT_KEY: ${{ secrets.BOT_KEY }}
-      AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AKAMAI_HOST: ${{ secrets.AKAMAI_HOST }}
-      AKAMAI_CLIENT_TOKEN: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
-      AKAMAI_CLIENT_SECRET: ${{ secrets.AKAMAI_CLIENT_SECRET }}
-      AKAMAI_ACCESS_TOKEN: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
+    secrets: inherit
       S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
 
   release-summary:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@b57ebf9bc8e9f7e60cd84f196e0afc8f774a3045
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@cb5e93b1737dab3e8bfb87d8d9b743cd1d92f6d6
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,6 @@ jobs:
       docs-target-path: nemo
       docs-directory: docs/source
       docs-requirements-file: requirements/requirements_docs.txt
-      docs-fail-on-warning: false
       publish-as-latest: true
       run-on-version-tag-only: ${{ github.ref_name != 'main' }}
       docs-skip-linkcheck: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
       docs-skip-linkcheck: true
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
-    secrets: inherit
+    secrets: inherit  # pragma: allowlist secret
 
   release-summary:
     needs: [pre-flight, release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@bec349ae1ea6e9cce74c15e661c6311e0b4756c8
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@b8fdc579e96fba4e59a24507a7be1643c74c7585
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo
@@ -105,6 +105,7 @@ jobs:
       docs-fail-on-warning: false
       publish-as-latest: true
       run-on-version-tag-only: ${{ github.ref_name != 'main' }}
+      docs-skip-linkcheck: true
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@cb5e93b1737dab3e8bfb87d8d9b743cd1d92f6d6
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@43d259e5b5f0a6cb4c14eefa04738a5bdf316fe1
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo
@@ -112,7 +112,6 @@ jobs:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
       BOT_KEY: ${{ secrets.BOT_KEY }}
       AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,8 @@ jobs:
       docs-target-path: nemo
       docs-directory: docs/source
       docs-requirements-file: requirements/requirements_docs.txt
+      sync-all: true
+      no-extras: "--no-extra cu12"
       publish-as-latest: true
       run-on-version-tag-only: ${{ github.ref_name != 'main' }}
       docs-skip-linkcheck: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,7 @@ jobs:
       library-name: Neural Modules
       validate-only: ${{ github.event_name != 'workflow_dispatch' }}
       dry-run: ${{ inputs.dry-run || false }}
+      wheel-content-ignore: "W002,W004,W005,W009"
       version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
       create-gh-release: ${{ inputs.create-gh-release || true }}
       app-id: ${{ vars.BOT_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ on:
       publish-docs:
         description: Publish docs
         required: false
-        default: false
+        default: true
         type: boolean
       gh-release-from-tag:
         description: Tag of previous release for changelog builder
@@ -98,7 +98,10 @@ jobs:
       create-gh-release: ${{ inputs.create-gh-release || true }}
       app-id: ${{ vars.BOT_ID }}
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
-      publish-docs: ${{ inputs.publish-docs || false }}
+      publish-docs: ${{ inputs.publish-docs || true }}
+      docs-target-path: nemo
+      publish-as-latest: true
+      run-on-version-tag-only: ${{ github.ref_name != 'main' }}
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       restrict-to-admins: true
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021, NVIDIA CORPORATION.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: "Release Neural Modules"
+name: "Build, validate, and release Neural Modules"
 
 on:
+  push:
+    branches:
+      - main
+      - "r**"
+      - "pull-request/**"
+      - "deploy-release/*"
   workflow_dispatch:
     inputs:
       release-ref:
@@ -25,7 +31,7 @@ on:
         required: true
         type: string
       dry-run:
-        description: Do not publish a wheel and GitHub release.
+        description: Compute the release but do not publish wheel, GH release, or docs.
         required: true
         default: true
         type: boolean
@@ -49,29 +55,43 @@ on:
         required: false
         type: string
         default: ""
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 jobs:
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v0.80.3
+    if: ${{ !cancelled() }}
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@2f00056b5f23aa546dd2587652b63dc359e94317
     with:
-      release-ref: ${{ inputs.release-ref }}
+      release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo
       python-version: "3.10"
       library-name: Neural Modules
-      dry-run: ${{ inputs.dry-run }}
-      version-bump-branch: ${{ inputs.version-bump-branch }}
-      create-gh-release: ${{ inputs.create-gh-release }}
+      validate-only: ${{ github.event_name != 'workflow_dispatch' }}
+      dry-run: ${{ inputs.dry-run || false }}
+      version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
+      create-gh-release: ${{ inputs.create-gh-release || true }}
       app-id: ${{ vars.BOT_ID }}
-      gh-release-use-changelog-builder: ${{ inputs.generate-changelog }}
-      publish-docs: ${{ inputs.publish-docs }}
-      gh-release-from-tag: ${{ inputs.gh-release-from-tag }}
+      gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
+      publish-docs: ${{ inputs.publish-docs || false }}
+      gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
+      restrict-to-admins: true
     secrets:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_ENDPOINT }}
-      PAT: ${{ secrets.PAT }}
-      SSH_KEY: ${{ secrets.SSH_KEY }}
-      SSH_PWD: ${{ secrets.SSH_PWD }}
       BOT_KEY: ${{ secrets.BOT_KEY }}
       AWS_ASSUME_ROLE_ARN: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -81,3 +101,23 @@ jobs:
       AKAMAI_CLIENT_SECRET: ${{ secrets.AKAMAI_CLIENT_SECRET }}
       AKAMAI_ACCESS_TOKEN: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
       S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+
+  release-summary:
+    needs: [release]
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --repo ${{ github.repository }} --json jobs --jq '[.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
+
+          if [ "${FAILED_JOBS:-0}" -eq 0 ]; then
+              echo "✅ All previous jobs completed successfully"
+              exit 0
+          else
+              echo "❌ Found $FAILED_JOBS failed job(s)"
+              gh run view $GITHUB_RUN_ID --repo ${{ github.repository }} --json jobs --jq '.jobs[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "action_required") | .name'
+              exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         || !(needs.pre-flight.outputs.docs_only == 'true'
              || needs.pre-flight.outputs.is_deployment_workflow == 'true')
       )
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@f5224c1bd6206ba3b26dd7a91c970a3902711b8f
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@bec349ae1ea6e9cce74c15e661c6311e0b4756c8
     with:
       release-ref: ${{ inputs.release-ref || github.sha }}
       python-package: nemo
@@ -100,6 +100,9 @@ jobs:
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
       publish-docs: ${{ inputs.publish-docs || true }}
       docs-target-path: nemo
+      docs-directory: docs/source
+      docs-requirements-file: requirements/requirements_docs.txt
+      docs-fail-on-warning: false
       publish-as-latest: true
       run-on-version-tag-only: ${{ github.ref_name != 'main' }}
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}


### PR DESCRIPTION
## Why

See the design discussion in NVIDIA-NeMo/FW-CI-templates#466.

## What

- **Delete** `.github/workflows/build-test-publish-wheel.yml`.
- **Rewrite** `.github/workflows/release.yml` as the single caller for both `push` and `workflow_dispatch`.

## Test plan

- [x] PR validate-only (push (mirror), sha 53f93bac88, 2026-05-07T11:45:12Z, success): https://github.com/NVIDIA-NeMo/NeMo/actions/runs/25493776840
- [x] `workflow_dispatch dry-run=true` (sha 53f93bac88, 2026-05-07T11:28:45Z, success): https://github.com/NVIDIA-NeMo/NeMo/actions/runs/25493047406
- [ ] Real release via `workflow_dispatch dry-run=false` on the next planned RC.

## Rollout

1. Land FW-CI-templates#466.
2. Cut FW-CI-templates `v1.0.0`.
3. Bump the SHA pin in this PR → tag.
