### PR TITLE
Fix SBNoiseScheduleVE.g() time handling

### DIFF
--- a/nemo/collections/audio/parts/submodules/schroedinger_bridge.py
+++ b/nemo/collections/audio/parts/submodules/schroedinger_bridge.py
@@ -266,7 +266,8 @@ class SBNoiseScheduleVE(SBNoiseSchedule):
         return torch.zeros_like(time)
 
     def g(self, time: torch.Tensor) -> torch.Tensor:
-        return torch.sqrt(self.c) * self.k**self.time
+        c = torch.as_tensor(self.c, device=time.device, dtype=time.dtype)
+        return torch.sqrt(c) * self.k**time
 
     def alpha(self, time: torch.Tensor) -> torch.Tensor:
         return torch.ones_like(time)

--- a/tests/collections/audio/test_audio_parts_submodules_schroedinger_bridge.py
+++ b/tests/collections/audio/test_audio_parts_submodules_schroedinger_bridge.py
@@ -21,6 +21,19 @@ from nemo.collections.audio.parts.submodules.schroedinger_bridge import SBNoiseS
 NUM_STEPS = [1, 5, 10, 20, 100]
 
 
+@pytest.mark.unit
+def test_sb_noise_schedule_ve_g_uses_input_time_and_preserves_dtype():
+    noise_schedule = SBNoiseScheduleVE(k=2.0, c=0.5, num_steps=5)
+    time = torch.tensor([0.0, 0.5, 1.0], dtype=torch.float64)
+
+    g = noise_schedule.g(time)
+
+    expected = torch.sqrt(torch.tensor(0.5, dtype=time.dtype, device=time.device)) * 2.0**time
+    torch.testing.assert_close(g, expected)
+    assert g.dtype == time.dtype
+    assert g.device == time.device
+
+
 @pytest.mark.parametrize("num_steps", NUM_STEPS)
 @pytest.mark.parametrize("process", ["sde", "ode"])
 @pytest.mark.parametrize("noise_schedule_type", ["ve", "vp"])


### PR DESCRIPTION
> [!IMPORTANT]
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fix `SBNoiseScheduleVE.g()` so it uses the provided `time` argument instead of a nonexistent `self.time`, and keep the scalar diffusion coefficient on the same dtype/device as the input tensor.

**Collection**: Audio

# Changelog

- replace the invalid `self.time` reference in `SBNoiseScheduleVE.g()` with the method argument `time`
- convert `c` to a tensor on `time`'s dtype/device before taking the square root
- add a regression test that checks the numerical result and dtype/device preservation

# Usage

```python
g = noise_schedule.g(time)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to #
- I couldn't run `pytest` in this checkout because the active interpreter is missing `pytest`, and it is also missing `torch`, so I verified the change with `python3 -m compileall`, `git diff --check`, and an isolated smoke test that executes the patched method body with lightweight stubs.
