### PR TITLE
Add verbose flag to UTMOSv2Calculator

### DIFF
--- a/nemo/collections/tts/modules/utmosv2.py
+++ b/nemo/collections/tts/modules/utmosv2.py
@@ -44,12 +44,13 @@ class UTMOSv2Calculator:
             Default is None.
     """
 
-    def __init__(self, device: Optional[str] = None):
+    def __init__(self, device: Optional[str] = None, verbose: bool = True):
         if device is None:
             device = get_available_device()
         self.model = utmosv2.create_model()
         self.model.eval()
         self.model.to(torch.device(device))
+        self.verbose = verbose
 
     def __call__(self, file_path):
         """
@@ -59,7 +60,9 @@ class UTMOSv2Calculator:
             # UTMOSv2 tends to launch many OpenMP threads which can overload the machine's CPUs
             # without actually speeding up prediction. Limit to 4 threads.
             with threadpool_limits(limits=4):
-                mos_score = self.model.predict(input_path=file_path, num_repetitions=1, num_workers=0)
+                mos_score = self.model.predict(
+                    input_path=file_path, num_repetitions=1, num_workers=0, verbose=self.verbose
+                )
         return mos_score
 
     def process_directory(
@@ -96,6 +99,7 @@ class UTMOSv2Calculator:
                     num_workers=num_workers,
                     batch_size=batch_size,
                     val_list=val_list,
+                    verbose=self.verbose,
                 )
         return results
 


### PR DESCRIPTION
# What does this PR do ?

Allow user to disable verbose logging (progress bar) when computing utmosv2.

The utmosv2 model does not have a good interface for batch computing; you either provide it a single file path or a directory path containing .wav files. I have a use case where I cannot use the directory method and instead run the single file inference multiple times, for which it is helpful to have the progress bar disabled.

**Collection**: [TTS]

# Changelog

- Add verbose flag to constructor of UTMOSv2Calculator

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
