### PR TITLE
fix decorator safe instantiation bug

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -155,6 +155,11 @@ def _is_target_allowed(target: str) -> bool:
                             return True
             return False
 
+    # @experimental / @deprecated wrap the class in a wrapt proxy that passes
+    # isinstance(.., type) but breaks issubclass(); unwrap to the real class.
+    while hasattr(obj, "__wrapped__"):
+        obj = obj.__wrapped__
+
     # If it's a class: allow only subclasses of safe bases
     if isinstance(obj, type):
         if target.startswith("nemo.core.config.") and is_dataclass(obj):

--- a/tests/core/test_safe_instantiate.py
+++ b/tests/core/test_safe_instantiate.py
@@ -23,7 +23,8 @@ from torch.distributed.fsdp import MixedPrecisionPolicy
 
 from nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers import BaseTokenizer
 from nemo.collections.tts.g2p.models.base import BaseG2p
-from nemo.core.classes.common import safe_instantiate
+from nemo.core.classes.common import _is_target_allowed, safe_instantiate
+from nemo.utils.decorators import experimental
 
 
 class MockDataset(torch.utils.data.Dataset):
@@ -49,6 +50,15 @@ class MockTokenizer(BaseTokenizer):
 
     def encode(self, text: str) -> list[int]:
         return [0]
+
+
+@experimental
+class MockExperimentalModule(torch.nn.Module):
+    """nn.Module wrapped by @experimental (wrapt), like asr's TransformerEncoder."""
+
+    def __init__(self, value: int = 0):
+        super().__init__()
+        self.value = value
 
 
 @pytest.mark.unit
@@ -125,3 +135,24 @@ def test_safe_instantiate_validates_nested_targets_before_hydra():
             safe_instantiate(config)
 
     instantiate_mock.assert_not_called()
+
+
+@pytest.mark.unit
+def test_safe_instantiate_allows_wrapt_decorated_module():
+    """Regression: a wrapt-decorated (@experimental) nn.Module must not be blocked."""
+    target = get_class_path(MockExperimentalModule)
+
+    assert _is_target_allowed(target) is True
+
+    obj = safe_instantiate(DictConfig({"_target_": target, "value": 7}))
+    assert isinstance(obj, torch.nn.Module)
+    assert obj.value == 7
+
+
+@pytest.mark.unit
+def test_safe_instantiate_allows_experimental_asr_transformer_encoder():
+    """The originally reported target: an @experimental nn.Module in asr.modules."""
+    pytest.importorskip("nemo.collections.asr.modules.transformer_encoder")
+
+    assert _is_target_allowed("nemo.collections.asr.modules.transformer_encoder.TransformerEncoder") is True
+    assert _is_target_allowed("nemo.collections.asr.modules.TransformerEncoder") is True


### PR DESCRIPTION
# What does this PR do ?

  Fix `_is_target_allowed` blocking valid config targets that are wrapped by a wrapt decorator (`@experimental` / `@deprecated`), e.g. `nemo.collections.asr.modules.TransformerEncoder`.

  **Collection**: core

  # Changelog

  - `nemo/core/classes/common.py`: in `_is_target_allowed`, unwrap `__wrapped__` (wrapt proxy) to the real class before the `issubclass` safe-base checks. The proxy passes `isinstance(.., type)` but raises `TypeError` on `issubclass()`, which `except TypeError: return False` caught and used to wrongly block the target.
  - `tests/core/test_safe_instantiate.py`: add regression tests for a wrapt-decorated `nn.Module` (and the reported asr `TransformerEncoder` target).

  # Usage

  ```python
  from omegaconf import DictConfig
  from nemo.core.classes.common import safe_instantiate

  # @experimental nn.Module target now instantiates instead of raising UnsafeTargetError
  safe_instantiate(DictConfig({"_target_": "nemo.collections.asr.modules.TransformerEncoder",
                               "feat_in": 80, "d_model": 64, "n_heads": 4, "n_layers": 2}))
```

  GitHub Actions CI

  The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

  The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
  To re-run CI remove and add the label again.
  To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

  Before your PR is "Ready for review"

  Pre checks:

  - [x] Make sure you read and followed Contributor guidelines
  - [x] Did you write any new necessary tests?
  - [ ] Did you add or update any necessary documentation?
  - [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
    - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

  PR Type:

  - [ ] New Feature
  - [x] Bugfix
  - [ ] Documentation

  Who can review?

  Anyone in the community is free to review the PR once the checks have passed.
  Contributor guidelines contains specific people who can review PRs to various areas.

  Additional Information

  - Related to #15802 (regression introduced by that PR)