### PR TITLE
build: add managed = true to [tool.uv]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -424,6 +424,7 @@ markers = [
 version = { attr = "nemo.package_info.__version__" }
 
 [tool.uv]
+managed = true
 conflicts = [
     [
         { extra = "cu12" },


### PR DESCRIPTION
## Summary
- Adds `managed = true` to `[tool.uv]` in `pyproject.toml`, declaring that uv manages this project's environment

## Test plan
- No functional change; CI passes as-is