### PR TITLE
Preserve SpeechLM perception checkpoint dtype

### DIFF
--- a/nemo/collections/speechlm2/modules/perception.py
+++ b/nemo/collections/speechlm2/modules/perception.py
@@ -126,9 +126,6 @@ class AudioPerceptionModule(NeuralModule, Exportable):
         if self.spec_augmentation is not None and self.training:
             processed_signal = self.spec_augmentation(input_spec=processed_signal, length=processed_signal_length)
 
-        encoder_dtype = next(self.encoder.parameters()).dtype
-        processed_signal = processed_signal.to(dtype=encoder_dtype)
-
         if isinstance(self.modality_adapter, (QformerConnector, MultiLayerProjectionConnector)):
             encoder_emb, encoded_len = self.encoder_multilayer(
                 audio_signal=processed_signal, length=processed_signal_length

--- a/nemo/collections/speechlm2/modules/perception.py
+++ b/nemo/collections/speechlm2/modules/perception.py
@@ -132,7 +132,6 @@ class AudioPerceptionModule(NeuralModule, Exportable):
             )
         else:
             encoder_emb, encoded_len = self.encoder(audio_signal=processed_signal, length=processed_signal_length)
-
         encoded, encoded_len = self.modality_adapter(audio_signal=encoder_emb, length=encoded_len)
 
         # b, c, t -> b, t, c

--- a/nemo/collections/speechlm2/modules/perception.py
+++ b/nemo/collections/speechlm2/modules/perception.py
@@ -126,12 +126,16 @@ class AudioPerceptionModule(NeuralModule, Exportable):
         if self.spec_augmentation is not None and self.training:
             processed_signal = self.spec_augmentation(input_spec=processed_signal, length=processed_signal_length)
 
+        encoder_dtype = next(self.encoder.parameters()).dtype
+        processed_signal = processed_signal.to(dtype=encoder_dtype)
+
         if isinstance(self.modality_adapter, (QformerConnector, MultiLayerProjectionConnector)):
             encoder_emb, encoded_len = self.encoder_multilayer(
                 audio_signal=processed_signal, length=processed_signal_length
             )
         else:
             encoder_emb, encoded_len = self.encoder(audio_signal=processed_signal, length=processed_signal_length)
+
         encoded, encoded_len = self.modality_adapter(audio_signal=encoder_emb, length=encoded_len)
 
         # b, c, t -> b, t, c

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -60,6 +60,7 @@ from nemo.collections.speechlm2.vllm.salm.backends import HybridBackend, make_ba
 from nemo.collections.speechlm2.vllm.salm.config import _AUDIO_PLACEHOLDER
 
 _AUDIO_INPUT_DTYPE = torch.float32
+_PERCEPTION_DTYPE = torch.bfloat16
 
 
 @MULTIMODAL_REGISTRY.register_processor(
@@ -146,14 +147,13 @@ class NeMoSpeechLMForConditionalGeneration(
                 input_signal=audio_signal,
                 length=audio_lengths,
             )
-            perception_dtype = next(self.perception.encoder.parameters()).dtype
-            processed_signal = processed_signal.to(dtype=perception_dtype)
+            processed_signal = processed_signal.to(dtype=_PERCEPTION_DTYPE)
             audio_embeds, audio_embed_lens = self.perception(
                 processed_signal=processed_signal,
                 processed_signal_length=processed_signal_length,
             )
 
-        audio_embeds = audio_embeds.to(torch.bfloat16)
+        audio_embeds = audio_embeds.to(_PERCEPTION_DTYPE)
 
         return tuple(audio_embeds[i, : audio_embed_lens[i]] for i in range(audio_embeds.shape[0]))
 
@@ -190,11 +190,7 @@ class NeMoSpeechLMForConditionalGeneration(
     # ── weight loading ──
 
     def _load_perception_weights(self, perception_weights: dict[str, torch.Tensor]) -> set[str]:
-        target_dtype = next(
-            (tensor.dtype for tensor in perception_weights.values() if tensor.is_floating_point()),
-            torch.float32,
-        )
-        self.perception = self.perception.to(target_dtype)
+        self.perception = self.perception.to(_PERCEPTION_DTYPE)
         self.perception.load_state_dict(perception_weights, strict=False)
         return {"perception." + k for k in perception_weights}
 

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -144,9 +144,15 @@ class NeMoSpeechLMForConditionalGeneration(
         audio_lengths = audio_input.audio_signal_length.to(device=device)
 
         with torch.no_grad():
-            audio_embeds, audio_embed_lens = self.perception(
+            processed_signal, processed_signal_length = self.perception.maybe_preprocess_audio(
                 input_signal=audio_signal,
                 input_signal_length=audio_lengths,
+            )
+            perception_dtype = next(self.perception.encoder.parameters()).dtype
+            processed_signal = processed_signal.to(dtype=perception_dtype)
+            audio_embeds, audio_embed_lens = self.perception(
+                processed_signal=processed_signal,
+                processed_signal_length=processed_signal_length,
             )
 
         audio_embeds = audio_embeds.to(self._lm_dtype)

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -98,8 +98,6 @@ class NeMoSpeechLMForConditionalGeneration(
                 architectures=backend.architectures(),
             )
 
-        self._lm_dtype = next(self.language_model.parameters()).dtype
-
         with self._mark_tower_model(vllm_config, {"audio"}):
             self.perception = _load_nemo_perception(config.perception)
 
@@ -155,7 +153,7 @@ class NeMoSpeechLMForConditionalGeneration(
                 processed_signal_length=processed_signal_length,
             )
 
-        audio_embeds = audio_embeds.to(self._lm_dtype)
+        audio_embeds = audio_embeds.to(torch.bfloat16)
 
         return tuple(audio_embeds[i, : audio_embed_lens[i]] for i in range(audio_embeds.shape[0]))
 

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -59,6 +59,8 @@ from nemo.collections.speechlm2.vllm.salm.audio import (
 from nemo.collections.speechlm2.vllm.salm.backends import HybridBackend, make_backend
 from nemo.collections.speechlm2.vllm.salm.config import _AUDIO_PLACEHOLDER
 
+_AUDIO_INPUT_DTYPE = torch.float32
+
 
 @MULTIMODAL_REGISTRY.register_processor(
     NeMoSpeechLMMultiModalProcessor,
@@ -96,9 +98,10 @@ class NeMoSpeechLMForConditionalGeneration(
                 architectures=backend.architectures(),
             )
 
+        self._lm_dtype = next(self.language_model.parameters()).dtype
+
         with self._mark_tower_model(vllm_config, {"audio"}):
             self.perception = _load_nemo_perception(config.perception)
-            self.perception = self.perception.to(torch.float32)
 
         self.make_empty_intermediate_tensors = self.language_model.make_empty_intermediate_tensors
 
@@ -137,7 +140,7 @@ class NeMoSpeechLMForConditionalGeneration(
         audio_signal = audio_input.audio_signal
         if isinstance(audio_signal, list):
             audio_signal = torch.stack(audio_signal, dim=0)
-        audio_signal = audio_signal.to(device=device, dtype=torch.float32)
+        audio_signal = audio_signal.to(device=device, dtype=_AUDIO_INPUT_DTYPE)
         audio_lengths = audio_input.audio_signal_length.to(device=device)
 
         with torch.no_grad():
@@ -146,7 +149,7 @@ class NeMoSpeechLMForConditionalGeneration(
                 input_signal_length=audio_lengths,
             )
 
-        audio_embeds = audio_embeds.to(torch.bfloat16)
+        audio_embeds = audio_embeds.to(self._lm_dtype)
 
         return tuple(audio_embeds[i, : audio_embed_lens[i]] for i in range(audio_embeds.shape[0]))
 
@@ -183,9 +186,16 @@ class NeMoSpeechLMForConditionalGeneration(
     # ── weight loading ──
 
     def _load_perception_weights(self, perception_weights: dict[str, torch.Tensor]) -> set[str]:
-        float32_weights = {k: v.float() for k, v in perception_weights.items()}
-        self.perception.load_state_dict(float32_weights, strict=False)
-        self.perception = self.perception.to(torch.float32)
+        target_dtype = next(
+            (tensor.dtype for tensor in perception_weights.values() if tensor.is_floating_point()),
+            torch.float32,
+        )
+        self.perception = self.perception.to(target_dtype)
+        dtype_weights = {
+            key: tensor.to(target_dtype) if tensor.is_floating_point() else tensor
+            for key, tensor in perception_weights.items()
+        }
+        self.perception.load_state_dict(dtype_weights, strict=False)
         return {"perception." + k for k in perception_weights}
 
     @staticmethod

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -153,8 +153,6 @@ class NeMoSpeechLMForConditionalGeneration(
                 processed_signal_length=processed_signal_length,
             )
 
-        audio_embeds = audio_embeds.to(_PERCEPTION_DTYPE)
-
         return tuple(audio_embeds[i, : audio_embed_lens[i]] for i in range(audio_embeds.shape[0]))
 
     def embed_multimodal(self, **kwargs) -> MultiModalEmbeddings:

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -197,11 +197,7 @@ class NeMoSpeechLMForConditionalGeneration(
             torch.float32,
         )
         self.perception = self.perception.to(target_dtype)
-        dtype_weights = {
-            key: tensor.to(target_dtype) if tensor.is_floating_point() else tensor
-            for key, tensor in perception_weights.items()
-        }
-        self.perception.load_state_dict(dtype_weights, strict=False)
+        self.perception.load_state_dict(perception_weights, strict=False)
         return {"perception." + k for k in perception_weights}
 
     @staticmethod

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -144,9 +144,9 @@ class NeMoSpeechLMForConditionalGeneration(
         audio_lengths = audio_input.audio_signal_length.to(device=device)
 
         with torch.no_grad():
-            processed_signal, processed_signal_length = self.perception.maybe_preprocess_audio(
+            processed_signal, processed_signal_length = self.perception.preprocessor(
                 input_signal=audio_signal,
-                input_signal_length=audio_lengths,
+                length=audio_lengths,
             )
             perception_dtype = next(self.perception.encoder.parameters()).dtype
             processed_signal = processed_signal.to(dtype=perception_dtype)

--- a/nemo/collections/speechlm2/vllm/salm/model.py
+++ b/nemo/collections/speechlm2/vllm/salm/model.py
@@ -143,14 +143,9 @@ class NeMoSpeechLMForConditionalGeneration(
         audio_lengths = audio_input.audio_signal_length.to(device=device)
 
         with torch.no_grad():
-            processed_signal, processed_signal_length = self.perception.preprocessor(
-                input_signal=audio_signal,
-                length=audio_lengths,
-            )
-            processed_signal = processed_signal.to(dtype=_PERCEPTION_DTYPE)
             audio_embeds, audio_embed_lens = self.perception(
-                processed_signal=processed_signal,
-                processed_signal_length=processed_signal_length,
+                input_signal=audio_signal,
+                input_signal_length=audio_lengths,
             )
 
         return tuple(audio_embeds[i, : audio_embed_lens[i]] for i in range(audio_embeds.shape[0]))


### PR DESCRIPTION
## Summary
- Stop forcing the SpeechLM vLLM perception module to FP32 when loading checkpoint weights.
- Keep raw audio input/preprocessing in FP32, then cast processed features to the encoder checkpoint dtype before encoder execution.
- Cast final audio embeddings to the initialized LLM dtype before inserting them into the language model stream.

## Test plan
- `python3 -c "import ast; ast.parse(open('/home/dongjig/NeMo_merge/nemo/collections/speechlm2/vllm/salm/model.py').read()); ast.parse(open('/home/dongjig/NeMo_merge/nemo/collections/speechlm2/modules/perception.py').read())"`
- VoxPopuli full local vLLM plugin check on NemotronH SpeechLM: WER 9.07, RTFx 814.54 at `/data/dongjig/results/quantization/speechlm_bf16_perception_checkpoint_dtype_voxpopuli_20260511_095950/result.json`.
- ASR leaderboard dtype comparison completed for LibriSpeech clean/other, TEDLIUM, SPGISpeech, VoxPopuli, GigaSpeech, and first 1024 Earnings22 samples under `/data/dongjig/results/quantization/speechlm_leaderboard_perception_dtype_20260510_150218`; no meaningful WER regression observed for BF16 perception.

