### PR TITLE
add soe fixes in documentation

### DIFF
--- a/docs/source/asr/asr_checkpoints.rst
+++ b/docs/source/asr/asr_checkpoints.rst
@@ -172,10 +172,10 @@ Cache-aware models for real-time / low-latency inference.
      - Capabilities
      - Language
      - Size
-   * - `nemotron-speech-streaming-en-0.6b <https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b>`__
+   * - `nemotron-3.5-asr-streaming-0.6b <https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b>`__
      - Hybrid
      - ASR, streaming
-     - English
+     - 40 languages
      - 0.6B
    * - `multitalker-parakeet-streaming-0.6b-v1 <https://huggingface.co/nvidia/multitalker-parakeet-streaming-0.6b-v1>`__
      - RNN-T

--- a/docs/source/asr/featured_models.rst
+++ b/docs/source/asr/featured_models.rst
@@ -13,7 +13,7 @@ Parakeet is a family of ASR models with a :ref:`FastConformer Encoder <Fast-Conf
 * `Parakeet-TDT-0.6B V3 <https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3>`__ — 25 languages, PnC, blazing fast
 * `Parakeet-TDT-0.6B V2 <https://huggingface.co/nvidia/parakeet-tdt-0.6b-v2>`__ — English-only, PnC, blazing fast
 * `Parakeet-TDT/CTC-110M <https://huggingface.co/nvidia/parakeet-tdt_ctc-110m>`__ — Edge deployment
-* `Nemotron-Speech-Streaming <https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b>`__ — Real-time streaming
+* `Nemotron-3.5-ASR-Streaming <https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b>`__ — Real-time streaming, 40 languages
 * `Multitalker-Parakeet <https://huggingface.co/nvidia/multitalker-parakeet-streaming-0.6b-v1>`__ — Multi-speaker streaming
 
 

--- a/docs/source/asr/fine_tuning.rst
+++ b/docs/source/asr/fine_tuning.rst
@@ -19,6 +19,12 @@ Fine-tuning is recommended when:
 If you have a large, diverse dataset and want to train from scratch, see :doc:`Configuration Files <./configs>` for full training setup.
 
 
+Working with an agent?
+----------------------
+
+Check out our latest ``/nemo-speech-finetune-asr`` `agent skill <https://github.com/NVIDIA-NeMo/NeMo/tree/main/.claude/skills/nemo-speech-asr-finetune>`_.
+
+
 Fine-Tuning Script
 ------------------
 

--- a/docs/source/checkpoints/intro.rst
+++ b/docs/source/checkpoints/intro.rst
@@ -1,5 +1,5 @@
-Checkpoints
-===========
+Checkpoint Formats
+==================
 
 In this section, we present the checkpoint formats supported by NVIDIA NeMo.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -70,6 +70,12 @@ Get started in 30 seconds:
    print(model.transcribe(["audio.wav"])[0].text)
 
 
+Trying to finetune a model?
+---------------------------
+
+Check out our latest ``/nemo-speech-finetune-asr`` `agent skill <https://github.com/NVIDIA-NeMo/NeMo/tree/main/.claude/skills/nemo-speech-asr-finetune>`_.
+
+
 .. toctree::
    :maxdepth: 1
    :caption: Getting Started
@@ -89,19 +95,7 @@ Get started in 30 seconds:
 
    features/parallelisms
    features/mixed_precision
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Model Checkpoints
-   :name: Checkpoints
-
    checkpoints/intro
-
-.. toctree::
-   :maxdepth: 1
-   :caption: Lhotse Dataloading
-   :name: Lhotse Dataloading
-
    dataloaders
 
 .. toctree::

--- a/docs/source/starthere/choosing_a_model.rst
+++ b/docs/source/starthere/choosing_a_model.rst
@@ -25,8 +25,8 @@ ASR: Which Model Should I Use?
      - `Parakeet-TDT 0.6B V3 <https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3>`_
      - 25 European languages in one model; automatic language detection; punctuation, capitalization, and word/segment timestamps; long-form and streaming options. No speech-to-text translation—use Canary-1B V2 if you need translation.
    * - Stream audio in real-time
-     - `Nemotron-Speech-Streaming <https://huggingface.co/nvidia/nemotron-speech-streaming-en-0.6b>`_
-     - Low-latency streaming English ASR with configurable chunk sizes. Cache-aware FastConformer + RNN-T.
+     - `Nemotron-3.5-ASR-Streaming <https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b>`_
+     - Low-latency streaming ASR with 40 languages, controllable latency (80ms–1s), and configurable chunk sizes. Cache-aware FastConformer.
    * - Minimize model size
      - `Canary-180M Flash <https://huggingface.co/nvidia/canary-180m-flash>`_
      - Smallest multilingual model. Good for edge deployment.
@@ -96,33 +96,6 @@ Speech Language Models: Which Model Should I Use?
    * - Build a speech-to-speech system
      - DuplexS2SModel
      - Full-duplex model that both understands and generates speech.
-
-
-Decision Flowchart
-------------------
-
-.. code-block:: text
-
-   What do you want to do?
-   │
-   ├─ Transcribe speech to text (ASR)
-   │  ├─ Best accuracy on English? → Canary-Qwen 2.5B (or Parakeet-TDT V2/V3 for fast offline)
-   │  ├─ Multiple languages + translation? → Canary-1B V2
-   │  ├─ European multilingual ASR (auto LID)? → Parakeet-TDT 0.6B V3
-   │  ├─ Stream audio in real-time? → Nemotron-Speech-Streaming
-   │  └─ Multi-speaker meeting? → Multitalker Parakeet Streaming
-   │
-   ├─ Generate speech from text (TTS)
-   │  ├─ Multilingual / voice cloning? → MagpieTTS
-   │  └─ English with pitch control? → FastPitch + HiFi-GAN
-   │
-   ├─ Identify speakers
-   │  ├─ Who spoke when? → Streaming Sortformer or Offline Sortformer
-   │  └─ Verify identity? → TitaNet
-   │
-   ├─ Enhance audio quality → See Audio Processing models
-   │
-   └─ Speech-aware LLM → Canary-Qwen 2.5B (SALM)
 
 
 Where to Find Models


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Reorganizes the docs sidebar, refreshes streaming ASR model references, removes the outdated model-selection flowchart, and links to the NeMo ASR fine-tuning agent skill.

**Collection**: Documentation (Getting Started, Training, ASR)

# Changelog

- **Sidebar / navigation** (`docs/source/index.rst`): Removed top-level **Model Checkpoints** and **Lhotse Dataloading** sections; moved `checkpoints/intro` and `dataloaders` under **Training** alongside Parallelisms and Mixed Precision Training.
- **Checkpoint Formats** (`docs/source/checkpoints/intro.rst`): Renamed page title from "Checkpoints" to "Checkpoint Formats".
- **Choosing a Model** (`docs/source/starthere/choosing_a_model.rst`): Removed the ASCII decision flowchart; updated the real-time streaming recommendation to **Nemotron-3.5-ASR-Streaming** (40 languages, updated Hugging Face link).
- **ASR checkpoints & featured models** (`docs/source/asr/asr_checkpoints.rst`, `docs/source/asr/featured_models.rst`): Replaced `nemotron-speech-streaming-en-0.6b` with `nemotron-3.5-asr-streaming-0.6b`.
- **Agent skill callouts**: Added **Trying to finetune a model?** section on the docs homepage and **Working with an agent?** section on the ASR fine-tuning page, linking to [`.claude/skills/nemo-speech-asr-finetune`](https://github.com/NVIDIA-NeMo/NeMo/tree/main/.claude/skills/nemo-speech-asr-finetune).

# Usage

Docs-only change. To preview locally:

```bash
pip install nvidia-sphinx-theme sphinx sphinxcontrib-bibtex sphinx-copybutton sphinxext-opengraph
make -C docs html
open docs/build/html/index.html
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
