### PR TITLE
fix(ci): make approve-test-queue tolerate races

### DIFF
--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -81,6 +81,20 @@ jobs:
                   return None
 
 
+          def cancel_run(run_id):
+              """Cancel a workflow run. Returns True on success."""
+              url = f"{API_BASE}/actions/runs/{run_id}/cancel"
+              try:
+                  response = requests.post(url, headers=headers)
+                  response.raise_for_status()
+                  return True
+              except requests.exceptions.RequestException as e:
+                  print(f"Error cancelling run {run_id}: {str(e)}")
+                  if hasattr(e.response, 'text'):
+                      print(f"Response: {e.response.text}")
+                  return False
+
+
           def get_workflow_runs(status):
               """Get all workflow runs for a given status."""
               all_results = []
@@ -129,6 +143,7 @@ jobs:
 
           # Process each deployment
           print("Processing ...")
+          had_unrecoverable = False
           for workflow in pending_workflows:
               if total_workflows >= MAX_CONCURRENCY:
                   print("Maximum concurrency reached, stopping approvals")
@@ -139,7 +154,11 @@ jobs:
               print(f"Approving workflow {workflow_name} with Run Id: {workflow_id}")
 
               deployment_url = f"actions/runs/{workflow_id}/pending_deployments"
-              deployment = make_request(deployment_url)[0]
+              deployments = make_request(deployment_url) or []
+              if not deployments:
+                  print(f"No pending deployments for run {workflow_id} (race: approved between list and GET), skipping")
+                  continue
+              deployment = deployments[0]
               environment_id = deployment["environment"]["id"]
 
               # Approve the deployment
@@ -152,9 +171,28 @@ jobs:
 
               if result:
                   total_workflows += 1
+                  continue
+
+              # POST failed. Distinguish race (someone else approved between our GET
+              # and POST) from a wedged run (deployment listed as pending but GitHub
+              # refuses to approve it — typically when the parent ref was force-pushed
+              # and the run was orphaned). The former is benign; the latter blocks
+              # every future cron tick because the run sits at the head of the
+              # waiting queue forever, so we cancel it.
+              deployments_after = make_request(deployment_url) or []
+              if not deployments_after:
+                  print(f"Run {workflow_id} approved by another path (race), skipping")
+                  continue
+
+              print(f"Run {workflow_id} is wedged: POST refused but pending_deployments still non-empty. Cancelling.")
+              if cancel_run(workflow_id):
+                  print(f"Cancelled wedged run {workflow_id}")
               else:
-                  print(f"Failed to approve deployment {deployment['id']}")
-                  exit(1)
+                  print(f"Could not cancel wedged run {workflow_id}; manual intervention required")
+                  had_unrecoverable = True
+
+          if had_unrecoverable:
+              exit(1)
 
           EOF
   notify:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Why

The `Approve Test Queue` cron has been failing every 5 minutes today with `KeyError: 'id'` followed by `exit 1`. Example: https://github.com/NVIDIA-NeMo/NeMo/actions/runs/25600162235/job/75152606750

The actual failure mode wasn't a race — it was a **wedged run**. After a force-push on PR #15668, a CICD run on the discarded head was left in `waiting` status. `GET /actions/runs/<id>/pending_deployments` returned a single entry, but `POST` to approve it 422'd (`No pending deployment requests to approve or reject`). With `MAX_CONCURRENCY=1` the cron picked the same orphan first every tick, crashed on a `deployment['id']` lookup (no such key on `/pending_deployments` items), and never reached anything else.

## What

Distinguish race from orphan, then remediate the orphan:

```python
result = make_request(deployment_url, method="POST", data=status_data)
if result:
    total_workflows += 1
    continue

# POST failed. Re-GET to tell race vs orphan apart.
deployments_after = make_request(deployment_url) or []
if not deployments_after:
    # benign race — someone else approved between our GET and POST
    continue

# wedged: pending_deployments still lists it, but POST refuses
if cancel_run(workflow_id):
    print(f"Cancelled wedged run {workflow_id}")
else:
    had_unrecoverable = True
```

- New `cancel_run()` helper: `POST /actions/runs/{id}/cancel` + `raise_for_status`.
- If a wedged run can't be cancelled (e.g. token lacks scope), set `had_unrecoverable` and `exit(1)` **after** the loop, so other queue items still get processed.
- Initial GET that returns an empty list is also handled (skip silently — same race window, just earlier).
- `KeyError: 'id'` is gone; the only place we printed `deployment['id']` referenced a key that does not exist on `/pending_deployments` items.

## Verification

- The wedged run that triggered today's outage (25597959104) has been cancelled manually; the next 5-min cron tick will be the first reproduction-free one.
- After this PR lands, the same orphan scenario from a future force-push will be auto-cleared on the next tick.

</details>
