### PR TITLE
Fix peak memory in TransformerEncoder rel_pos attention

### DIFF
--- a/nemo/collections/asr/modules/transformer_encoder.py
+++ b/nemo/collections/asr/modules/transformer_encoder.py
@@ -170,20 +170,6 @@ class MultiHeadAttention(nn.Module):
             self.pos_bias_u = None
             self.pos_bias_v = None
 
-        # Per-forward Transformer-XL (b)+(d) bias of shape (B, H, T, T), set by ``forward`` and
-        # read by ``_rel_pos_score_mod`` while FlexAttention is executing.
-        self._rel_pos_bias = None
-
-    def _rel_pos_score_mod(self, score, b, h, q_idx, kv_idx):
-        """FlexAttention ``score_mod`` adding the Transformer-XL (b)+(d) bias.
-
-        FlexAttention's ``score_mod`` API expects a callable with a fixed signature, so the
-        per-forward bias tensor is passed in via ``self._rel_pos_bias`` rather than as an
-        explicit argument; ``forward`` populates that attribute immediately before invoking
-        ``flex_attention``.
-        """
-        return score + self._rel_pos_bias[b, h, q_idx, kv_idx]
-
     def _rel_shift(self, x):
         """Transformer-XL relative-position shift.
 
@@ -202,11 +188,12 @@ class MultiHeadAttention(nn.Module):
         - Matrices (b) + (d) — the position-dependent score bias ``(Q + v) @ R^T`` rel-
           shifted into ``(q_idx, kv_idx)`` coordinates — are precomputed into a
           ``(B, H, T, T)`` tensor, scaled by ``1/sqrt(D)`` (to match FlexAttention's
-          already-scaled ``QK^T`` scores), and stashed on ``self._rel_pos_bias``. The
-          bound closure ``self._rel_pos_score_mod`` reads that buffer while FlexAttention
-          is executing. The state-passing detour is necessary because FlexAttention's
-          ``score_mod`` API fixes the callable signature, so the per-forward tensor
-          cannot be threaded through as an explicit argument.
+          already-scaled ``QK^T`` scores), and captured by a local ``score_mod`` closure.
+          FlexAttention's ``score_mod`` API fixes the callable signature, so the per-forward
+          tensor is threaded in via closure capture rather than as an explicit argument.
+          Keeping it local (instead of on ``self``) lets the ``(B, H, T, T)`` bias be freed
+          as soon as the layer's attention call returns, so peak memory holds at most one
+          layer's bias rather than all layers' biases at once.
         - Matrix (c) — the global-content bias ``u @ K^T`` — is folded into FlexAttention
           by rewriting the query as ``Q + pos_bias_u``, which is returned.
 
@@ -234,9 +221,13 @@ class MultiHeadAttention(nn.Module):
         matrix_bd = torch.matmul(q_with_bias_v, p.transpose(-2, -1))  # (B, H, T, 2T - 1)
         # rel_shift converts absolute-relative-position columns into (query, key) columns;
         # keep the first T to land in (B, H, T, T) bias space.
-        self._rel_pos_bias = self._rel_shift(matrix_bd)[..., :T] * (D**-0.5)
+        rel_pos_bias = self._rel_shift(matrix_bd)[..., :T] * (D**-0.5)
+
+        def score_mod(score, b, h, q_idx, kv_idx):
+            return score + rel_pos_bias[b, h, q_idx, kv_idx]
+
         # Matrix c: fold u @ K^T into FlexAttention by rewriting Q as (Q + u).
-        return self._rel_pos_score_mod, q + bias_u
+        return score_mod, q + bias_u
 
     def forward(self, x, block_mask=None, pos_emb=None):
         B, T, _ = x.shape


### PR DESCRIPTION
# What does this PR do ?

Follow-up work after the TF encoder PR (https://github.com/NVIDIA-NeMo/NeMo/pull/15703).

Fixes a memory inefficiency in the ASR `TransformerEncoder`'s Transformer-XL relative positional encoding (`self_attention_model="rel_pos"`). The per-forward (b)+(d) positional bias — a `(B, H, T, T)` tensor — was stored on the module as `self._rel_pos_bias` and read by a bound `score_mod` method while FlexAttention executed. Because each encoder layer is its own attention instance and the attribute was never cleared, every layer's bias tensor stayed resident simultaneously until the next forward pass. Peak memory for the positional bias therefore scaled as `num_layers × (B·H·T²)` instead of `1 × (B·H·T²)`.

This is quadratic in sequence length *and* multiplied by layer count, so it dominates memory on long inputs (e.g. deep encoders run on long audio) and partially defeats FlexAttention, which is specifically designed to avoid materializing the `QK^T` score matrix.

The fix captures the bias as a local variable inside the `score_mod` closure instead of stashing it on `self`. Each layer's `(B, H, T, T)` bias is now freed as soon as that layer's attention call returns, so peak memory holds at most one layer's bias. The change is behavior-preserving and numerically identical — only the lifetime of the bias tensor changes.

**Collection**: ASR

# Changelog

- Replaced the module-level `self._rel_pos_bias` attribute and the bound `_rel_pos_score_mod` method with a `score_mod` closure that captures the `(B, H, T, T)` bias as a local in `_build_rel_pos_score_mod`.
- Each layer's relative-position bias is now released after its FlexAttention call instead of being retained across all layers, reducing peak `rel_pos` memory from `num_layers × (B·H·T²)` to `1 × (B·H·T²)`.
- Updated docstrings to reflect the closure-capture approach and the memory rationale.
- No change to numerics or public API; FlexAttention's fixed `score_mod(score, b, h, q_idx, kv_idx)` signature is still satisfied via closure capture.

# Usage
```python
from nemo.collections.asr.modules.transformer_encoder import TransformerEncoder

encoder = TransformerEncoder(
    feat_in=128,
    d_model=512,
    n_heads=8,
    n_layers=17,
    subsampling="feature_stacking",
    subsampling_factor=4,
    self_attention_model="rel_pos",  # one of "rel_pos" | "abs_pos" | "no_pos" (or None)
)

encoded, encoded_len = encoder(audio_signal=features, length=feature_lengths)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (Behavior-preserving change; covered by existing `rel_pos` encoder tests.)
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

Follow-up work after the TF encoder PR (https://github.com/NVIDIA-NeMo/NeMo/pull/15703).

The remaining `(B, H, T, T)` bias materialization is intrinsic to the Transformer-XL formulation (the rel-shifted `(Q + v) @ R^T` term). A future optimization could compute the bias analytically from `q_idx - kv_idx` inside `score_mod` so the full tensor is never materialized at all; that is a larger change and out of scope here.
