### PR TITLE
bf16/fp16 cache quantization for Cache Aware Pipelines

### DIFF
--- a/examples/asr/conf/asr_streaming_inference/cache_aware_ctc.yaml
+++ b/examples/asr/conf/asr_streaming_inference/cache_aware_ctc.yaml
@@ -74,6 +74,7 @@ streaming:
   att_context_size: [70,13]                   # Attention context size: [70,13],[70,6],[70,1],[70,0]
   use_cache: true                             # Whether to use cache for streaming
   use_feat_cache: true                        # Whether to cache mel-spec features, set false to re-calculate all mel-spec features in audio buffer
+  cache_dtype: bf16                           # Cache float precision: "fp32" (full) | "fp16" | "bf16" (2x compression)
   chunk_size_in_secs: null                    # Amount of audio to load for each streaming step, e.g., 0.08s for FastConformer. Set to `null` for using default size equal to 1+lookahead frames.
   request_type: frame                         # Type of request: frame or feature_buffer
   num_slots: 1024                             # Number of slots in the context manager: must be >= batch_size

--- a/examples/asr/conf/asr_streaming_inference/cache_aware_rnnt.yaml
+++ b/examples/asr/conf/asr_streaming_inference/cache_aware_rnnt.yaml
@@ -95,6 +95,7 @@ streaming:
   att_context_size: [70,13]                   # Attention context size: [70,13],[70,6],[70,1],[70,0]
   use_cache: true                             # Whether to use cache for streaming
   use_feat_cache: true                        # Whether to cache mel-spec features, set false to re-calculate all mel-spec features in audio buffer
+  cache_dtype: bf16                           # Cache float precision: "fp32" (full) | "fp16" | "bf16" (2x compression)
   chunk_size_in_secs: null                    # Amount of audio to load for each streaming step, e.g., 0.08s for FastConformer. Set to `null` for using default size equal to 1+lookahead frames.
   request_type: frame                         # Type of request: frame or feature_buffer
   num_slots: 256                             # Number of slots in the context manager: must be >= batch_size

--- a/nemo/collections/asr/inference/pipelines/base_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/base_pipeline.py
@@ -46,6 +46,7 @@ from nemo.collections.asr.inference.utils.pipeline_utils import (
 from nemo.collections.asr.inference.utils.progressbar import ProgressBar
 from nemo.collections.asr.inference.utils.text_segment import TextSegment
 from nemo.collections.common.tokenizers.tokenizer_spec import TokenizerSpec
+from nemo.utils import logging
 
 if TYPE_CHECKING:
     from nemo.collections.asr.inference.itn.inverse_normalizer import AlignmentPreservingInverseNormalizer
@@ -478,12 +479,15 @@ class BasePipeline(PipelineInterface):
     def init_context_manager(self) -> None:
         """Initialize the context manager."""
         check_existance_of_required_attributes(self, ['asr_model', 'num_slots', 'use_cache'])
+        cache_dtype = getattr(self, 'cache_dtype', 'bf16')
+        model_dtype = getattr(self.asr_model, 'compute_dtype', None)
+        logging.info(f"Cache-aware streaming: cache dtype = {cache_dtype}, model compute dtype = {model_dtype}")
         self.context_manager = CacheAwareContextManager(
             cache_aware_model=self.asr_model,
             num_slots=self.num_slots,
             use_cache=self.use_cache,
-            cache_dtype=getattr(self, 'cache_dtype', 'bf16'),
-            working_dtype=getattr(self.asr_model, 'compute_dtype', None),
+            cache_dtype=cache_dtype,
+            working_dtype=model_dtype,
         )
 
     def init_prompt_support(self) -> None:

--- a/nemo/collections/asr/inference/pipelines/base_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/base_pipeline.py
@@ -479,7 +479,11 @@ class BasePipeline(PipelineInterface):
         """Initialize the context manager."""
         check_existance_of_required_attributes(self, ['asr_model', 'num_slots', 'use_cache'])
         self.context_manager = CacheAwareContextManager(
-            cache_aware_model=self.asr_model, num_slots=self.num_slots, use_cache=self.use_cache
+            cache_aware_model=self.asr_model,
+            num_slots=self.num_slots,
+            use_cache=self.use_cache,
+            cache_dtype=getattr(self, 'cache_dtype', 'bf16'),
+            working_dtype=getattr(self.asr_model, 'compute_dtype', None),
         )
 
     def init_prompt_support(self) -> None:

--- a/nemo/collections/asr/inference/pipelines/cache_aware_ctc_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_ctc_pipeline.py
@@ -88,6 +88,7 @@ class CacheAwareCTCPipeline(BasePipeline):
 
         self.use_cache = cfg.streaming.use_cache
         self.use_feat_cache = cfg.streaming.use_feat_cache
+        self.cache_dtype = cfg.streaming.get("cache_dtype", "bf16")
         self.batch_size = cfg.streaming.batch_size
         self.num_slots = cfg.streaming.num_slots
         if self.num_slots < self.batch_size:

--- a/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
@@ -96,6 +96,7 @@ class CacheAwareRNNTPipeline(BasePipeline):
 
         self.use_cache = cfg.streaming.use_cache
         self.use_feat_cache = cfg.streaming.use_feat_cache
+        self.cache_dtype = cfg.streaming.get("cache_dtype", "bf16")
 
         if cfg.streaming.get("chunk_size_in_secs", None) is not None:
             self.chunk_size_in_secs = cfg.streaming.chunk_size_in_secs

--- a/nemo/collections/asr/inference/utils/cache.py
+++ b/nemo/collections/asr/inference/utils/cache.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import torch
+from torch import Tensor
+
+
+class CastCache:
+    """Per-slot storage for a Cache-Aware `cache_last_channel` / `cache_last_time` tensor,
+    held at a chosen float precision.
+
+    The cache is stored as the underlying [L, B, T, D] tensor cast to `storage_dtype`; the
+    slot dimension is dim 1. Three float precisions are supported:
+
+    - `torch.float32`: an identity cast, i.e. full precision (no compression).
+    - `torch.float16` / `torch.bfloat16`: 2x compression versus fp32.
+
+    `source_dtype` is the dtype `gather_slots` returns (the precision the encoder consumes).
+    It defaults to the seed tensor's dtype but can be set explicitly so the cache round-trips
+    at the model's compute precision (e.g. bf16) instead of the fp32 seed, which makes a bf16
+    cast cache an effectively lossless, half-memory no-op round trip.
+    """
+
+    def __init__(self, tensor: Tensor, storage_dtype: torch.dtype, source_dtype: torch.dtype | None = None):
+        """
+        Args:
+            tensor (Tensor): initial cache tensor of shape [L, B, T, D].
+            storage_dtype (torch.dtype): dtype used for backing storage (e.g. torch.bfloat16).
+            source_dtype (torch.dtype | None): dtype returned by `gather_slots`. Defaults to
+                `tensor.dtype`.
+        """
+        self._source_dtype = source_dtype if source_dtype is not None else tensor.dtype
+        self._data = tensor.to(storage_dtype)
+        self._gather_buf: Tensor | None = None
+
+    @classmethod
+    def empty(
+        cls,
+        shape: tuple[int, ...],
+        source_dtype: torch.dtype,
+        storage_dtype: torch.dtype,
+        device: torch.device,
+    ) -> "CastCache":
+        """Construct a zero-valued cast cache without materialising the full-precision tensor."""
+        obj = cls.__new__(cls)
+        obj._source_dtype = source_dtype
+        obj._data = torch.zeros(shape, dtype=storage_dtype, device=device)
+        obj._gather_buf = None
+        return obj
+
+    def _storage_gather_buf(self, shape: torch.Size) -> Tensor:
+        # Reusable storage-dtype scratch for index_select, sized to the current gather.
+        if self._gather_buf is None or self._gather_buf.shape != shape:
+            self._gather_buf = torch.empty(shape, dtype=self._data.dtype, device=self._data.device)
+        return self._gather_buf
+
+    @property
+    def device(self) -> torch.device:
+        """Device on which the underlying storage lives."""
+        return self._data.device
+
+    def reset_slots(self, slot_ids: Tensor) -> None:
+        """
+        Zero out the given slots along the slot dimension (dim 1), in place.
+        Args:
+            slot_ids (Tensor): 1-D long tensor of slot indices to zero.
+        """
+        self._data.index_fill_(1, slot_ids, 0)
+
+    def update_slots(self, dst_slot_ids: Tensor, src: Tensor, src_slot_ids: Tensor) -> None:
+        """
+        Copy `src[:, src_slot_ids]` into `self[:, dst_slot_ids]` along the slot dimension, in place.
+        Args:
+            dst_slot_ids (Tensor): 1-D long tensor of destination slot indices.
+            src (Tensor): raw float tensor of shape [L, B, T, D] supplying new values.
+            src_slot_ids (Tensor): 1-D long tensor of source slot indices into `src`.
+        """
+        src_slice = src.index_select(1, src_slot_ids).to(self._data.dtype)
+        self._data.index_copy_(1, dst_slot_ids, src_slice)
+
+    def gather_slots(self, slot_ids: list[int], out: Tensor | None = None) -> Tensor:
+        """
+        Return the float tensor for the requested slots, in the source dtype.
+        Args:
+            slot_ids (list[int]): slot indices to gather.
+            out (Tensor | None): optional preallocated buffer of shape [L, len(slot_ids), T, D]
+                in the source dtype. When provided with a matching shape it is written in place
+                to avoid a per-step allocation on the streaming hot path. Callers MUST use the
+                returned tensor rather than assuming `out` was written.
+        Returns:
+            Tensor of shape [L, len(slot_ids), T, D] in the source dtype.
+        """
+        if out is None:
+            return self._data[:, slot_ids, :, :].to(self._source_dtype)
+        idx = torch.as_tensor(slot_ids, device=self._data.device, dtype=torch.long)
+        buf = self._storage_gather_buf(out.shape)
+        torch.index_select(self._data, 1, idx, out=buf)
+        out.copy_(buf)  # casts storage_dtype -> source_dtype in place
+        return out
+
+    def storage_nbytes(self) -> int:
+        """Total bytes occupied by the underlying storage tensor (excludes Python overhead)."""
+        return self._data.element_size() * self._data.numel()

--- a/nemo/collections/asr/inference/utils/context_manager.py
+++ b/nemo/collections/asr/inference/utils/context_manager.py
@@ -19,6 +19,16 @@ from typing import Any
 import torch
 from torch import Tensor
 
+from nemo.collections.asr.inference.utils.cache import CastCache
+
+
+_CAST_DTYPES: dict[str, torch.dtype] = {
+    "fp32": torch.float32,
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+}
+_VALID_CACHE_DTYPES = tuple(_CAST_DTYPES)
+
 
 class CacheAwareContext:
     """
@@ -52,6 +62,8 @@ class CacheAwareContextManager:
         cache_aware_model: Any,
         num_slots: int,
         use_cache: bool = True,
+        cache_dtype: str = "bf16",
+        working_dtype: torch.dtype | None = None,
     ):
         """
         Initialize the CacheAwareContextManager.
@@ -59,7 +71,16 @@ class CacheAwareContextManager:
             cache_aware_model (Any): Cache-Aware model object. It should have the get_initial_cache_state method.
             num_slots (int): Number of slots to use for the cache. It should be greater than or equal to the batch size.
             use_cache (bool): Whether to use the cache. Default is True. If False, the cache is disabled.
+            cache_dtype (str): Float precision for the backing storage of `cache_last_channel` /
+                `cache_last_time`. One of "fp32" (full precision), "fp16" or "bf16" (2x compression).
+                `cache_last_channel_len` is always stored raw. Default "bf16".
+            working_dtype (torch.dtype | None): dtype the caches return on gather, i.e. the
+                precision the encoder consumes. Defaults to the initial cache dtype (fp32) when
+                None. Set to the model compute dtype (e.g. bf16) so a "bf16" cache is a lossless,
+                half-memory no-op round trip.
         """
+        if cache_dtype not in _VALID_CACHE_DTYPES:
+            raise ValueError(f"cache_dtype must be one of {_VALID_CACHE_DTYPES}, got {cache_dtype!r}")
         self.cache_aware_model = cache_aware_model
         # Cache aware model should have the following methods:
         if not hasattr(self.cache_aware_model, "get_initial_cache_state"):
@@ -67,9 +88,14 @@ class CacheAwareContextManager:
 
         self.num_slots = num_slots
         self.cache_disabled = not use_cache
-        self.cache_last_channel = None
-        self.cache_last_time = None
+        self.cache_dtype = cache_dtype
+        self.working_dtype = working_dtype
+        self.cache_last_channel: CastCache | None = None
+        self.cache_last_time: CastCache | None = None
         self.cache_last_channel_len = None
+        # Reusable gather output buffers, refreshed when the active-slot count changes.
+        self._channel_gather_buf: Tensor | None = None
+        self._time_gather_buf: Tensor | None = None
         self.reset()
 
     def reset(self) -> None:
@@ -82,11 +108,35 @@ class CacheAwareContextManager:
         self.free_slots = Queue(self.num_slots)
         for i in range(self.num_slots):
             self.free_slots.put(i)
+        self._channel_gather_buf = None
+        self._time_gather_buf = None
         (
-            self.cache_last_channel,  # [17, B, 70, 512]
-            self.cache_last_time,  # [17, B, 512, 8]
+            initial_cache_last_channel,  # [17, B, 70, 512]
+            initial_cache_last_time,  # [17, B, 512, 8]
             self.cache_last_channel_len,  # B
         ) = self.cache_aware_model.get_initial_cache_state(self.num_slots)
+
+        # Caches return `working_dtype` (the compute precision) on gather when set, else the fp32 seed.
+        channel_source_dtype = self.working_dtype or initial_cache_last_channel.dtype
+        time_source_dtype = self.working_dtype or initial_cache_last_time.dtype
+
+        # `cache_dtype` is validated to be one of fp32/fp16/bf16, so a CastCache always applies.
+        storage_dtype = _CAST_DTYPES[self.cache_dtype]
+        self.cache_last_channel = CastCache.empty(
+            shape=tuple(initial_cache_last_channel.shape),
+            source_dtype=channel_source_dtype,
+            storage_dtype=storage_dtype,
+            device=initial_cache_last_channel.device,
+        )
+        self.cache_last_time = CastCache.empty(
+            shape=tuple(initial_cache_last_time.shape),
+            source_dtype=time_source_dtype,
+            storage_dtype=storage_dtype,
+            device=initial_cache_last_time.device,
+        )
+        del initial_cache_last_channel
+        del initial_cache_last_time
+
         self.device = self.cache_last_channel.device
 
     def _reset_slots(self, slot_ids: list[int]) -> None:
@@ -99,8 +149,8 @@ class CacheAwareContextManager:
             return
 
         slot_ids_tensor = torch.tensor(slot_ids, device=self.device, dtype=torch.long)
-        self.cache_last_channel.index_fill_(1, slot_ids_tensor, 0.0)
-        self.cache_last_time.index_fill_(1, slot_ids_tensor, 0.0)
+        self.cache_last_channel.reset_slots(slot_ids_tensor)
+        self.cache_last_time.reset_slots(slot_ids_tensor)
         self.cache_last_channel_len.index_fill_(0, slot_ids_tensor, 0)
 
         # free the slot, so that it can be used by other streams
@@ -131,11 +181,25 @@ class CacheAwareContextManager:
         )
 
         # In-place copy along batch/slot dimension
-        self.cache_last_channel.index_copy_(1, slot_ids, new_context.cache_last_channel.index_select(1, tgt_slot_ids))
-        self.cache_last_time.index_copy_(1, slot_ids, new_context.cache_last_time.index_select(1, tgt_slot_ids))
+        self.cache_last_channel.update_slots(slot_ids, new_context.cache_last_channel, tgt_slot_ids)
+        self.cache_last_time.update_slots(slot_ids, new_context.cache_last_time, tgt_slot_ids)
         self.cache_last_channel_len.index_copy_(
             0, slot_ids, new_context.cache_last_channel_len.index_select(0, tgt_slot_ids)
         )
+
+    def _gather_reuse(self, cache: CastCache, slot_ids: list[int], buf_attr: str) -> Tensor:
+        """Gather slots, reusing a persistent output buffer when the active-slot count is stable.
+
+        The buffer is the tensor handed to the previous step's context; the encoder has finished
+        reading it by the time the next gather runs, so writing into it in place is safe. The
+        buffer is rebuilt whenever the number of active slots changes.
+        """
+        buf = getattr(self, buf_attr)
+        if buf is not None and buf.shape[1] == len(slot_ids):
+            return cache.gather_slots(slot_ids, out=buf)
+        result = cache.gather_slots(slot_ids)
+        setattr(self, buf_attr, result)
+        return result
 
     def reset_slots(self, stream_ids: list[int], eos_flags: list[bool]) -> None:
         """
@@ -181,8 +245,8 @@ class CacheAwareContextManager:
 
         # get the cache for the particular stream_ids
         slot_ids = [self.streamidx2slotidx[stream_id] for stream_id in stream_ids]
-        cache_last_channel = self.cache_last_channel[:, slot_ids, :, :]
-        cache_last_time = self.cache_last_time[:, slot_ids, :, :]
+        cache_last_channel = self._gather_reuse(self.cache_last_channel, slot_ids, "_channel_gather_buf")
+        cache_last_time = self._gather_reuse(self.cache_last_time, slot_ids, "_time_gather_buf")
         cache_last_channel_len = self.cache_last_channel_len[slot_ids]
 
         # create a context object

--- a/tests/collections/asr/inference/test_cache.py
+++ b/tests/collections/asr/inference/test_cache.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo.collections.asr.inference.utils.cache import CastCache
+
+# Cache tensors are [L, B, T, D] with the slot dimension on dim 1.
+_L, _B, _T, _D = 2, 4, 3, 8
+
+# Reconstruction tolerance (max abs error) per storage dtype.
+_CAST_BOUND = {torch.float32: 0.0, torch.float16: 0.05, torch.bfloat16: 0.05}
+
+
+def _make_x(seed: int = 0) -> torch.Tensor:
+    """Random fp32 cache tensor of shape [L, B, T, D]."""
+    torch.manual_seed(seed)
+    return torch.randn(_L, _B, _T, _D)
+
+
+def _rel_err(out: torch.Tensor, ref: torch.Tensor, vec_axis: int = 3) -> float:
+    """Max per-vector reconstruction error relative to the vector's absmax."""
+    denom = ref.abs().amax(dim=vec_axis, keepdim=True).clamp_min(1e-9)
+    return ((out - ref).abs() / denom).max().item()
+
+
+def _assert_slot_ops(cache, src: torch.Tensor, bound: float) -> None:
+    """Shared assertions for update_slots / reset_slots / gather_slots ordering.
+
+    `cache` must start zero-valued with _B slots. Copies src slots [0, 1] into cache
+    slots [1, 2], checks reconstruction, then resets slot 1 and verifies slot 2 survives.
+    """
+    dst_ids = torch.tensor([1, 2])
+    src_ids = torch.tensor([0, 1])
+    cache.update_slots(dst_ids, src, src_ids)
+
+    out = cache.gather_slots([1, 2])
+    ref = src.index_select(1, src_ids)
+    assert out.shape == ref.shape
+    assert _rel_err(out, ref) <= bound + 1e-4
+
+    # Slot 0 was never written, so it stays at its zero init.
+    assert torch.count_nonzero(cache.gather_slots([0])) == 0
+
+    cache.reset_slots(torch.tensor([1]))
+    assert torch.count_nonzero(cache.gather_slots([1])) == 0
+    # Slot 2 (holding src slot 1) must be untouched by resetting slot 1.
+    assert torch.count_nonzero(cache.gather_slots([2])) > 0
+
+
+def _assert_gather_out_matches(cache, slot_ids: list[int]) -> None:
+    """`gather_slots(out=buf)` must write into `buf` and match the freshly-allocated gather."""
+    ref = cache.gather_slots(slot_ids)
+    buf = torch.empty_like(ref)
+    got = cache.gather_slots(slot_ids, out=buf)
+    assert got.data_ptr() == buf.data_ptr()  # result was written into the provided buffer
+    assert got.dtype == ref.dtype
+    assert torch.equal(got, ref)
+
+
+class TestCastCache:
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_round_trip(self, dtype):
+        x = _make_x()
+        cache = CastCache(x, dtype)
+        out = cache.gather_slots(list(range(_B)))
+        assert out.shape == x.shape
+        assert out.dtype == x.dtype  # gather returns the source dtype
+        assert (out - x).abs().max().item() <= _CAST_BOUND[dtype]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_empty_is_zero(self, dtype):
+        cache = CastCache.empty(
+            (_L, _B, _T, _D), source_dtype=torch.float32, storage_dtype=dtype, device=torch.device("cpu")
+        )
+        assert torch.count_nonzero(cache.gather_slots(list(range(_B)))) == 0
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_slot_ops(self, dtype):
+        cache = CastCache.empty(
+            (_L, _B, _T, _D), source_dtype=torch.float32, storage_dtype=dtype, device=torch.device("cpu")
+        )
+        _assert_slot_ops(cache, _make_x(seed=2), bound=_CAST_BOUND[dtype])
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("dtype,bytes_per_elem", [(torch.float32, 4), (torch.float16, 2), (torch.bfloat16, 2)])
+    def test_storage_nbytes(self, dtype, bytes_per_elem):
+        cache = CastCache(_make_x(), dtype)
+        assert cache.storage_nbytes() == bytes_per_elem * (_L * _B * _T * _D)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+    def test_gather_out_buffer(self, dtype):
+        cache = CastCache(_make_x(), dtype)
+        _assert_gather_out_matches(cache, [2, 0, 1])
+
+    @pytest.mark.unit
+    def test_source_dtype_overrides_seed(self):
+        # bf16 working dtype + bf16 storage is a lossless, no-cast round trip.
+        x = _make_x()  # fp32 seed
+        cache = CastCache(x, torch.bfloat16, source_dtype=torch.bfloat16)
+        out = cache.gather_slots(list(range(_B)))
+        assert out.dtype == torch.bfloat16
+        assert torch.equal(out, x.to(torch.bfloat16))


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Stores the cache-aware streaming cache (`cache_last_channel` / `cache_last_time`) in `bf16` instead of fp32, cutting cache GPU memory by **2x**.

**Collection**: [ASR]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

```python
python3 asr_streaming_infer.py \
    --config-path=../conf/asr_streaming_inference/ \
    --config-name=cache_aware_rnnt.yaml \
    asr.model_name=nvidia/nemotron-speech-streaming-en-0.6b \
    audio_file=sample.wav \
    output_filename=out.json \
    streaming.cache_dtype=bf16        # or fp16 / fp32
```

# Details

**Key Results:**

- fp16/bf16 reduce cache memory by 50% versus fp32 (936 MB vs. 1872 MB) with essentially no WER degradation.
- Reduced precision also improves speed: fp16/bf16 consistently achieve higher RTFX than fp32, with bf16 slightly fastest in most settings. This also revealed a bug in the current CacheAwarePipeline: the model runs in bf16 by default, but the cache is kept in fp32, causing repeated type casts during inference. Changing the cache dtype to bf16 improves RTFX with no WER degradation while also providing 2x cache memory savings.

| Method | Att Context Size | NUM SLOTS | BATCH SIZE | BITS | Cache Total (MB) | Cache Last Channel (MB) | Cache Last Time (MB) | Comp Ratio | AMI | E22 | LS CLEAN | LS OTHER | TED | VOX | AVG. | RTFX (LS-OTHER) |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| fp32 | [70, 13] | 256 | 64 | 32 | 1872 | 1680 | 192 | 1 | 14.91% | 19.86% | 5.28% | 8.26% | 12.03% | 11.13% | 11.91% | 367 |
| fp16 | [70, 13] | 256 | 64 | 16 | 936 | 840 | 96 | 2 | 14.91% | 19.87% | 5.29% | 8.25% | 12.05% | 11.13% | 11.92% | 412 |
| bf16 | [70, 13] | 256 | 64 | 16 | 936 | 840 | 96 | 2 | 14.91% | 19.86% | 5.28% | 8.26% | 12.03% | 11.13% | 11.91% | 414 |
| fp32 | [70, 6] | 256 | 64 | 32 | 1872 | 1680 | 192 | 1 | 15.06% | 20.01% | 5.38% | 8.49% | 12.02% | 11.23% | 12.03% | 246 |
| fp16 | [70, 6] | 256 | 64 | 16 | 936 | 840 | 96 | 2 | 15.05% | 20.01% | 5.38% | 8.50% | 12.00% | 11.24% | 12.03% | 273 |
| bf16 | [70, 6] | 256 | 64 | 16 | 936 | 840 | 96 | 2 | 15.06% | 20.01% | 5.38% | 8.49% | 12.02% | 11.23% | 12.03% | 282 |
| fp32 | [70, 1] | 256 | 64 | 32 | 1872 | 1680 | 192 | 1 | 17.08% | 20.48% | 5.57% | 8.91% | 12.30% | 11.56% | 12.65% | 103 |
| fp16 | [70, 1] | 256 | 64 | 16 | 936 | 840 | 96 | 2 | 17.03% | 20.45% | 5.56% | 8.90% | 12.31% | 11.55% | 12.63% | 105 |
| bf16 | [70, 1] | 256 | 64 | 16 | 936 | 840 | 96 | 2 | 17.08% | 20.48% | 5.57% | 8.91% | 12.30% | 11.56% | 12.65% | 108 |
| fp32 | [70, 0] | 256 | 64 | 32 | 1872 | 1680 | 192 | 1 | 20.29% | 21.01% | 6.06% | 9.80% | 12.61% | 12.70% | 13.74% | 62 |
| fp16 | [70, 0] | 256 | 64 | 16 | 936 | 840 | 96 | 2 | 20.29% | 21.00% | 6.04% | 9.81% | 12.65% | 12.73% | 13.75% | 63 |
| bf16 | [70, 0] | 256 | 64 | 16 | 936 | 840 | 96 | 2 | 20.29% | 21.01% | 6.06% | 9.80% | 12.61% | 12.70% | 13.74% | 63 |

**Experiments done on NVIDIA RTX 5000 Ada GPU**
# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
