### PR TITLE
fix: Secure tar archive extraction

### DIFF
--- a/nemo/collections/asr/parts/mixins/mixins.py
+++ b/nemo/collections/asr/parts/mixins/mixins.py
@@ -16,6 +16,7 @@ import json
 import os
 import tarfile
 from abc import ABC, abstractmethod
+from pathlib import PurePosixPath
 from typing import List
 
 import torch
@@ -59,6 +60,14 @@ class ASRBPEMixin(ABC):
 
     # this will be used in configs and nemo artifacts
     AGGREGATE_TOKENIZERS_DICT_PREFIX = 'langs'
+
+    @staticmethod
+    def _get_extracted_tokenizer_name(member_name: str) -> str:
+        member_file_name = PurePosixPath(member_name).name
+        new_name = member_file_name.split("_")[1:]
+        if len(new_name) > 1:
+            return "_".join(new_name)
+        return new_name[0]
 
     def _setup_tokenizer(self, tokenizer_cfg: DictConfig):
         tokenizer_type = tokenizer_cfg.get('type')
@@ -472,11 +481,7 @@ class ASRBPEMixin(ABC):
                     members = [x for x in tar.getmembers() if nemo_object_name in x.name]
                     extracted_members = SaveRestoreConnector._safe_extract(tar, dir, members=members)
                     for member in extracted_members:
-                        new_name = member.name.split("_")[1:]
-                        if len(new_name) > 1:
-                            new_name = "_".join(new_name)
-                        else:
-                            new_name = new_name[0]
+                        new_name = self._get_extracted_tokenizer_name(member.name)
                         os.rename(os.path.join(dir, member.name), os.path.join(dir, new_name))
 
                         logging.info(f"Saved {nemo_object_name} at {os.path.join(dir, new_name)}")

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -36,6 +36,7 @@ from nemo.utils.file_utils import robust_copy
 from nemo.utils.get_rank import is_global_rank_zero
 from nemo.utils.model_utils import inject_model_parallel_rank
 from nemo.utils.msc_utils import import_multistorageclient, is_multistorageclient_url
+from nemo.utils.tar_utils import is_safe_tar_member, safe_extract
 
 
 class SaveRestoreConnector:
@@ -630,34 +631,11 @@ class SaveRestoreConnector:
 
     @staticmethod
     def _is_safe_path(member, extract_to):
-        # Check for path traversal characters or absolute paths
-        member_path = os.path.normpath(member.name)
-        # Ensure the path does not start with a slash or contain ".." after normalization
-        if os.path.isabs(member_path) or ".." in member_path.split(os.sep):
-            return False
-        # Construct the full path where the member would be extracted
-        full_path = os.path.join(extract_to, member_path)
-        # Ensure the member would be extracted within the intended directory
-        if os.path.commonprefix([full_path, extract_to]) != extract_to:
-            return False
-        # Check if the member is a symbolic link
-        if member.issym() or member.islnk():
-            return False
-        return True
+        return is_safe_tar_member(member, os.path.realpath(extract_to))
 
     @staticmethod
     def _safe_extract(tar, out_folder: str, members=None):
-        extract_to = os.path.realpath(out_folder)
-        if members is None:
-            members = tar.getmembers()
-        extracted_members = []
-        for member in members:
-            if SaveRestoreConnector._is_safe_path(member, extract_to):
-                tar.extract(member, extract_to)
-                extracted_members.append(member)
-            else:
-                logging.warning(f"Skipping potentially unsafe member: {member.name}")
-        return extracted_members
+        return safe_extract(tar, out_folder, members=members, skip_unsafe=True)
 
     @staticmethod
     def _filtered_tar_info(tar_path: str, filter_fn: Optional[Callable[[str], bool]] = None) -> list[tarfile.TarInfo]:

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -23,7 +23,7 @@ import tempfile
 from dataclasses import dataclass, is_dataclass
 from enum import Enum
 from functools import lru_cache
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, List, Optional, Tuple, Type, Union
 
 import wrapt
@@ -36,6 +36,7 @@ from nemo.utils.data_utils import (  # imported for compatibility: model_utils.r
     is_datastore_path,
     resolve_cache_dir,
 )
+from nemo.utils.tar_utils import TarPathTraversalError, safe_extract
 
 if TYPE_CHECKING:
     import lightning.pytorch as pl
@@ -82,7 +83,7 @@ def load_config(model_file: str) -> DictConfig:
     if os.path.isfile(model_file):
         with tempfile.TemporaryDirectory() as tmp, tarfile.open(model_file, "r:") as tar:
             prefix = detect_prefix(tar.getnames())
-            tar.extract(f"{prefix}{MODEL_CONFIG}", path=tmp)
+            safe_extract(tar, tmp, members=[f"{prefix}{MODEL_CONFIG}"])
             model_config = OmegaConf.load(os.path.join(tmp, MODEL_CONFIG))
     elif os.path.isdir(model_file):
         model_config = OmegaConf.load(os.path.join(model_file, MODEL_CONFIG))
@@ -90,6 +91,13 @@ def load_config(model_file: str) -> DictConfig:
         raise FileNotFoundError(model_file)
 
     return model_config
+
+
+def _validate_artifact_path(path: str) -> PurePosixPath:
+    artifact_path = PurePosixPath(path)
+    if artifact_path.is_absolute() or ".." in artifact_path.parts:
+        raise TarPathTraversalError(f"Unsafe artifact path: {path}")
+    return artifact_path
 
 
 def unwrap_model(model, module_instances: Optional[Union[Type, Tuple[Type]]] = None):
@@ -743,12 +751,14 @@ def save_artifacts(model, output_dir: str, use_abspath: bool = False) -> None:
             prefix = detect_prefix(maybe_tar.getnames())
         for arti_name, arti_item in model.artifacts.items():
             _, arti_file = arti_item.path.split("nemo:")
+            artifact_path = _validate_artifact_path(arti_file)
             arti_path = os.path.join(output_dir, arti_name)
             if maybe_tar is not None:
-                maybe_tar.extract(f"{prefix}{arti_file}", path=output_dir)
-                os.rename(os.path.join(output_dir, arti_file), arti_path)
+                member_name = f"{prefix}{artifact_path.as_posix()}"
+                safe_extract(maybe_tar, output_dir, members=[member_name])
+                os.rename(os.path.join(output_dir, *PurePosixPath(member_name).parts), arti_path)
             else:
-                shutil.copy(os.path.join(model_file, arti_file), arti_path)
+                shutil.copy(os.path.join(model_file, *artifact_path.parts), arti_path)
             # Store artifact path as basename by default. Otherwise save absolute path but bear in mind
             # that in this case output directory should be permanent for correct artifact recovery later
             arti_path = os.path.abspath(arti_path) if use_abspath else os.path.basename(arti_path)

--- a/nemo/utils/notebook_utils.py
+++ b/nemo/utils/notebook_utils.py
@@ -21,6 +21,7 @@ import urllib.request
 from typing import Optional
 
 from nemo.utils.dependency import import_optional_dependency
+from nemo.utils.tar_utils import safe_extract
 
 
 def build_manifest(transcripts_path, manifest_path, data_dir, mount_dir, wav_path):
@@ -76,8 +77,8 @@ def download_an4(data_dir: str = "./", train_mount_dir: Optional[str] = None, te
         an4_path = data_dir + '/an4_sphere.tar.gz'
 
     if not os.path.exists(data_dir + '/an4/'):
-        tar = tarfile.open(an4_path)
-        tar.extractall(path=data_dir)
+        with tarfile.open(an4_path) as tar:
+            safe_extract(tar, data_dir)
 
         print("Converting .sph to .wav...")
         sph_list = glob.glob(data_dir + '/an4/**/*.sph', recursive=True)

--- a/nemo/utils/tar_utils.py
+++ b/nemo/utils/tar_utils.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import tarfile
+from pathlib import PurePosixPath
+from typing import Iterable, Optional, Union
+
+
+class TarPathTraversalError(ValueError):
+    """Raised when a tar member would extract outside the target directory."""
+
+
+def is_safe_tar_member(member: tarfile.TarInfo, extract_to: str) -> bool:
+    member_path = PurePosixPath(member.name)
+    if member_path.is_absolute() or ".." in member_path.parts:
+        return False
+
+    if member.issym() or member.islnk():
+        return False
+
+    destination = os.path.realpath(os.path.join(extract_to, *member_path.parts))
+    return os.path.commonpath([destination, extract_to]) == extract_to
+
+
+def safe_extract(
+    tar: tarfile.TarFile,
+    path: str,
+    members: Optional[Iterable[Union[tarfile.TarInfo, str]]] = None,
+    *,
+    skip_unsafe: bool = False,
+) -> list[tarfile.TarInfo]:
+    extract_to = os.path.realpath(path)
+    os.makedirs(extract_to, exist_ok=True)
+    if members is None:
+        members = tar.getmembers()
+
+    extracted_members = []
+    for member in members:
+        member = tar.getmember(member) if isinstance(member, str) else member
+        if is_safe_tar_member(member, extract_to):
+            tar.extract(member, extract_to, filter="data")
+            extracted_members.append(member)
+            continue
+
+        message = f"Skipping potentially unsafe tar member: {member.name}"
+        if skip_unsafe:
+            logging.warning(message)
+            continue
+        raise TarPathTraversalError(message)
+
+    return extracted_members

--- a/scripts/dataset_processing/get_aishell_data.py
+++ b/scripts/dataset_processing/get_aishell_data.py
@@ -24,6 +24,8 @@ import urllib.request
 
 from tqdm import tqdm
 
+from nemo.utils.tar_utils import safe_extract
+
 parser = argparse.ArgumentParser(description="Aishell Data download")
 parser.add_argument("--data_root", required=True, default=None, type=str)
 args = parser.parse_args()
@@ -88,9 +90,8 @@ def __extract_all_files(filepath: str, data_root: str, data_dir: str):
 
 def extract_file(filepath: str, data_dir: str):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, data_dir)
     except Exception:
         logging.info("Not extracting. Maybe already there?")
 

--- a/scripts/dataset_processing/get_commonvoice_data.py
+++ b/scripts/dataset_processing/get_commonvoice_data.py
@@ -45,6 +45,8 @@ from typing import List
 
 from tqdm import tqdm
 
+from nemo.utils.tar_utils import safe_extract
+
 parser = argparse.ArgumentParser(description='Downloads and processes Mozilla Common Voice dataset.')
 parser.add_argument("--data_root", default='CommonVoice_dataset/', type=str, help="Directory to store the dataset.")
 parser.add_argument('--manifest_dir', default='./', type=str, help='Output directory for manifests')
@@ -192,9 +194,8 @@ def main():
 
         os.makedirs(target_unpacked_dir, exist_ok=True)
         logging.info("Unpacking corpus to {} ...".format(target_unpacked_dir))
-        tar = tarfile.open(target_file)
-        tar.extractall(target_unpacked_dir)
-        tar.close()
+        with tarfile.open(target_file) as tar:
+            safe_extract(tar, target_unpacked_dir)
         if args.cleanup:
             logging.info("removing tar archive to save space")
             os.remove(target_file)

--- a/scripts/dataset_processing/get_librispeech_data.py
+++ b/scripts/dataset_processing/get_librispeech_data.py
@@ -31,6 +31,8 @@ import urllib.request
 
 from tqdm import tqdm
 
+from nemo.utils.tar_utils import safe_extract
+
 parser = argparse.ArgumentParser(description="LibriSpeech Data download")
 parser.add_argument("--data_root", required=True, default=None, type=str)
 parser.add_argument("--data_sets", default="dev_clean", type=str)
@@ -108,9 +110,8 @@ def __maybe_download_file(destination: str, source: str):
 
 def __extract_file(filepath: str, data_dir: str):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, data_dir)
     except Exception:
         logging.info("Not extracting. Maybe already there?")
 

--- a/scripts/dataset_processing/process_speech_commands_data.py
+++ b/scripts/dataset_processing/process_speech_commands_data.py
@@ -42,6 +42,8 @@ import numpy as np
 import soundfile
 from tqdm import tqdm
 
+from nemo.utils.tar_utils import safe_extract
+
 URL_v1 = 'http://download.tensorflow.org/data/speech_commands_v0.01.tar.gz'
 URL_v2 = 'http://download.tensorflow.org/data/speech_commands_v0.02.tar.gz'
 
@@ -77,9 +79,8 @@ def __extract_all_files(filepath: str, data_dir: str):
 
 def extract_file(filepath: str, data_dir: str):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, data_dir)
     except Exception:
         logging.info('Not extracting. Maybe already there?')
 

--- a/scripts/dataset_processing/process_vad_data.py
+++ b/scripts/dataset_processing/process_vad_data.py
@@ -35,6 +35,8 @@ import numpy as np
 import soundfile as sf
 from sklearn.model_selection import train_test_split
 
+from nemo.utils.tar_utils import safe_extract
+
 sr = 16000
 
 # google speech command v2
@@ -64,9 +66,8 @@ def __maybe_download_file(destination: str, source: str):
 
 def extract_file(filepath: str, data_dir: str):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, data_dir)
     except Exception:
         logging.info('Not extracting. Maybe already there?')
 

--- a/scripts/dataset_processing/speaker_tasks/get_aishell_diarization_data.py
+++ b/scripts/dataset_processing/speaker_tasks/get_aishell_diarization_data.py
@@ -24,6 +24,7 @@ import urllib.request
 from pathlib import Path
 
 from nemo.collections.asr.parts.utils.manifest_utils import create_manifest
+from nemo.utils.tar_utils import safe_extract
 
 train_url = "https://www.openslr.org/resources/111/train_{}.tar.gz"
 train_datasets = ["S", "M", "L"]
@@ -44,9 +45,8 @@ def _load_sox_transformer():
 
 def extract_file(filepath: str, data_dir: str):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, data_dir)
     except Exception:
         logging.info("Not extracting. Maybe already there?")
 

--- a/scripts/dataset_processing/speaker_tasks/get_hi-mia_data.py
+++ b/scripts/dataset_processing/speaker_tasks/get_hi-mia_data.py
@@ -26,6 +26,8 @@ import librosa as l
 from sklearn.model_selection import StratifiedShuffleSplit
 from tqdm import tqdm
 
+from nemo.utils.tar_utils import safe_extract
+
 parser = argparse.ArgumentParser(description="HI-MIA Data download")
 parser.add_argument("--data_root", required=True, default=None, type=str)
 parser.add_argument("--log_level", default=20, type=int)
@@ -104,9 +106,8 @@ def __extract_all_files(filepath: str, data_root: str, data_dir: str):
 
 def extract_file(filepath: str, data_dir: str):
     try:
-        tar = tarfile.open(filepath, encoding='utf-8')
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath, encoding='utf-8') as tar:
+            safe_extract(tar, data_dir)
     except Exception:
         logging.info("Not extracting. Maybe already there?")
 

--- a/scripts/dataset_processing/tts/aishell3/get_data.py
+++ b/scripts/dataset_processing/tts/aishell3/get_data.py
@@ -28,6 +28,8 @@ import numpy as np
 from nemo_text_processing.text_normalization.normalize import Normalizer
 from opencc import OpenCC
 
+from nemo.utils.tar_utils import safe_extract
+
 URL = "https://www.openslr.org/resources/93/data_aishell3.tgz"
 
 
@@ -67,9 +69,8 @@ def __maybe_download_file(source_url, destination_path):
 
 def __extract_file(filepath, data_dir):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, str(data_dir))
     except Exception:
         print(f"Error while extracting {filepath}. Already extracted?")
 

--- a/scripts/dataset_processing/tts/hifitts/get_data.py
+++ b/scripts/dataset_processing/tts/hifitts/get_data.py
@@ -22,6 +22,8 @@ from pathlib import Path
 
 from tqdm import tqdm
 
+from nemo.utils.tar_utils import safe_extract
+
 
 def get_args():
     parser = argparse.ArgumentParser(description='Download HiFiTTS and create manifests with predefined split')
@@ -54,9 +56,8 @@ def __maybe_download_file(source_url, destination_path):
 
 def __extract_file(filepath, data_dir):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, str(data_dir))
     except Exception:
         print(f"Error while extracting {filepath}. Already extracted?")
 

--- a/scripts/dataset_processing/tts/libritts/get_data.py
+++ b/scripts/dataset_processing/tts/libritts/get_data.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 from tqdm import tqdm
 
+from nemo.utils.tar_utils import safe_extract
+
 parser = argparse.ArgumentParser(description='Download LibriTTS and create manifests')
 parser.add_argument("--data-root", required=True, type=Path)
 parser.add_argument("--data-sets", default="dev_clean", type=str)
@@ -56,9 +58,8 @@ def __maybe_download_file(source_url, destination_path):
 
 def __extract_file(filepath, data_dir):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, str(data_dir))
     except Exception:
         print(f"Error while extracting {filepath}. Already extracted?")
 

--- a/scripts/dataset_processing/tts/ljspeech/get_data.py
+++ b/scripts/dataset_processing/tts/ljspeech/get_data.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 from tqdm import tqdm
 
+from nemo.utils.tar_utils import safe_extract
+
 try:
     from nemo_text_processing.text_normalization.normalize import Normalizer
 except (ImportError, ModuleNotFoundError):
@@ -62,9 +64,8 @@ def __maybe_download_file(source_url, destination_path):
 
 def __extract_file(filepath, data_dir):
     try:
-        tar = tarfile.open(filepath)
-        tar.extractall(data_dir)
-        tar.close()
+        with tarfile.open(filepath) as tar:
+            safe_extract(tar, str(data_dir))
     except Exception:
         print(f"Error while extracting {filepath}. Already extracted?")
 

--- a/scripts/speech_recognition/convert_torchaudio_nemo.py
+++ b/scripts/speech_recognition/convert_torchaudio_nemo.py
@@ -45,6 +45,8 @@ import tempfile
 import torch
 import yaml
 
+from nemo.utils.tar_utils import safe_extract
+
 
 MODEL_CONFIG_YAML = "model_config.yaml"
 MODEL_WEIGHTS_CKPT = "model_weights.ckpt"
@@ -84,28 +86,14 @@ def migrate_config(cfg: dict) -> bool:
 def convert_nemo_file(nemo_path: str, output_path: str) -> None:
     """Extract, migrate, and repack a .nemo archive."""
     with tempfile.TemporaryDirectory() as tmpdir:
-
-        def _safe_extract_all(tar_obj: tarfile.TarFile, dest_dir: str) -> None:
-            """Safely extract all members of a tar file into dest_dir.
-
-            Ensures that no member escapes dest_dir via absolute paths or '..' components.
-            """
-            dest_dir_abs = os.path.abspath(dest_dir)
-            for member in tar_obj.getmembers():
-                member_path = os.path.join(dest_dir_abs, member.name)
-                member_path_abs = os.path.abspath(member_path)
-                if os.path.commonpath([dest_dir_abs, member_path_abs]) != dest_dir_abs:
-                    raise ValueError(f"Illegal tar archive entry path: {member.name!r}")
-                tar_obj.extract(member, path=dest_dir_abs)
-
         # --- Unpack --------------------------------------------------------
         # Older checkpoints may be gzipped; newer ones are plain tar.
         try:
             tar = tarfile.open(nemo_path, "r:")
         except tarfile.ReadError:
             tar = tarfile.open(nemo_path, "r:gz")
-        _safe_extract_all(tar, tmpdir)
-        tar.close()
+        with tar:
+            safe_extract(tar, tmpdir)
 
         # --- Migrate state dict --------------------------------------------
         weights_path = os.path.join(tmpdir, MODEL_WEIGHTS_CKPT)

--- a/tests/collections/common/test_lhotse_multirank_rng.py
+++ b/tests/collections/common/test_lhotse_multirank_rng.py
@@ -194,10 +194,10 @@ def test_dataloader_multiple_ranks_trng(nemo_tarred_manifest_path: tuple[str, st
     dp1 = get_lhotse_dataloader_from_config(config=config, global_rank=1, world_size=2, dataset=_Identity())
 
     dloaders = zip(*[iter(dl) for dl in (dp0, dp0_cpy, dp0_incrseed, dp1)])
+    batches = [next(dloaders) for _ in range(5)]
+    b0_batches, b0_cpy_batches, b0_incrseed_batches, b1_batches = map(list, zip(*batches))
 
-    for i in range(5):
-        b0, b0_cpy, b0_incrseed, b1 = next(dloaders)
-        assert b0 != b0_cpy
-        assert b0 != b1
-        assert b0_incrseed != b1
-        assert b0 != b0_incrseed
+    assert b0_batches != b0_cpy_batches
+    assert b0_batches != b1_batches
+    assert b0_incrseed_batches != b1_batches
+    assert b0_batches != b0_incrseed_batches

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ from typing import Tuple
 import pytest
 
 from nemo.utils.metaclasses import Singleton
+from nemo.utils.tar_utils import safe_extract
 
 # Those variables probably should go to main NeMo configuration file (config.yaml).
 __TEST_DATA_FILENAME = "test_data.tar.gz"
@@ -172,9 +173,8 @@ def extract_data_from_tar(test_dir, test_data_archive, url=None, local_data=Fals
 
     # Extract tar
     print("Extracting the `{}` test archive, please wait...".format(test_data_archive))
-    tar = tarfile.open(test_data_archive)
-    tar.extractall(path=test_dir)
-    tar.close()
+    with tarfile.open(test_data_archive) as tar:
+        safe_extract(tar, test_dir)
 
 
 @pytest.fixture(scope="session")

--- a/tests/utils/test_tar_utils.py
+++ b/tests/utils/test_tar_utils.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import io
+import subprocess
+import tarfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from omegaconf import OmegaConf
+
+from nemo.collections.asr.parts.mixins.mixins import ASRBPEMixin
+from nemo.utils.app_state import AppState
+from nemo.utils.model_utils import load_config, save_artifacts
+from nemo.utils.notebook_utils import download_an4
+from nemo.utils.tar_utils import TarPathTraversalError
+
+REPO_ROOT = Path(__file__).parents[2]
+RAW_TAR_EXTRACTION_ALLOWLIST = {REPO_ROOT / "nemo/utils/tar_utils.py"}
+
+
+def _is_tarfile_open_call(node):
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "open"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "tarfile"
+    )
+
+
+def _add_tar_file(tar, name, data=b""):
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    tar.addfile(info, io.BytesIO(data))
+
+
+def test_load_config_rejects_traversal_model_config(tmp_path):
+    nemo_path = tmp_path / "malicious.nemo"
+    with tarfile.open(nemo_path, "w:") as tar:
+        _add_tar_file(tar, "../model_config.yaml", b"model:\n  value: 1\n")
+
+    with pytest.raises(TarPathTraversalError):
+        load_config(str(nemo_path))
+
+
+def test_save_artifacts_rejects_traversal_artifact_path(tmp_path):
+    nemo_path = tmp_path / "malicious.nemo"
+    with tarfile.open(nemo_path, "w:") as tar:
+        _add_tar_file(tar, "model_config.yaml", b"model:\n  value: 1\n")
+        _add_tar_file(tar, "../tokenizer.model", b"payload")
+
+    model = SimpleNamespace(
+        cfg=OmegaConf.create({"tokenizer": {"library": "sentencepiece"}}),
+        artifacts={"tokenizer.model": SimpleNamespace(path="nemo:../tokenizer.model")},
+    )
+    AppState().model_restore_path = str(nemo_path)
+
+    with pytest.raises(TarPathTraversalError):
+        save_artifacts(model, str(tmp_path / "output"))
+
+
+def test_save_artifacts_rejects_absolute_artifact_path_before_rename(tmp_path):
+    secret_path = tmp_path / "secret.txt"
+    secret_path.write_text("sensitive")
+    nemo_path = tmp_path / "malicious.nemo"
+    with tarfile.open(nemo_path, "w:") as tar:
+        _add_tar_file(tar, "nested/model_config.yaml", b"model:\n  value: 1\n")
+        _add_tar_file(tar, f"nested/{secret_path.as_posix()}", b"payload")
+
+    model = SimpleNamespace(
+        cfg=OmegaConf.create({"tokenizer": {"library": "sentencepiece"}}),
+        artifacts={"tokenizer.model": SimpleNamespace(path=f"nemo:{secret_path.as_posix()}")},
+    )
+    output_dir = tmp_path / "output"
+    AppState().model_restore_path = str(nemo_path)
+
+    with pytest.raises(TarPathTraversalError):
+        save_artifacts(model, str(output_dir))
+
+    assert secret_path.read_text() == "sensitive"
+    assert not (output_dir / "tokenizer.model").exists()
+
+
+def test_asr_tokenizer_rename_uses_member_basename():
+    assert ASRBPEMixin._get_extracted_tokenizer_name("prefix_/tmp/tokenizer_vocab") == "vocab"
+
+
+def test_download_an4_rejects_traversal_archive(tmp_path):
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    an4_path = data_dir / "an4_sphere.tar.gz"
+    with tarfile.open(an4_path, "w:gz") as tar:
+        _add_tar_file(tar, "an4/etc/an4_train.transcription")
+        _add_tar_file(tar, "an4/etc/an4_test.transcription")
+        _add_tar_file(tar, "../nemo_poc_traversal_test", b"payload")
+
+    with pytest.raises(TarPathTraversalError):
+        download_an4(str(data_dir))
+
+    assert not (tmp_path / "nemo_poc_traversal_test").exists()
+
+
+def test_no_raw_tar_extraction_outside_safe_helper():
+    raw_extractions = []
+    python_files = subprocess.run(
+        ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard", "--", "*.py"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    for python_file in python_files:
+        if not python_file:
+            continue
+        path = REPO_ROOT / python_file.decode()
+        if path in RAW_TAR_EXTRACTION_ALLOWLIST:
+            continue
+
+        tar_vars = set()
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and _is_tarfile_open_call(node.value):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        tar_vars.add(target.id)
+            elif isinstance(node, ast.With):
+                for item in node.items:
+                    if _is_tarfile_open_call(item.context_expr) and isinstance(item.optional_vars, ast.Name):
+                        tar_vars.add(item.optional_vars.id)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+            if (
+                node.func.attr in {"extract", "extractall"}
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id in tar_vars
+            ):
+                raw_extractions.append(f"{path.relative_to(REPO_ROOT)}:{node.lineno}")
+
+    assert raw_extractions == []


### PR DESCRIPTION
# What does this PR do ?

Adds a shared safe tar extraction helper and replaces raw tar extraction in model, notebook, test-data, and dataset-processing paths to prevent path traversal when unpacking archives. It also validates `save_artifacts()` artifact paths before extract/copy/rename and sanitizes ASR tokenizer rename targets so raw archive metadata cannot move files outside the intended output directory.

# Changelog

- Add `nemo.utils.tar_utils.safe_extract`, which rejects absolute paths, `..` traversal, symlinks, and hardlinks by default.
- Route `SaveRestoreConnector._safe_extract()` through the shared helper while preserving its legacy skip-and-warn behavior with `skip_unsafe=True`.
- Replace raw `tar.extract()` / `tar.extractall()` usage across affected model utilities, notebook dataset download, test-data setup, dataset-processing scripts, and the torchaudio conversion script.
- Validate `save_artifacts()` artifact paths before constructing extract, copy, or rename paths.
- Derive ASR tokenizer output names from extracted member basenames before `os.rename()`.
- Add regression tests for traversal rejection, absolute artifact-path move prevention, ASR tokenizer rename target sanitization, and a static guard preventing raw tar extraction outside the shared helper.

# Verification

- `MPLCONFIGDIR=.pytest_cache/matplotlib UV_CACHE_DIR=.uv-cache uv run pytest tests/utils/test_tar_utils.py -v`
- Targeted `tests/core/test_save_restore.py` save/restore compatibility cases
- `UV_CACHE_DIR=.uv-cache uv run isort --check <changed files>`
- `UV_CACHE_DIR=.uv-cache uv run --with black==24.10.0 black --check <changed files>`
- `rg -n "tar\\.extract(all)?\\(" nemo tests scripts`