### PR TITLE
add confidences to beam search + cache_aware in streaming inference

### DIFF
--- a/examples/asr/asr_chunked_inference/rnnt/speech_to_text_streaming_infer_rnnt.py
+++ b/examples/asr/asr_chunked_inference/rnnt/speech_to_text_streaming_infer_rnnt.py
@@ -97,6 +97,7 @@ from nemo.collections.asr.parts.utils.transcribe_utils import (
     get_inference_device,
     get_inference_dtype,
     setup_model,
+    wire_confidence_cfg,
     write_transcription,
 )
 from nemo.core.config import hydra_runner
@@ -247,6 +248,10 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
         with open_dict(cfg.decoding):
             cfg.decoding.greedy.enable_per_stream_biasing = use_per_stream_biasing
             cfg.decoding.beam.enable_per_stream_biasing = use_per_stream_biasing
+
+    if cfg.confidence:
+        wire_confidence_cfg(cfg.decoding, enabled=True)
+
     if use_simulated_decoding:
         # simulated decoding: any config allowed, do not change config
         with open_dict(cfg.decoding):
@@ -266,10 +271,6 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
             cfg.decoding.greedy.preserve_alignments = False
             cfg.decoding.fused_batch_size = -1  # temporarily stop fused batch during inference.
             cfg.decoding.beam.return_best_hypothesis = True  # return and write the best hypothsis only
-            if cfg.confidence:
-                cfg.decoding.greedy.preserve_frame_confidence = True
-                cfg.decoding.confidence_cfg.preserve_frame_confidence = True
-                cfg.decoding.confidence_cfg.preserve_word_confidence = True
 
     # Setup decoding strategy
     if hasattr(asr_model, 'change_decoding_strategy'):

--- a/examples/asr/conf/asr_streaming_inference/cache_aware_rnnt.yaml
+++ b/examples/asr/conf/asr_streaming_inference/cache_aware_rnnt.yaml
@@ -34,6 +34,7 @@ asr:
       # Cache-aware streaming supports MALSD beam search only (set asr.decoding.strategy: malsd_batch).
       beam_size: 4
       allow_cuda_graphs: true
+      preserve_frame_confidence: false  # Set to true to calculate confidence (token/word etc.)
       # n-gram LM (off by default)
       ngram_lm_model: null
       ngram_lm_alpha: 0.0

--- a/examples/asr/speech_to_text_eval.py
+++ b/examples/asr/speech_to_text_eval.py
@@ -60,6 +60,19 @@ python speech_to_text_eval.py \
     use_cer=False \
     only_score_manifest=True
 
+## Offline batched beam search with confidence (RNNT)
+
+python speech_to_text_eval.py \
+    pretrained_name=nvidia/stt_en_fastconformer_transducer_large \
+    dataset_manifest=<path/to/manifest.json> \
+    output_filename=<path/to/output.jsonl> \
+    batch_size=32 \
+    confidence=true \
+    rnnt_decoding.strategy=malsd_batch \
+    rnnt_decoding.beam.beam_size=4 \
+    rnnt_decoding.beam.allow_cuda_graphs=true \
+    scores_per_sample=true
+
 """
 
 import json
@@ -186,13 +199,13 @@ def main(cfg: EvaluationConfig):
         if cfg.use_punct_er:
             metrics_to_compute.append("punct_er")
 
-        samples_with_metrics = compute_metrics_per_sample(
-            manifest_path=cfg.dataset_manifest,
+        compute_metrics_per_sample(
+            manifest_path=transcription_cfg.output_filename,
             reference_field=cfg.gt_text_attr_name,
             hypothesis_field="pred_text",
             metrics=metrics_to_compute,
             punctuation_marks=cfg.text_processing.punctuation_marks,
-            output_manifest_path=cfg.output_filename,
+            output_manifest_path=transcription_cfg.output_filename,
         )
 
     # Compute the WER

--- a/examples/asr/speech_to_text_eval.py
+++ b/examples/asr/speech_to_text_eval.py
@@ -60,19 +60,6 @@ python speech_to_text_eval.py \
     use_cer=False \
     only_score_manifest=True
 
-## Offline batched beam search with confidence (RNNT)
-
-python speech_to_text_eval.py \
-    pretrained_name=nvidia/stt_en_fastconformer_transducer_large \
-    dataset_manifest=<path/to/manifest.json> \
-    output_filename=<path/to/output.jsonl> \
-    batch_size=32 \
-    confidence=true \
-    rnnt_decoding.strategy=malsd_batch \
-    rnnt_decoding.beam.beam_size=4 \
-    rnnt_decoding.beam.allow_cuda_graphs=true \
-    scores_per_sample=true
-
 """
 
 import json

--- a/examples/asr/speech_to_text_eval.py
+++ b/examples/asr/speech_to_text_eval.py
@@ -186,8 +186,8 @@ def main(cfg: EvaluationConfig):
         if cfg.use_punct_er:
             metrics_to_compute.append("punct_er")
 
-        compute_metrics_per_sample(
-            manifest_path=transcription_cfg.output_filename,
+        samples_with_metrics = compute_metrics_per_sample(
+            manifest_path=cfg.dataset_manifest,
             reference_field=cfg.gt_text_attr_name,
             hypothesis_field="pred_text",
             metrics=metrics_to_compute,

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -36,6 +36,7 @@ from nemo.collections.asr.parts.utils.transcribe_utils import (
     prepare_audio_data,
     restore_transcription_order,
     setup_model,
+    wire_confidence_cfg,
     write_transcription,
 )
 from nemo.core.config import hydra_runner
@@ -100,6 +101,18 @@ python transcribe_speech.py \
     amp=True \
     append_pred=False \
     pred_name_postfix="<remove or use another model name for output filename>"
+
+## Offline batched beam search with confidence (RNNT)
+
+python transcribe_speech.py \
+    pretrained_name=nvidia/stt_en_fastconformer_transducer_large \
+    dataset_manifest=<path/to/manifest.json> \
+    output_filename=<path/to/output.jsonl> \
+    batch_size=32 \
+    confidence=true \
+    rnnt_decoding.strategy=malsd_batch \
+    rnnt_decoding.beam.beam_size=4 \
+    rnnt_decoding.beam.allow_cuda_graphs=true
 """
 
 
@@ -206,6 +219,8 @@ class TranscriptionConfig:
 
     extract_nbest: bool = False  # Extract n-best hypotheses from the model
 
+    confidence: bool = False  # output token and word confidence in the manifest
+
     calculate_rtfx: bool = False
     warmup_steps: int = 0  # by default - no warmup
     run_steps: int = 1  # by default - single run
@@ -290,6 +305,11 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
 
     if cfg.timestamps:
         cfg.return_hypotheses = True
+
+    if cfg.confidence:
+        cfg.return_hypotheses = True
+        wire_confidence_cfg(cfg.rnnt_decoding, enabled=True)
+        wire_confidence_cfg(cfg.ctc_decoding, enabled=True)
 
     # Check whether model and decoder type match
     if isinstance(asr_model, EncDecCTCModel):
@@ -465,6 +485,7 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
         filepaths=filepaths,
         compute_langs=compute_langs,
         timestamps=cfg.timestamps,
+        confidence=cfg.confidence,
     )
     logging.info(f"Finished writing predictions to {output_filename}!")
 

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -101,18 +101,6 @@ python transcribe_speech.py \
     amp=True \
     append_pred=False \
     pred_name_postfix="<remove or use another model name for output filename>"
-
-## Offline batched beam search with confidence (RNNT)
-
-python transcribe_speech.py \
-    pretrained_name=nvidia/stt_en_fastconformer_transducer_large \
-    dataset_manifest=<path/to/manifest.json> \
-    output_filename=<path/to/output.jsonl> \
-    batch_size=32 \
-    confidence=true \
-    rnnt_decoding.strategy=malsd_batch \
-    rnnt_decoding.beam.beam_size=4 \
-    rnnt_decoding.beam.allow_cuda_graphs=true
 """
 
 

--- a/nemo/collections/asr/inference/factory/base_builder.py
+++ b/nemo/collections/asr/inference/factory/base_builder.py
@@ -76,13 +76,16 @@ class BaseBuilder:
     def _apply_confidence_cfg(cfg: DictConfig, decoding_cfg: RNNTDecodingConfig) -> None:
         """
         Wire the separately-stored `confidence` block into the RNNT decoding confidence config so the
-        greedy decoder computes per-token confidence with the configured method. The streaming pipelines
-        only support non-blank confidence (`confidence.exclude_blank=true`).
+        greedy or batched-beam decoder computes per-token confidence with the configured method. The streaming
+        pipelines only support non-blank confidence (`confidence.exclude_blank=true`).
         Args:
             cfg: (DictConfig) Full pipeline config (provides the top-level `confidence` block).
             decoding_cfg: (RNNTDecodingConfig) Decoding config to update in place.
         """
-        if not decoding_cfg.greedy.get("preserve_frame_confidence", False):
+        preserve_frame_confidence = decoding_cfg.greedy.get(
+            "preserve_frame_confidence", False
+        ) or decoding_cfg.beam.get("preserve_frame_confidence", False)
+        if not preserve_frame_confidence:
             return
         confidence_cfg = cfg.get("confidence", None)
         if confidence_cfg is None:
@@ -92,6 +95,8 @@ class BaseBuilder:
                 "Streaming confidence supports only non-blank confidence (`confidence.exclude_blank=true`)."
             )
         decoding_cfg.confidence_cfg.preserve_frame_confidence = True
+        decoding_cfg.confidence_cfg.preserve_token_confidence = True
+        decoding_cfg.confidence_cfg.preserve_word_confidence = True
         decoding_cfg.confidence_cfg.exclude_blank = True
         decoding_cfg.confidence_cfg.aggregation = confidence_cfg.get("aggregation", "mean")
         decoding_cfg.confidence_cfg.method_cfg = OmegaConf.merge(

--- a/nemo/collections/asr/inference/model_wrappers/cache_aware_rnnt_inference_wrapper.py
+++ b/nemo/collections/asr/inference/model_wrappers/cache_aware_rnnt_inference_wrapper.py
@@ -230,7 +230,7 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
                 encs_dim_last, encoded_len, batched_state, multi_biasing_ids=multi_biasing_ids
             )
 
-            chunk_tokens, chunk_timestamps, root_ptrs, chunk_confidences = export_batched_beam_hyps_to_cpu_lists(
+            chunk_tokens, chunk_timestamps, chunk_confidences, root_ptrs = export_batched_beam_hyps_to_cpu_lists(
                 best_batched_hyps
             )
             beam_indices = best_batched_hyps.scores.argmax(dim=-1).detach().cpu().tolist()

--- a/nemo/collections/asr/inference/model_wrappers/cache_aware_rnnt_inference_wrapper.py
+++ b/nemo/collections/asr/inference/model_wrappers/cache_aware_rnnt_inference_wrapper.py
@@ -230,15 +230,24 @@ class CacheAwareRNNTInferenceWrapper(CacheAwareASRInferenceWrapper):
                 encs_dim_last, encoded_len, batched_state, multi_biasing_ids=multi_biasing_ids
             )
 
-            chunk_tokens, chunk_timestamps, root_ptrs = export_batched_beam_hyps_to_cpu_lists(best_batched_hyps)
+            chunk_tokens, chunk_timestamps, root_ptrs, chunk_confidences = export_batched_beam_hyps_to_cpu_lists(
+                best_batched_hyps
+            )
             beam_indices = best_batched_hyps.scores.argmax(dim=-1).detach().cpu().tolist()
             scores_cpu = best_batched_hyps.scores.detach().cpu()
 
             carry_items = malsd_computer.split_batched_state(batched_state)
-            for state, ct, cts, rp, best_hyp_idx, carry in zip(
-                states, chunk_tokens, chunk_timestamps, root_ptrs, beam_indices, carry_items
+            for b, (state, ct, cts, rp, best_hyp_idx, carry) in enumerate(
+                zip(states, chunk_tokens, chunk_timestamps, root_ptrs, beam_indices, carry_items)
             ):
-                state.append_chunk_beam_(ct, cts, rp, best_batched_hyps.beam_size, best_hyp_idx)
+                state.append_chunk_beam_(
+                    ct,
+                    cts,
+                    rp,
+                    best_batched_hyps.beam_size,
+                    best_hyp_idx,
+                    chunk_confidences=(chunk_confidences[b] if chunk_confidences is not None else None),
+                )
                 state.hyp_decoding_state = carry
 
         hyps = [state.get_hypothesis(float(scores_cpu[b, beam_indices[b]].item())) for b, state in enumerate(states)]

--- a/nemo/collections/asr/inference/pipelines/buffered_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/buffered_rnnt_pipeline.py
@@ -655,7 +655,7 @@ class BufferedRNNTPipeline(BasePipeline):
                 tokens, timestamp, self.tokens_to_move, self.underscore_id
             )
             # Per-token non-blank confidence precomputed during RNN-T decoding (aligned with `tokens`).
-            # Populated only when `asr.decoding.greedy.preserve_frame_confidence=true`; otherwise None.
+            # Populated when greedy or batched-beam preserve_frame_confidence is enabled; otherwise None.
             confidences = hyp.non_blank_step_confidence_precomputed
             if confidences is not None:
                 confidences = torch.tensor(confidences, dtype=torch.float32, device=tokens.device)

--- a/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/cache_aware_rnnt_pipeline.py
@@ -366,7 +366,7 @@ class CacheAwareRNNTPipeline(BasePipeline):
         """
         eou_detected = request.is_last
         # Per-token non-blank confidence precomputed during RNN-T decoding (aligned with `hyp.y_sequence`).
-        # Populated only when `asr.decoding.greedy.preserve_frame_confidence=true`; otherwise None.
+        # Populated when greedy or batched-beam preserve_frame_confidence is enabled; otherwise None.
         cur_output, cur_labels, new_offset = self.greedy_rnnt_decoder(
             global_timestamps=hyp.timestamp,
             tokens=hyp.y_sequence,

--- a/nemo/collections/asr/inference/streaming/state/cache_aware_rnnt_state.py
+++ b/nemo/collections/asr/inference/streaming/state/cache_aware_rnnt_state.py
@@ -86,8 +86,10 @@ class CacheAwareRNNTBeamStreamingState(CacheAwareRNNTStreamingState):
         self.hyp_decoding_state: MALSDStateItem | None = None
         self.cumulative_tokens: list[int] = []
         self.cumulative_timestamps: list[int] = []
+        self.cumulative_confidences: list[float] = []
         self.partial_tokens: list[list[int]] | None = None
         self.partial_timestamps: list[list[int]] | None = None
+        self.partial_confidences: list[list[float]] | None = None
         self._cumulative_tokens_len: int = 0
         self.best_hyp_idx: int | None = None
 
@@ -96,8 +98,10 @@ class CacheAwareRNNTBeamStreamingState(CacheAwareRNNTStreamingState):
         self.hyp_decoding_state = None
         self.cumulative_tokens = []
         self.cumulative_timestamps = []
+        self.cumulative_confidences = []
         self.partial_tokens = None
         self.partial_timestamps = None
+        self.partial_confidences = None
         self._cumulative_tokens_len = 0
         self.best_hyp_idx = None
 
@@ -108,18 +112,26 @@ class CacheAwareRNNTBeamStreamingState(CacheAwareRNNTStreamingState):
         root_ptrs: list[int],
         beam_size: int,
         best_hyp_idx: int,
+        chunk_confidences: list[list[float]] | None = None,
     ) -> None:
         """Append chunk-local beam exports into state."""
         prev_t = self.partial_tokens or [[] for _ in range(beam_size)]
         prev_ts = self.partial_timestamps or [[] for _ in range(beam_size)]
+        prev_conf = self.partial_confidences or [[] for _ in range(beam_size)]
         next_tokens: list[list[int]] = []
         next_timestamps: list[list[int]] = []
+        next_confidences: list[list[float]] = []
         for k in range(beam_size):
             lineage = int(root_ptrs[k])
             next_tokens.append(prev_t[lineage] + list(chunk_tokens[k]))
             next_timestamps.append(prev_ts[lineage] + list(chunk_timestamps[k]))
+            if chunk_confidences is not None:
+                next_confidences.append(prev_conf[lineage] + list(chunk_confidences[k]))
+            else:
+                next_confidences.append(prev_conf[lineage] + [0.0] * len(chunk_tokens[k]))
         self.partial_tokens = next_tokens
         self.partial_timestamps = next_timestamps
+        self.partial_confidences = next_confidences
         self.best_hyp_idx = best_hyp_idx
 
     def select_best_beam_idx_(self, *, score_norm: bool = False) -> int:
@@ -156,26 +168,42 @@ class CacheAwareRNNTBeamStreamingState(CacheAwareRNNTStreamingState):
             self.cumulative_timestamps + list(self.partial_timestamps[best_hyp_idx]),
         )
 
+    def _get_confidences(self) -> list[float]:
+        """``cumulative_confidences`` plus the current top-1 ``partial_confidences`` suffix."""
+        if self.partial_tokens is None or self.hyp_decoding_state is None:
+            return []
+        best_hyp_idx = self.get_best_hyp_idx()
+        partial_conf = (
+            list(self.partial_confidences[best_hyp_idx])
+            if self.partial_confidences is not None
+            else [0.0] * len(self.partial_tokens[best_hyp_idx])
+        )
+        return self.cumulative_confidences + partial_conf
+
     def get_hypothesis(self, score: float) -> Hypothesis:
         """Build the publishable cumulative hypothesis for the current top-1 beam."""
         cum_tokens, cum_ts = self._get_tokens()
+        cum_conf = self._get_confidences()
         return Hypothesis(
             score=score,
             y_sequence=cum_tokens,
             timestamp=cum_ts,
             length=len(cum_tokens),
+            non_blank_step_confidence_precomputed=cum_conf if cum_conf else None,
         )
 
     def update_(self, eou_detected: bool) -> None:
         """Refresh publish tokens; on EOU fold utterance into ``cumulative_*`` and clear ``partial_*``."""
         cum_tokens, cum_ts = self._get_tokens()
+        cum_conf = self._get_confidences()
         if cum_tokens:
             start = max(0, min(int(self._cumulative_tokens_len), len(cum_tokens)))
             tokens = list(cum_tokens[start:])
             timesteps = list(cum_ts[start:])
+            confidences = list(cum_conf[start:]) if cum_conf else [0.0] * len(tokens)
             self.tokens = tokens
             self.timesteps = timesteps
-            self.confidences = [0.0] * len(tokens)
+            self.confidences = confidences
             if tokens:
                 self.last_token = tokens[-1]
                 self.last_token_idx = timesteps[-1] if timesteps else None
@@ -187,6 +215,8 @@ class CacheAwareRNNTBeamStreamingState(CacheAwareRNNTStreamingState):
             self._cumulative_tokens_len = len(cum_tokens)
             self.cumulative_tokens = list(cum_tokens)
             self.cumulative_timestamps = list(cum_ts)
+            self.cumulative_confidences = list(cum_conf)
         self.partial_tokens = None
         self.partial_timestamps = None
+        self.partial_confidences = None
         self.best_hyp_idx = None

--- a/nemo/collections/asr/inference/streaming/state/cache_aware_rnnt_state.py
+++ b/nemo/collections/asr/inference/streaming/state/cache_aware_rnnt_state.py
@@ -158,32 +158,26 @@ class CacheAwareRNNTBeamStreamingState(CacheAwareRNNTStreamingState):
             raise RuntimeError("Cannot resolve top-1 beam index without decoding carry.")
         return int(self.hyp_decoding_state.score.argmax().item())
 
-    def _get_tokens(self) -> tuple[list[int], list[int]]:
+    def _get_tokens(self) -> tuple[list[int], list[int], list[float]]:
         """``cumulative_*`` plus the current top-1 ``partial_*`` suffix."""
         if self.partial_tokens is None or self.hyp_decoding_state is None:
-            return [], []
+            return [], [], []
         best_hyp_idx = self.get_best_hyp_idx()
-        return (
-            self.cumulative_tokens + list(self.partial_tokens[best_hyp_idx]),
-            self.cumulative_timestamps + list(self.partial_timestamps[best_hyp_idx]),
-        )
-
-    def _get_confidences(self) -> list[float]:
-        """``cumulative_confidences`` plus the current top-1 ``partial_confidences`` suffix."""
-        if self.partial_tokens is None or self.hyp_decoding_state is None:
-            return []
-        best_hyp_idx = self.get_best_hyp_idx()
+        partial_tokens = list(self.partial_tokens[best_hyp_idx])
         partial_conf = (
             list(self.partial_confidences[best_hyp_idx])
             if self.partial_confidences is not None
-            else [0.0] * len(self.partial_tokens[best_hyp_idx])
+            else [0.0] * len(partial_tokens)
         )
-        return self.cumulative_confidences + partial_conf
+        return (
+            self.cumulative_tokens + partial_tokens,
+            self.cumulative_timestamps + list(self.partial_timestamps[best_hyp_idx]),
+            self.cumulative_confidences + partial_conf,
+        )
 
     def get_hypothesis(self, score: float) -> Hypothesis:
         """Build the publishable cumulative hypothesis for the current top-1 beam."""
-        cum_tokens, cum_ts = self._get_tokens()
-        cum_conf = self._get_confidences()
+        cum_tokens, cum_ts, cum_conf = self._get_tokens()
         return Hypothesis(
             score=score,
             y_sequence=cum_tokens,
@@ -194,8 +188,7 @@ class CacheAwareRNNTBeamStreamingState(CacheAwareRNNTStreamingState):
 
     def update_(self, eou_detected: bool) -> None:
         """Refresh publish tokens; on EOU fold utterance into ``cumulative_*`` and clear ``partial_*``."""
-        cum_tokens, cum_ts = self._get_tokens()
-        cum_conf = self._get_confidences()
+        cum_tokens, cum_ts, cum_conf = self._get_tokens()
         if cum_tokens:
             start = max(0, min(int(self._cumulative_tokens_len), len(cum_tokens)))
             tokens = list(cum_tokens[start:])

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -1768,7 +1768,7 @@ class BeamRNNTInferConfig:
     enable_per_stream_biasing: bool = False
     preserve_frame_confidence: bool = False
     tdt_include_duration_confidence: bool = False
-    confidence_method_cfg: Optional[ConfidenceMethodConfig] = field(default_factory=lambda: ConfidenceMethodConfig())
+    confidence_method_cfg: Optional[ConfidenceMethodConfig] = field(default_factory=ConfidenceMethodConfig)
 
     def __post_init__(self):
         # OmegaConf.structured ensures that post_init check is always executed

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
+from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
 
 from nemo.collections.asr.modules import rnnt_abstract
@@ -39,7 +40,7 @@ from nemo.collections.asr.parts.context_biasing import BoostingTreeModelConfig
 from nemo.collections.asr.parts.submodules.ngram_lm import DEFAULT_TOKEN_OFFSET, NGramGPULanguageModel
 from nemo.collections.asr.parts.submodules.rnnt_maes_batched_computer import ModifiedAESBatchedRNNTComputer
 from nemo.collections.asr.parts.submodules.rnnt_malsd_batched_computer import ModifiedALSDBatchedRNNTComputer
-from nemo.collections.asr.parts.utils.asr_confidence_utils import ConfidenceMethodMixin
+from nemo.collections.asr.parts.utils.asr_confidence_utils import ConfidenceMethodConfig, ConfidenceMethodMixin
 from nemo.collections.asr.parts.utils.batched_beam_decoding_utils import BlankLMScoreMode, PruningMode
 from nemo.collections.asr.parts.utils.rnnt_utils import (
     HATJointOutput,
@@ -1561,6 +1562,8 @@ class BeamBatchedRNNTInfer(Typing, ConfidenceMethodMixin, WithOptionalCudaGraphs
         allow_cuda_graphs: Optional[bool] = True,
         return_best_hypothesis: Optional[str] = True,
         enable_per_stream_biasing: bool = False,
+        preserve_step_confidence: bool = False,
+        confidence_method_cfg: Optional[DictConfig] = None,
     ):
         """
         Init method.
@@ -1593,6 +1596,8 @@ class BeamBatchedRNNTInfer(Typing, ConfidenceMethodMixin, WithOptionalCudaGraphs
             allow_cuda_graphs: whether to allow CUDA graphs
             return_best_hypothesis: whether to return the best hypothesis or N-best hypotheses
             enable_per_stream_biasing: whether to enable per-stream biasing via multi-boosting tree
+            preserve_step_confidence: if step confidence should be preserved in beam hypotheses
+            confidence_method_cfg: config for the confidence estimation method
         """
 
         super().__init__()
@@ -1632,6 +1637,8 @@ class BeamBatchedRNNTInfer(Typing, ConfidenceMethodMixin, WithOptionalCudaGraphs
                 pruning_mode=pruning_mode,
                 allow_cuda_graphs=allow_cuda_graphs,
                 enable_per_stream_biasing=enable_per_stream_biasing,
+                preserve_step_confidence=preserve_step_confidence,
+                confidence_method_cfg=confidence_method_cfg,
             )
         elif search_type == "maes_batch":
             self.decoding_computer = ModifiedAESBatchedRNNTComputer(
@@ -1759,3 +1766,14 @@ class BeamRNNTInferConfig:
     pruning_mode: Optional[str | PruningMode] = PruningMode.LATE
     allow_cuda_graphs: Optional[bool] = True
     enable_per_stream_biasing: bool = False
+    preserve_frame_confidence: bool = False
+    tdt_include_duration_confidence: bool = False
+    confidence_method_cfg: Optional[ConfidenceMethodConfig] = field(default_factory=lambda: ConfidenceMethodConfig())
+
+    def __post_init__(self):
+        # OmegaConf.structured ensures that post_init check is always executed
+        self.confidence_method_cfg = OmegaConf.structured(
+            self.confidence_method_cfg
+            if isinstance(self.confidence_method_cfg, ConfidenceMethodConfig)
+            else ConfidenceMethodConfig(**self.confidence_method_cfg)
+        )

--- a/nemo/collections/asr/parts/submodules/rnnt_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_decoding.py
@@ -643,6 +643,8 @@ class AbstractRNNTDecoding(ConfidenceMixin):
                     allow_cuda_graphs=self.cfg.beam.get('allow_cuda_graphs', True),
                     return_best_hypothesis=self.cfg.beam.get('return_best_hypothesis', True),
                     enable_per_stream_biasing=self.cfg.beam.get('enable_per_stream_biasing', False),
+                    preserve_step_confidence=self.preserve_frame_confidence,
+                    confidence_method_cfg=self.confidence_method_cfg,
                 )
             case TransducerDecodingStrategyType.MALSD_BATCH, TransducerModelType.TDT:
                 self.decoding = tdt_beam_decoding.BeamBatchedTDTInfer(
@@ -662,6 +664,9 @@ class AbstractRNNTDecoding(ConfidenceMixin):
                     allow_cuda_graphs=self.cfg.beam.get('allow_cuda_graphs', True),
                     return_best_hypothesis=self.cfg.beam.get('return_best_hypothesis', True),
                     enable_per_stream_biasing=self.cfg.beam.get('enable_per_stream_biasing', False),
+                    preserve_step_confidence=self.preserve_frame_confidence,
+                    include_duration_confidence=self.tdt_include_duration_confidence,
+                    confidence_method_cfg=self.confidence_method_cfg,
                 )
             case TransducerDecodingStrategyType.MAES_BATCH, TransducerModelType.RNNT:
                 self.decoding = rnnt_beam_decoding.BeamBatchedRNNTInfer(

--- a/nemo/collections/asr/parts/submodules/rnnt_malsd_batched_computer.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_malsd_batched_computer.py
@@ -299,6 +299,12 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
         self.preserve_step_confidence = preserve_step_confidence
         if self.preserve_step_confidence:
             self._init_confidence_method(confidence_method_cfg=confidence_method_cfg)
+            logging.info(
+                "Batched beam search stores per-step confidences for all decode steps (including blanks) "
+                "internally. Exported hypotheses expose non-blank scores via "
+                "`non_blank_step_confidence_precomputed` only; `Hypothesis.frame_confidence` is not populated. "
+                "Run `compute_confidence()` for token- and word-level scores."
+            )
         self._SOS = self._blank_index
         self.allow_cuda_graphs = allow_cuda_graphs
 

--- a/nemo/collections/asr/parts/submodules/rnnt_malsd_batched_computer.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_malsd_batched_computer.py
@@ -342,11 +342,6 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
             return None
         return self._get_confidence_tensor(log_probs).to(dtype=log_probs.dtype)
 
-    def _gather_parent_step_confidence(
-        self, step_confidence: torch.Tensor, parent_indices: torch.Tensor
-    ) -> torch.Tensor:
-        return torch.gather(step_confidence, dim=-1, index=parent_indices)
-
     @property
     def per_stream_biasing_enabled(self) -> bool:
         return self.biasing_multi_model is not None
@@ -649,11 +644,13 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
             next_step_confidence = None
             if self.preserve_step_confidence:
                 step_confidence = self._get_step_confidence(log_probs)
-                next_step_confidence = self._gather_parent_step_confidence(step_confidence, hyps_indices)
+                next_step_confidence = torch.gather(step_confidence, dim=-1, index=hyps_indices)
 
             # step 3: store results
             if self.max_symbols is None:
-                batched_hyps.add_results_(hyps_indices, next_labels, next_hyps_prob, next_step_confidence=next_step_confidence)
+                batched_hyps.add_results_(
+                    hyps_indices, next_labels, next_hyps_prob, next_step_confidence=next_step_confidence
+                )
             else:
                 batched_hyps.add_results_no_checks_(
                     hyps_indices, next_labels, next_hyps_prob, next_step_confidence=next_step_confidence
@@ -1288,7 +1285,7 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
         next_step_confidence = None
         if self.preserve_step_confidence:
             step_confidence = self._get_step_confidence(log_probs)
-            next_step_confidence = self._gather_parent_step_confidence(step_confidence, self.state.next_idx)
+            next_step_confidence = torch.gather(step_confidence, dim=-1, index=self.state.next_idx)
 
         # step 3: store results
         if self.max_symbols is None:

--- a/nemo/collections/asr/parts/submodules/rnnt_malsd_batched_computer.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_malsd_batched_computer.py
@@ -17,6 +17,7 @@ from typing import Any, List, Optional, Union
 import numpy as np
 import torch
 import torch.nn.functional as F
+from omegaconf import DictConfig
 
 from nemo.collections.asr.parts.context_biasing.biasing_multi_model import (
     GPUBiasingMultiModel,
@@ -120,6 +121,7 @@ class MALSDState:
         device: torch.device,
         float_dtype: torch.dtype,
         blank_index: int,
+        with_step_confidence: bool = False,
     ):
         """
         Args:
@@ -191,6 +193,7 @@ class MALSDState:
             init_length=max_time * (max_symbols + 1) if max_symbols is not None else max_time,
             device=device,
             float_dtype=float_dtype,
+            with_step_confidence=with_step_confidence,
         )
 
     def need_reinit(self, encoder_output_projected: torch.Tensor) -> bool:
@@ -263,6 +266,8 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
         pruning_mode: Optional[str | PruningMode] = None,
         allow_cuda_graphs: bool = True,
         enable_per_stream_biasing: bool = False,
+        preserve_step_confidence: bool = False,
+        confidence_method_cfg: Optional[DictConfig] = None,
     ):
         """
         Init method.
@@ -279,6 +284,8 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
             pruning_mode: mode for pruning hypotheses with fusion models
             allow_cuda_graphs: whether to allow CUDA graphs
             enable_per_stream_biasing: whether to enable per-stream biasing via multi-boosting tree
+            preserve_step_confidence: if step confidence should be preserved in beam hypotheses
+            confidence_method_cfg: config for the confidence estimation method
         """
 
         super().__init__()
@@ -289,6 +296,9 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
         self.beam_size = beam_size
         self.max_symbols = max_symbols_per_step
         self.preserve_alignments = preserve_alignments
+        self.preserve_step_confidence = preserve_step_confidence
+        if self.preserve_step_confidence:
+            self._init_confidence_method(confidence_method_cfg=confidence_method_cfg)
         self._SOS = self._blank_index
         self.allow_cuda_graphs = allow_cuda_graphs
 
@@ -325,6 +335,17 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
             )
         else:
             self.blank_lm_score_mode = None
+
+    def _get_step_confidence(self, log_probs: torch.Tensor) -> Optional[torch.Tensor]:
+        """Compute per-beam step confidence from token log-probabilities."""
+        if not self.preserve_step_confidence:
+            return None
+        return self._get_confidence_tensor(log_probs).to(dtype=log_probs.dtype)
+
+    def _gather_parent_step_confidence(
+        self, step_confidence: torch.Tensor, parent_indices: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.gather(step_confidence, dim=-1, index=parent_indices)
 
     @property
     def per_stream_biasing_enabled(self) -> bool:
@@ -468,6 +489,7 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
             init_length=max_time * (self.max_symbols + 1) if self.max_symbols is not None else max_time,
             device=device,
             float_dtype=float_dtype,
+            with_step_confidence=self.preserve_step_confidence,
         )
         batch_beam_indices = (
             torch.arange(batch_size, dtype=torch.long, device=device)[:, None]
@@ -624,11 +646,18 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
                 labels_top_k.reshape(batch_size, -1), dim=-1, index=hyps_candidates_indices
             )  # labels for extended hypotheses
 
+            next_step_confidence = None
+            if self.preserve_step_confidence:
+                step_confidence = self._get_step_confidence(log_probs)
+                next_step_confidence = self._gather_parent_step_confidence(step_confidence, hyps_indices)
+
             # step 3: store results
             if self.max_symbols is None:
-                batched_hyps.add_results_(hyps_indices, next_labels, next_hyps_prob)
+                batched_hyps.add_results_(hyps_indices, next_labels, next_hyps_prob, next_step_confidence=next_step_confidence)
             else:
-                batched_hyps.add_results_no_checks_(hyps_indices, next_labels, next_hyps_prob)
+                batched_hyps.add_results_no_checks_(
+                    hyps_indices, next_labels, next_hyps_prob, next_step_confidence=next_step_confidence
+                )
 
             # step 4: recombine hypotheses: sum probabilities of identical hypotheses.
             batched_hyps.recombine_hyps_()
@@ -955,6 +984,7 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
             device=encoder_output_projected.device,
             float_dtype=encoder_output_projected.dtype,
             blank_index=self._blank_index,
+            with_step_confidence=self.preserve_step_confidence,
         )
 
         self.state.decoder_state = self.decoder.initialize_state(
@@ -1255,12 +1285,25 @@ class ModifiedALSDBatchedRNNTComputer(WithOptionalCudaGraphs, ConfidenceMethodMi
         )  # labels for extended hypotheses
         self.state.next_scores.copy_(next_hyps_prob)
 
+        next_step_confidence = None
+        if self.preserve_step_confidence:
+            step_confidence = self._get_step_confidence(log_probs)
+            next_step_confidence = self._gather_parent_step_confidence(step_confidence, self.state.next_idx)
+
         # step 3: store results
         if self.max_symbols is None:
-            self.state.batched_hyps.add_results_(self.state.next_idx, self.state.next_labels, self.state.next_scores)
+            self.state.batched_hyps.add_results_(
+                self.state.next_idx,
+                self.state.next_labels,
+                self.state.next_scores,
+                next_step_confidence=next_step_confidence,
+            )
         else:
             self.state.batched_hyps.add_results_no_checks_(
-                self.state.next_idx, self.state.next_labels, self.state.next_scores
+                self.state.next_idx,
+                self.state.next_labels,
+                self.state.next_scores,
+                next_step_confidence=next_step_confidence,
             )
 
         # step 4: recombine hypotheses: sum probabilities of identical hypotheses.

--- a/nemo/collections/asr/parts/submodules/tdt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/tdt_beam_decoding.py
@@ -30,6 +30,7 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 import torch
+from omegaconf import DictConfig
 from tqdm import tqdm
 
 from nemo.collections.asr.modules import rnnt_abstract
@@ -853,6 +854,9 @@ class BeamBatchedTDTInfer(Typing, ConfidenceMethodMixin, WithOptionalCudaGraphs)
         allow_cuda_graphs: Optional[bool] = True,
         return_best_hypothesis: Optional[str] = True,
         enable_per_stream_biasing: bool = False,
+        preserve_step_confidence: bool = False,
+        include_duration_confidence: bool = False,
+        confidence_method_cfg: Optional[DictConfig] = None,
     ):
         """
         Init method.
@@ -871,6 +875,9 @@ class BeamBatchedTDTInfer(Typing, ConfidenceMethodMixin, WithOptionalCudaGraphs)
             allow_cuda_graphs: whether to allow CUDA graphs
             score_norm: whether to normalize scores before best hypothesis extraction
             enable_per_stream_biasing: whether to enable per-stream biasing via multi-boosting tree
+            preserve_step_confidence: if step confidence should be preserved in beam hypotheses
+            include_duration_confidence: if duration confidence is requested (not supported; logged and skipped)
+            confidence_method_cfg: config for the confidence estimation method
         """
         super().__init__()
         self.decoder = decoder_model
@@ -905,6 +912,9 @@ class BeamBatchedTDTInfer(Typing, ConfidenceMethodMixin, WithOptionalCudaGraphs)
                 pruning_mode=pruning_mode,
                 allow_cuda_graphs=allow_cuda_graphs,
                 enable_per_stream_biasing=enable_per_stream_biasing,
+                preserve_step_confidence=preserve_step_confidence,
+                include_duration_confidence=include_duration_confidence,
+                confidence_method_cfg=confidence_method_cfg,
             )
         else:
             raise Exception(f"Decoding strategy {search_type} nor implemented.")

--- a/nemo/collections/asr/parts/submodules/tdt_malsd_batched_computer.py
+++ b/nemo/collections/asr/parts/submodules/tdt_malsd_batched_computer.py
@@ -17,6 +17,7 @@ from typing import Any, List, Optional, Union
 import numpy as np
 import torch
 import torch.nn.functional as F
+from omegaconf import DictConfig
 
 from nemo.collections.asr.parts.context_biasing.biasing_multi_model import (
     GPUBiasingMultiModel,
@@ -123,6 +124,7 @@ class MALSDState:
         device: torch.device,
         float_dtype: torch.dtype,
         blank_index: int,
+        with_step_confidence: bool = False,
     ):
         """
         Args:
@@ -201,6 +203,7 @@ class MALSDState:
             device=device,
             float_dtype=float_dtype,
             model_type='tdt',
+            with_step_confidence=with_step_confidence,
         )
 
     def need_reinit(self, encoder_output_projected: torch.Tensor) -> bool:
@@ -259,6 +262,9 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
         pruning_mode: Optional[str | PruningMode] = None,
         allow_cuda_graphs: bool = False,
         enable_per_stream_biasing: bool = False,
+        preserve_step_confidence: bool = False,
+        include_duration_confidence: bool = False,
+        confidence_method_cfg: Optional[DictConfig] = None,
     ):
         """
         Init method.
@@ -275,6 +281,9 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
             pruning_mode: mode for pruning hypotheses with fusion models
             allow_cuda_graphs: whether to allow CUDA graphs
             enable_per_stream_biasing: whether to enable per-stream biasing via multi-boosting tree
+            preserve_step_confidence: if step confidence should be preserved in beam hypotheses
+            include_duration_confidence: if duration confidence is requested (not supported; logged and skipped)
+            confidence_method_cfg: config for the confidence estimation method
         """
 
         super().__init__()
@@ -285,6 +294,13 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
         self.beam_size = beam_size
         self.max_symbols = max_symbols_per_step
         self.preserve_alignments = preserve_alignments
+        self.preserve_step_confidence = preserve_step_confidence
+        if include_duration_confidence:
+            logging.warning(
+                "Duration confidence is not supported for malsd_batch TDT decoding. Skipping duration confidence."
+            )
+        if self.preserve_step_confidence:
+            self._init_confidence_method(confidence_method_cfg=confidence_method_cfg)
         self._SOS = self._blank_index
         self.durations = durations
         self.allow_cuda_graphs = allow_cuda_graphs
@@ -322,6 +338,17 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
             )
         else:
             self.blank_lm_score_mode = None
+
+    def _get_step_confidence(self, token_log_probs: torch.Tensor) -> Optional[torch.Tensor]:
+        """Compute per-beam step confidence from token log-probabilities (excluding durations)."""
+        if not self.preserve_step_confidence:
+            return None
+        return self._get_confidence_tensor(token_log_probs).to(dtype=token_log_probs.dtype)
+
+    def _gather_parent_step_confidence(
+        self, step_confidence: torch.Tensor, parent_indices: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.gather(step_confidence, dim=-1, index=parent_indices)
 
     @property
     def per_stream_biasing_enabled(self) -> bool:
@@ -467,6 +494,7 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
             device=device,
             float_dtype=float_dtype,
             model_type='tdt',
+            with_step_confidence=self.preserve_step_confidence,
         )
         batch_beam_indices = (
             torch.arange(batch_size, dtype=torch.long, device=device)[:, None]
@@ -639,11 +667,20 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
                 durations_top_k.reshape(batch_size, -1), dim=-1, index=hyps_candidates_indices
             )  # durations for extended hypotheses
 
+            next_step_confidence = None
+            if self.preserve_step_confidence:
+                step_confidence = self._get_step_confidence(log_probs)
+                next_step_confidence = self._gather_parent_step_confidence(step_confidence, hyps_indices)
+
             # step 3: store results
             if self.max_symbols is None:
-                batched_hyps.add_results_(hyps_indices, next_labels, next_hyps_prob, next_label_durations)
+                batched_hyps.add_results_(
+                    hyps_indices, next_labels, next_hyps_prob, next_label_durations, next_step_confidence=next_step_confidence
+                )
             else:
-                batched_hyps.add_results_no_checks_(hyps_indices, next_labels, next_hyps_prob, next_label_durations)
+                batched_hyps.add_results_no_checks_(
+                    hyps_indices, next_labels, next_hyps_prob, next_label_durations, next_step_confidence=next_step_confidence
+                )
 
             # step 4: recombine hypotheses: sum probabilities of identical hypotheses.
             batched_hyps.recombine_hyps_()
@@ -999,6 +1036,7 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
             device=encoder_output_projected.device,
             float_dtype=encoder_output_projected.dtype,
             blank_index=self._blank_index,
+            with_step_confidence=self.preserve_step_confidence,
         )
 
         self.state.decoder_state = self.decoder.initialize_state(
@@ -1334,14 +1372,27 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
         )  # labels for extended hypotheses
         self.state.next_scores.copy_(next_hyps_prob)
 
+        next_step_confidence = None
+        if self.preserve_step_confidence:
+            step_confidence = self._get_step_confidence(log_probs)
+            next_step_confidence = self._gather_parent_step_confidence(step_confidence, self.state.next_idx)
+
         # step 3: store results
         if self.max_symbols is None:
             self.state.batched_hyps.add_results_(
-                self.state.next_idx, self.state.next_labels, self.state.next_scores, self.state.next_label_durations
+                self.state.next_idx,
+                self.state.next_labels,
+                self.state.next_scores,
+                self.state.next_label_durations,
+                next_step_confidence=next_step_confidence,
             )
         else:
             self.state.batched_hyps.add_results_no_checks_(
-                self.state.next_idx, self.state.next_labels, self.state.next_scores, self.state.next_label_durations
+                self.state.next_idx,
+                self.state.next_labels,
+                self.state.next_scores,
+                self.state.next_label_durations,
+                next_step_confidence=next_step_confidence,
             )
 
         # step 4: recombine hypotheses: sum probabilities of identical hypotheses.

--- a/nemo/collections/asr/parts/submodules/tdt_malsd_batched_computer.py
+++ b/nemo/collections/asr/parts/submodules/tdt_malsd_batched_computer.py
@@ -345,11 +345,6 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
             return None
         return self._get_confidence_tensor(token_log_probs).to(dtype=token_log_probs.dtype)
 
-    def _gather_parent_step_confidence(
-        self, step_confidence: torch.Tensor, parent_indices: torch.Tensor
-    ) -> torch.Tensor:
-        return torch.gather(step_confidence, dim=-1, index=parent_indices)
-
     @property
     def per_stream_biasing_enabled(self) -> bool:
         return self.biasing_multi_model is not None
@@ -670,16 +665,24 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
             next_step_confidence = None
             if self.preserve_step_confidence:
                 step_confidence = self._get_step_confidence(log_probs)
-                next_step_confidence = self._gather_parent_step_confidence(step_confidence, hyps_indices)
+                next_step_confidence = torch.gather(step_confidence, dim=-1, index=hyps_indices)
 
             # step 3: store results
             if self.max_symbols is None:
                 batched_hyps.add_results_(
-                    hyps_indices, next_labels, next_hyps_prob, next_label_durations, next_step_confidence=next_step_confidence
+                    hyps_indices,
+                    next_labels,
+                    next_hyps_prob,
+                    next_label_durations,
+                    next_step_confidence=next_step_confidence,
                 )
             else:
                 batched_hyps.add_results_no_checks_(
-                    hyps_indices, next_labels, next_hyps_prob, next_label_durations, next_step_confidence=next_step_confidence
+                    hyps_indices,
+                    next_labels,
+                    next_hyps_prob,
+                    next_label_durations,
+                    next_step_confidence=next_step_confidence,
                 )
 
             # step 4: recombine hypotheses: sum probabilities of identical hypotheses.
@@ -1375,7 +1378,7 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
         next_step_confidence = None
         if self.preserve_step_confidence:
             step_confidence = self._get_step_confidence(log_probs)
-            next_step_confidence = self._gather_parent_step_confidence(step_confidence, self.state.next_idx)
+            next_step_confidence = torch.gather(step_confidence, dim=-1, index=self.state.next_idx)
 
         # step 3: store results
         if self.max_symbols is None:

--- a/nemo/collections/asr/parts/submodules/tdt_malsd_batched_computer.py
+++ b/nemo/collections/asr/parts/submodules/tdt_malsd_batched_computer.py
@@ -301,6 +301,12 @@ class ModifiedALSDBatchedTDTComputer(WithOptionalCudaGraphs, ConfidenceMethodMix
             )
         if self.preserve_step_confidence:
             self._init_confidence_method(confidence_method_cfg=confidence_method_cfg)
+            logging.info(
+                "Batched beam search stores per-step confidences for all decode steps (including blanks) "
+                "internally. Exported hypotheses expose non-blank token scores via "
+                "`non_blank_step_confidence_precomputed` only; `Hypothesis.frame_confidence` is not populated. "
+                "Run `compute_confidence()` for token- and word-level scores."
+            )
         self._SOS = self._blank_index
         self.durations = durations
         self.allow_cuda_graphs = allow_cuda_graphs

--- a/nemo/collections/asr/parts/utils/asr_confidence_utils.py
+++ b/nemo/collections/asr/parts/utils/asr_confidence_utils.py
@@ -366,19 +366,25 @@ class ConfidenceMixin(ABC):
         self.confidence_aggregation_bank = get_confidence_aggregation_bank()
         self._aggregate_confidence = self.confidence_aggregation_bank[self.word_confidence_aggregation]
 
-        # Update preserve frame confidence
+        # Update preserve frame confidence from strategy-specific config (greedy or batched beam).
+        strategy_overrides = None
         if self.cfg.strategy in ['greedy', 'greedy_batch']:
+            strategy_overrides = self.cfg.greedy
+        elif self.cfg.strategy in ['malsd_batch', 'maes_batch']:
+            strategy_overrides = self.cfg.beam
+
+        if strategy_overrides is not None:
             if not self.preserve_frame_confidence:
-                self.preserve_frame_confidence = self.cfg.greedy.get('preserve_frame_confidence', False)
+                self.preserve_frame_confidence = strategy_overrides.get('preserve_frame_confidence', False)
                 # OmegaConf.structured ensures that post_init check is always executed
-                confidence_method_cfg = OmegaConf.structured(self.cfg.greedy).get('confidence_method_cfg', None)
+                confidence_method_cfg = OmegaConf.structured(strategy_overrides).get('confidence_method_cfg', None)
                 self.confidence_method_cfg = (
                     OmegaConf.structured(ConfidenceMethodConfig())
                     if confidence_method_cfg is None
                     else OmegaConf.structured(ConfidenceMethodConfig(**confidence_method_cfg))
                 )
             if not self.tdt_include_duration_confidence:
-                self.tdt_include_duration_confidence = self.cfg.greedy.get('tdt_include_duration_confidence', False)
+                self.tdt_include_duration_confidence = strategy_overrides.get('tdt_include_duration_confidence', False)
 
     @abstractmethod
     def compute_confidence(self, hypotheses_list: List["Hypothesis"]) -> List["Hypothesis"]:

--- a/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
+++ b/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
@@ -1052,7 +1052,7 @@ class BatchedBeamHyps:
 
 def export_batched_beam_hyps_to_cpu_lists(
     bbh: BatchedBeamHyps,
-) -> tuple[list[list[list[int]]], list[list[list[int]]], list[list[int]], list[list[list[float]]] | None]:
+) -> tuple[list[list[list[int]]], list[list[list[int]]], list[list[list[float]]] | None, list[list[int]]]:
     """Export chunk-local per-beam tokens/timestamps/confidences and beam descent map to CPU lists."""
     _, transcripts, timestamps, _, root_ptrs, step_confidence = bbh._export(sort=False)
     root_ptrs_list = root_ptrs.detach().cpu().tolist()
@@ -1080,4 +1080,4 @@ def export_batched_beam_hyps_to_cpu_lists(
         timestamps_out.append(bts)
         if step_confidence_cpu is not None:
             confidences_out.append(bc)
-    return tokens, timestamps_out, root_ptrs_list, confidences_out
+    return tokens, timestamps_out, confidences_out, root_ptrs_list

--- a/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
+++ b/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
@@ -1062,9 +1062,9 @@ def export_batched_beam_hyps_to_cpu_lists(
     tokens: list[list[list[int]]] = []
     timestamps_out: list[list[list[int]]] = []
     confidences_out: list[list[list[float]]] | None = None
-    if step_confidence is not None:
+    step_confidence_cpu = step_confidence.detach().cpu() if step_confidence is not None else None
+    if step_confidence_cpu is not None:
         confidences_out = []
-        step_confidence_cpu = step_confidence.detach().cpu()
     for b in range(bbh.batch_size):
         bt: list[list[int]] = []
         bts: list[list[int]] = []
@@ -1074,10 +1074,10 @@ def export_batched_beam_hyps_to_cpu_lists(
             mask = bbh._create_transcripts_mask(t)
             bt.append(t[mask].tolist())
             bts.append(timestamps_cpu[b, k][mask].tolist())
-            if confidences_out is not None:
+            if step_confidence_cpu is not None:
                 bc.append(step_confidence_cpu[b, k][mask].tolist())
         tokens.append(bt)
         timestamps_out.append(bts)
-        if confidences_out is not None:
+        if step_confidence_cpu is not None:
             confidences_out.append(bc)
     return tokens, timestamps_out, root_ptrs_list, confidences_out

--- a/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
+++ b/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
@@ -1062,9 +1062,9 @@ def export_batched_beam_hyps_to_cpu_lists(
     tokens: list[list[list[int]]] = []
     timestamps_out: list[list[list[int]]] = []
     confidences_out: list[list[list[float]]] | None = None
-    if step_confidence is not None:
+    step_confidence_cpu = None if step_confidence is None else step_confidence.detach().cpu()
+    if step_confidence_cpu is not None:
         confidences_out = []
-        step_confidence_cpu = step_confidence.detach().cpu()
     for b in range(bbh.batch_size):
         bt: list[list[int]] = []
         bts: list[list[int]] = []
@@ -1074,10 +1074,10 @@ def export_batched_beam_hyps_to_cpu_lists(
             mask = bbh._create_transcripts_mask(t)
             bt.append(t[mask].tolist())
             bts.append(timestamps_cpu[b, k][mask].tolist())
-            if confidences_out is not None:
+            if step_confidence_cpu is not None:
                 bc.append(step_confidence_cpu[b, k][mask].tolist())
         tokens.append(bt)
         timestamps_out.append(bts)
-        if confidences_out is not None:
+        if step_confidence_cpu is not None:
             confidences_out.append(bc)
     return tokens, timestamps_out, root_ptrs_list, confidences_out

--- a/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
+++ b/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
@@ -122,6 +122,7 @@ class BatchedBeamHyps:
         float_dtype: torch.dtype = None,
         store_prefix_hashes: Optional[bool] = False,
         model_type: Optional[ASRModelTypeEnum | str] = ASRModelTypeEnum.RNNT,
+        with_step_confidence: Optional[bool] = False,
     ):
         """
         Initializes the batched beam hypotheses utility for Transducer decoding (RNN-T and TDT models).
@@ -134,6 +135,7 @@ class BatchedBeamHyps:
             float_dtype (torch.dtype): The floating-point data type. Defaults to None.
             store_prefix_hashes (bool, optional): Whether to store prefix hashes for hypotheses. Defaults to False.
             model_type: (str or ModelTypeEnum, optional): Model type, either 'rnnt', 'tdt' or 'ctc'. Defaults to 'rnnt'.
+            with_step_confidence: Whether to store per-step confidence scores aligned with ``transcript_wb``.
         """
 
         if beam_size <= 0:
@@ -148,6 +150,7 @@ class BatchedBeamHyps:
         self.ZERO_TENSOR = torch.tensor(0, device=device, dtype=torch.long)
 
         self.model_type = ASRModelTypeEnum(model_type)
+        self.with_step_confidence = with_step_confidence
         self.store_prefix_hashes = store_prefix_hashes
         self._max_length = init_length
         self.beam_size = beam_size
@@ -210,6 +213,13 @@ class BatchedBeamHyps:
                     (batch_size, self.beam_size, self._max_length), device=device, dtype=torch.long
                 )
 
+        if self.with_step_confidence:
+            self.step_confidence = torch.zeros(
+                (batch_size, self.beam_size, self._max_length), device=device, dtype=float_dtype
+            )
+        else:
+            self.step_confidence = None
+
     def clear_(self):
         """
         Clears and resets the internal state of the object.
@@ -239,6 +249,9 @@ class BatchedBeamHyps:
             self.last_timestamp_lasts.fill_(0)
             if self.model_type == ASRModelTypeEnum.TDT:
                 self.token_durations.fill_(0)
+
+        if self.with_step_confidence:
+            self.step_confidence.fill_(0.0)
 
     def export_cross_chunk_state(self, batch_size: Optional[int] = None) -> dict[str, Optional[torch.Tensor]]:
         """
@@ -303,6 +316,7 @@ class BatchedBeamHyps:
             float_dtype=self.scores.dtype,
             store_prefix_hashes=self.store_prefix_hashes,
             model_type=self.model_type,
+            with_step_confidence=self.with_step_confidence,
         )
         # Destination is freshly allocated at exactly [out_batch, beam_size, _max_length],
         # so we can copy whole rows of `self` directly without per-axis trimming.
@@ -321,6 +335,8 @@ class BatchedBeamHyps:
             new_hyps.last_timestamp_lasts.copy_(self.last_timestamp_lasts[:out_batch])
             if self.model_type == ASRModelTypeEnum.TDT:
                 new_hyps.token_durations.copy_(self.token_durations[:out_batch])
+        if self.with_step_confidence:
+            new_hyps.step_confidence.copy_(self.step_confidence[:out_batch])
         return new_hyps
 
     def keep_beam_(self, beam_indices: torch.Tensor) -> None:
@@ -371,6 +387,9 @@ class BatchedBeamHyps:
                     (self.token_durations, torch.zeros_like(self.token_durations)), dim=-1
                 )
 
+        if self.with_step_confidence:
+            self.step_confidence = torch.cat((self.step_confidence, torch.zeros_like(self.step_confidence)), dim=-1)
+
         self._max_length *= 2
 
     def add_results_(
@@ -379,6 +398,7 @@ class BatchedBeamHyps:
         next_labels: torch.Tensor,
         next_hyps_prob: torch.Tensor,
         next_label_durations: Optional[torch.Tensor] = None,
+        next_step_confidence: Optional[torch.Tensor] = None,
     ):
         """
         Updates batch of beam hypotheses with labels. If the maximum allowed length
@@ -388,6 +408,7 @@ class BatchedBeamHyps:
             next_labels (torch.Tensor): Labels corresponding to the next step in the beam search.
             next_hyps_prob (torch.Tensor): Probabilities of the next hypotheses.
             next_label_durations (torch.Tensor, optional): Durations associated with the next labels. Required when `model_type='tdt'`.
+            next_step_confidence (torch.Tensor, optional): Per-beam step confidence aligned with ``next_labels``.
         """
 
         if self.model_type == ASRModelTypeEnum.TDT and next_label_durations is None:
@@ -401,6 +422,7 @@ class BatchedBeamHyps:
             next_labels=next_labels,
             next_hyps_prob=next_hyps_prob,
             next_label_durations=next_label_durations,
+            next_step_confidence=next_step_confidence,
         )
 
     def add_results_no_checks_(
@@ -409,6 +431,7 @@ class BatchedBeamHyps:
         next_labels: torch.Tensor,
         next_hyps_prob: torch.Tensor,
         next_label_durations: Optional[torch.Tensor] = None,
+        next_step_confidence: Optional[torch.Tensor] = None,
     ):
         """
         Updates batch of beam hypotheses with labels.
@@ -417,6 +440,7 @@ class BatchedBeamHyps:
             next_labels (torch.Tensor): Labels corresponding to the next step in the beam search.
             next_hyps_prob (torch.Tensor): Probabilities of the next hypotheses.
             next_label_durations (torch.Tensor, optional): Durations associated with the next labels. Required when `model_type='tdt'`.
+            next_step_confidence (torch.Tensor, optional): Per-beam step confidence aligned with ``next_labels``.
         """
         if self.model_type == ASRModelTypeEnum.TDT and next_label_durations is None:
             raise ValueError("`next_label_durations` is required when model type is TDT.")
@@ -468,6 +492,17 @@ class BatchedBeamHyps:
                 dim=-1,
                 index=self.current_lengths_wb.unsqueeze(-1),
                 src=torch.where(is_extended, next_label_durations, 0).unsqueeze(-1).to(self.token_durations.dtype),
+            )
+
+        if self.with_step_confidence and next_step_confidence is not None:
+            self.step_confidence.scatter_(
+                dim=-1,
+                index=self.current_lengths_wb.unsqueeze(-1),
+                src=torch.where(
+                    is_extended.unsqueeze(-1),
+                    next_step_confidence.unsqueeze(-1).to(self.step_confidence.dtype),
+                    torch.zeros(1, device=self.device, dtype=self.step_confidence.dtype),
+                ),
             )
 
         self.current_lengths_nb.copy_(
@@ -630,9 +665,9 @@ class BatchedBeamHyps:
             list[Hypothesis]: A list where each element corresponds to a batch and contains
             best hypothesis.
         """
-        scores, transcripts, timestamps, durations, _ = self._export(sort=True, score_norm=score_norm)
+        scores, transcripts, timestamps, durations, _, step_confidence = self._export(sort=True, score_norm=score_norm)
         return [
-            self._hypothesis_from_flat(b, 0, scores, transcripts, timestamps, durations)
+            self._hypothesis_from_flat(b, 0, scores, transcripts, timestamps, durations, step_confidence)
             for b in range(self.batch_size)
         ]
 
@@ -645,7 +680,7 @@ class BatchedBeamHyps:
             list[NBestHypotheses]: A list where each element corresponds to a batch and contains
             N-best hypotheses.
         """
-        scores, transcripts, timestamps, durations, _ = self._export(sort=True, score_norm=score_norm)
+        scores, transcripts, timestamps, durations, _, step_confidence = self._export(sort=True, score_norm=score_norm)
         hypotheses = []
         for batch_idx in range(self.batch_size):
             nbest = []
@@ -653,14 +688,21 @@ class BatchedBeamHyps:
                 if scores[batch_idx][beam_idx] <= INACTIVE_SCORE:
                     continue
                 nbest.append(
-                    self._hypothesis_from_flat(batch_idx, beam_idx, scores, transcripts, timestamps, durations)
+                    self._hypothesis_from_flat(
+                        batch_idx, beam_idx, scores, transcripts, timestamps, durations, step_confidence
+                    )
                 )
             hypotheses.append(NBestHypotheses(nbest))
         return hypotheses
 
-    def _export(
-        self, sort: bool = True, score_norm: bool = True
-    ) -> tuple[list[list[float]], torch.Tensor, torch.Tensor, Optional[torch.Tensor], torch.Tensor]:
+    def _export(self, sort: bool = True, score_norm: bool = True) -> tuple[
+        list[list[float]],
+        torch.Tensor,
+        torch.Tensor,
+        Optional[torch.Tensor],
+        torch.Tensor,
+        Optional[torch.Tensor],
+    ]:
         """
         Flatten the prefix tree and return per-(batch, beam) views.
 
@@ -670,10 +712,10 @@ class BatchedBeamHyps:
             score_norm: passed to :meth:`flatten_sort_` when ``sort=True``.
 
         Returns:
-            (scores, transcripts, timestamps, durations, root_ptrs). The first four
-            are inputs for :meth:`_hypothesis_from_flat`; ``root_ptrs`` is the
+            (scores, transcripts, timestamps, durations, root_ptrs, step_confidence). The first
+            four are inputs for :meth:`_hypothesis_from_flat`; ``root_ptrs`` is the
             chunk-start -> chunk-end slot descent map (``[batch, beam]`` long
-            tensor) for the current beam ordering.
+            tensor) for the current beam ordering; ``step_confidence`` is optional.
         """
         if sort:
             root_ptrs = self.flatten_sort_(score_norm)
@@ -684,7 +726,8 @@ class BatchedBeamHyps:
         transcripts = self.transcript_wb[..., : max_idx + 1]
         timestamps = self.timestamps[..., : max_idx + 1]
         durations = self.token_durations[..., : max_idx + 1] if self.model_type == ASRModelTypeEnum.TDT else None
-        return scores, transcripts, timestamps, durations, root_ptrs
+        step_confidence = self.step_confidence[..., : max_idx + 1] if self.with_step_confidence else None
+        return scores, transcripts, timestamps, durations, root_ptrs, step_confidence
 
     def _hypothesis_from_flat(
         self,
@@ -694,6 +737,7 @@ class BatchedBeamHyps:
         transcripts: torch.Tensor,
         timestamps: torch.Tensor,
         durations: Optional[torch.Tensor],
+        step_confidence: Optional[torch.Tensor] = None,
     ) -> Hypothesis:
         """Build one ``Hypothesis`` from already-flattened per-(batch, beam) views."""
         transcript = transcripts[batch_idx][beam_idx]
@@ -707,6 +751,9 @@ class BatchedBeamHyps:
         else:
             timestamp = end_times.cpu().detach().numpy()
             token_duration = None
+        nb_confidence = None
+        if step_confidence is not None:
+            nb_confidence = step_confidence[batch_idx][beam_idx][mask].cpu().detach().tolist()
         return Hypothesis(
             score=scores[batch_idx][beam_idx],
             y_sequence=transcript[mask].cpu().detach().numpy(),
@@ -714,6 +761,7 @@ class BatchedBeamHyps:
             token_duration=token_duration,
             alignments=None,
             dec_state=None,
+            non_blank_step_confidence_precomputed=nb_confidence,
         )
 
     def flatten_sort_(self, score_norm: bool = True) -> torch.Tensor:
@@ -793,6 +841,8 @@ class BatchedBeamHyps:
                     self.token_durations[..., idx].copy_(
                         self.token_durations[self.batch_indices.unsqueeze(-1), ptrs, idx]
                     )
+            if self.with_step_confidence:
+                self.step_confidence[..., idx].copy_(self.step_confidence[self.batch_indices.unsqueeze(-1), ptrs, idx])
             ptrs = self.transcript_wb_prev_ptr[self.batch_indices.unsqueeze(-1), ptrs, idx]
         self.transcript_wb_prev_ptr[..., : max_idx + 1].copy_(self.beam_indices.unsqueeze(0).unsqueeze(-1))
 
@@ -960,6 +1010,12 @@ class BatchedBeamHyps:
                 index=shifted_indices,
                 src=other.token_durations[..., :max_other_len],
             )
+        if self.with_step_confidence:
+            self.step_confidence.scatter_(
+                dim=-1,
+                index=shifted_indices,
+                src=other.step_confidence[..., :max_other_len],
+            )
 
         # Lengths in the chunk-local write cursor are always additive (``other`` always
         # reports a chunk-local ``current_lengths_wb``).
@@ -996,23 +1052,32 @@ class BatchedBeamHyps:
 
 def export_batched_beam_hyps_to_cpu_lists(
     bbh: BatchedBeamHyps,
-) -> tuple[list[list[list[int]]], list[list[list[int]]], list[list[int]]]:
-    """Export chunk-local per-beam tokens/timestamps and beam descent map to CPU lists."""
-    _, transcripts, timestamps, _, root_ptrs = bbh._export(sort=False)
+) -> tuple[list[list[list[int]]], list[list[list[int]]], list[list[int]], list[list[list[float]]] | None]:
+    """Export chunk-local per-beam tokens/timestamps/confidences and beam descent map to CPU lists."""
+    _, transcripts, timestamps, _, root_ptrs, step_confidence = bbh._export(sort=False)
     root_ptrs_list = root_ptrs.detach().cpu().tolist()
     transcripts_cpu = transcripts.detach().cpu()
     timestamps_cpu = timestamps.detach().cpu()
 
     tokens: list[list[list[int]]] = []
     timestamps_out: list[list[list[int]]] = []
+    confidences_out: list[list[list[float]]] | None = None
+    if step_confidence is not None:
+        confidences_out = []
+        step_confidence_cpu = step_confidence.detach().cpu()
     for b in range(bbh.batch_size):
         bt: list[list[int]] = []
         bts: list[list[int]] = []
+        bc: list[list[float]] = []
         for k in range(bbh.beam_size):
             t = transcripts_cpu[b, k]
             mask = bbh._create_transcripts_mask(t)
             bt.append(t[mask].tolist())
             bts.append(timestamps_cpu[b, k][mask].tolist())
+            if confidences_out is not None:
+                bc.append(step_confidence_cpu[b, k][mask].tolist())
         tokens.append(bt)
         timestamps_out.append(bts)
-    return tokens, timestamps_out, root_ptrs_list
+        if confidences_out is not None:
+            confidences_out.append(bc)
+    return tokens, timestamps_out, root_ptrs_list, confidences_out

--- a/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
+++ b/nemo/collections/asr/parts/utils/batched_beam_decoding_utils.py
@@ -1062,9 +1062,9 @@ def export_batched_beam_hyps_to_cpu_lists(
     tokens: list[list[list[int]]] = []
     timestamps_out: list[list[list[int]]] = []
     confidences_out: list[list[list[float]]] | None = None
-    step_confidence_cpu = step_confidence.detach().cpu() if step_confidence is not None else None
-    if step_confidence_cpu is not None:
+    if step_confidence is not None:
         confidences_out = []
+        step_confidence_cpu = step_confidence.detach().cpu()
     for b in range(bbh.batch_size):
         bt: list[list[int]] = []
         bts: list[list[int]] = []
@@ -1074,10 +1074,10 @@ def export_batched_beam_hyps_to_cpu_lists(
             mask = bbh._create_transcripts_mask(t)
             bt.append(t[mask].tolist())
             bts.append(timestamps_cpu[b, k][mask].tolist())
-            if step_confidence_cpu is not None:
+            if confidences_out is not None:
                 bc.append(step_confidence_cpu[b, k][mask].tolist())
         tokens.append(bt)
         timestamps_out.append(bts)
-        if step_confidence_cpu is not None:
+        if confidences_out is not None:
             confidences_out.append(bc)
     return tokens, timestamps_out, root_ptrs_list, confidences_out

--- a/nemo/collections/asr/parts/utils/streaming_utils.py
+++ b/nemo/collections/asr/parts/utils/streaming_utils.py
@@ -2463,8 +2463,8 @@ class DynamicLengthTensor:
         other_len = data.shape[1]
         indices = torch.arange(other_len, device=self.device)
         shifted_indices = self.lengths[:, None] + indices[None, :]
-        # add trailing len(dim_shape) axes to shifted_indices (tuple index: py3.10-compatible)
-        shifted_indices = shifted_indices[(...,) + (None,) * len(self.dim_shape)]
+        # add trailing len(dim_shape) axes to shifted_indices
+        shifted_indices = shifted_indices[..., *[None for _ in range(len(self.dim_shape))]]
         self.data.scatter_(dim=1, index=shifted_indices.expand([-1, -1] + self.dim_shape), src=data)
         if lengths is None:
             self.lengths += other_len

--- a/nemo/collections/asr/parts/utils/streaming_utils.py
+++ b/nemo/collections/asr/parts/utils/streaming_utils.py
@@ -2463,8 +2463,8 @@ class DynamicLengthTensor:
         other_len = data.shape[1]
         indices = torch.arange(other_len, device=self.device)
         shifted_indices = self.lengths[:, None] + indices[None, :]
-        # add trailing len(dim_shape) axes to shifted_indices
-        shifted_indices = shifted_indices[..., *[None for _ in range(len(self.dim_shape))]]
+        # add trailing len(dim_shape) axes to shifted_indices (tuple index: py3.10-compatible)
+        shifted_indices = shifted_indices[(...,) + (None,) * len(self.dim_shape)]
         self.data.scatter_(dim=1, index=shifted_indices.expand([-1, -1] + self.dim_shape), src=data)
         if lengths is None:
             self.lengths += other_len

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -21,7 +21,7 @@ from tempfile import NamedTemporaryFile
 from typing import List, Optional, Tuple, Union
 
 import torch
-from omegaconf import DictConfig
+from omegaconf import DictConfig, open_dict
 from tqdm.auto import tqdm
 
 from nemo.collections.asr.metrics.wer import word_error_rate
@@ -36,6 +36,24 @@ _MPS_WARNING_TEXT = (
     "MPS device (Apple Silicon M-series GPU) support is experimental."
     " Env variable `PYTORCH_ENABLE_MPS_FALLBACK=1` should be set in most cases to avoid failures."
 )
+
+
+def wire_confidence_cfg(decoding_cfg: DictConfig, enabled: bool = True) -> None:
+    """Enable confidence estimation on a CTC or RNNT decoding config.
+
+    Mirrors the greedy/beam strategy override pattern used by ``ConfidenceMixin._init_confidence``.
+    """
+    if not enabled:
+        return
+    with open_dict(decoding_cfg):
+        decoding_cfg.confidence_cfg.preserve_frame_confidence = True
+        decoding_cfg.confidence_cfg.preserve_token_confidence = True
+        decoding_cfg.confidence_cfg.preserve_word_confidence = True
+        strategy = decoding_cfg.get("strategy", "greedy")
+        if strategy in ("greedy", "greedy_batch"):
+            decoding_cfg.greedy.preserve_frame_confidence = True
+        elif strategy in ("malsd_batch", "maes_batch"):
+            decoding_cfg.beam.preserve_frame_confidence = True
 
 
 def get_auto_inference_device(allow_mps: bool = True) -> torch.device:
@@ -508,6 +526,8 @@ def write_transcription(
                         if hasattr(transcription, "word_confidence"):
                             item["word_confidence"] = transcription.word_confidence
                             item["words"] = transcription.words
+                        if getattr(transcription, "token_confidence", None) is not None:
+                            item["token_confidence"] = transcription.token_confidence
 
                     if compute_langs:
                         item['pred_lang'] = transcription.langs
@@ -542,6 +562,8 @@ def write_transcription(
                             if hasattr(hyp, "word_confidence"):
                                 item["word_confidence"] = hyp.word_confidence
                                 item["words"] = hyp.words
+                            if getattr(hyp, "token_confidence", None) is not None:
+                                item["token_confidence"] = hyp.token_confidence
 
                         if compute_langs:
                             item['pred_lang'] = best_hyps[idx].langs

--- a/tests/collections/asr/decoding/test_batched_beam_hyps.py
+++ b/tests/collections/asr/decoding/test_batched_beam_hyps.py
@@ -1295,7 +1295,7 @@ class TestConvertToHypotheses:
             next_hyps_prob=torch.tensor([[0.0]], device=device),
             next_step_confidence=torch.tensor([[0.8]], device=device),
         )
-        tokens, timestamps, root_ptrs, confidences = export_batched_beam_hyps_to_cpu_lists(hyps)
+        tokens, timestamps, confidences, root_ptrs = export_batched_beam_hyps_to_cpu_lists(hyps)
         assert tokens == [[[5, 2]]]
         assert confidences[0][0] == pytest.approx([0.9, 0.8])
         assert root_ptrs == [[0]]

--- a/tests/collections/asr/decoding/test_batched_beam_hyps.py
+++ b/tests/collections/asr/decoding/test_batched_beam_hyps.py
@@ -22,6 +22,7 @@ from nemo.collections.asr.parts.utils.batched_beam_decoding_utils import (
     INIT_POINTER_VALUE,
     NON_EXISTENT_LABEL_VALUE,
     BatchedBeamHyps,
+    export_batched_beam_hyps_to_cpu_lists,
 )
 from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis, NBestHypotheses
 
@@ -1229,3 +1230,70 @@ class TestConvertToHypotheses:
         assert hypotheses[1].n_best_hypotheses[0].score == pytest.approx(0.6)
         assert hypotheses[1].n_best_hypotheses[1].score == pytest.approx(0.55)
         assert hypotheses[1].n_best_hypotheses[2].score == pytest.approx(0.4)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("device", DEVICES)
+    def test_to_hyps_list_with_step_confidence(self, device: torch.device):
+        blank_index = 1024
+        hyps = BatchedBeamHyps(
+            batch_size=1,
+            beam_size=1,
+            init_length=4,
+            device=device,
+            blank_index=blank_index,
+            with_step_confidence=True,
+        )
+        hyps.add_results_(
+            next_indices=torch.tensor([[0]], device=device),
+            next_labels=torch.tensor([[5]], device=device),
+            next_hyps_prob=torch.tensor([[0.0]], device=device),
+            next_step_confidence=torch.tensor([[0.9]], device=device),
+        )
+        hyps.add_results_(
+            next_indices=torch.tensor([[0]], device=device),
+            next_labels=torch.tensor([[blank_index]], device=device),
+            next_hyps_prob=torch.tensor([[0.0]], device=device),
+            next_step_confidence=torch.tensor([[0.5]], device=device),
+        )
+        hyps.add_results_(
+            next_indices=torch.tensor([[0]], device=device),
+            next_labels=torch.tensor([[2]], device=device),
+            next_hyps_prob=torch.tensor([[0.0]], device=device),
+            next_step_confidence=torch.tensor([[0.8]], device=device),
+        )
+        hypotheses = hyps.to_hyps_list(score_norm=False)
+        assert hypotheses[0].non_blank_step_confidence_precomputed == pytest.approx([0.9, 0.8])
+        assert hypotheses[0].y_sequence.tolist() == [5, 2]
+
+    def test_export_batched_beam_hyps_to_cpu_lists_with_step_confidence(self, device: torch.device):
+        blank_index = 1024
+        hyps = BatchedBeamHyps(
+            batch_size=1,
+            beam_size=1,
+            init_length=4,
+            device=device,
+            blank_index=blank_index,
+            with_step_confidence=True,
+        )
+        hyps.add_results_(
+            next_indices=torch.tensor([[0]], device=device),
+            next_labels=torch.tensor([[5]], device=device),
+            next_hyps_prob=torch.tensor([[0.0]], device=device),
+            next_step_confidence=torch.tensor([[0.9]], device=device),
+        )
+        hyps.add_results_(
+            next_indices=torch.tensor([[0]], device=device),
+            next_labels=torch.tensor([[blank_index]], device=device),
+            next_hyps_prob=torch.tensor([[0.0]], device=device),
+            next_step_confidence=torch.tensor([[0.5]], device=device),
+        )
+        hyps.add_results_(
+            next_indices=torch.tensor([[0]], device=device),
+            next_labels=torch.tensor([[2]], device=device),
+            next_hyps_prob=torch.tensor([[0.0]], device=device),
+            next_step_confidence=torch.tensor([[0.8]], device=device),
+        )
+        tokens, timestamps, root_ptrs, confidences = export_batched_beam_hyps_to_cpu_lists(hyps)
+        assert tokens == [[[5, 2]]]
+        assert confidences == [[[0.9, 0.8]]]
+        assert root_ptrs == [[0]]

--- a/tests/collections/asr/decoding/test_batched_beam_hyps.py
+++ b/tests/collections/asr/decoding/test_batched_beam_hyps.py
@@ -1265,6 +1265,8 @@ class TestConvertToHypotheses:
         assert hypotheses[0].non_blank_step_confidence_precomputed == pytest.approx([0.9, 0.8])
         assert hypotheses[0].y_sequence.tolist() == [5, 2]
 
+    @pytest.mark.unit
+    @pytest.mark.parametrize("device", DEVICES)
     def test_export_batched_beam_hyps_to_cpu_lists_with_step_confidence(self, device: torch.device):
         blank_index = 1024
         hyps = BatchedBeamHyps(
@@ -1295,5 +1297,5 @@ class TestConvertToHypotheses:
         )
         tokens, timestamps, root_ptrs, confidences = export_batched_beam_hyps_to_cpu_lists(hyps)
         assert tokens == [[[5, 2]]]
-        assert confidences == [[[0.9, 0.8]]]
+        assert confidences[0][0] == pytest.approx([0.9, 0.8])
         assert root_ptrs == [[0]]

--- a/tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_char.py
+++ b/tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_char.py
@@ -343,6 +343,9 @@ class TestEncDecHybridRNNTCTCModel:
             'blank_index',
             'boosting_tree',
             'boosting_tree_alpha',
+            'preserve_frame_confidence',
+            'tdt_include_duration_confidence',
+            'confidence_method_cfg',
         ]
 
         result = assert_dataclass_signature_match(

--- a/tests/collections/asr/test_asr_rnnt_encdec_model.py
+++ b/tests/collections/asr/test_asr_rnnt_encdec_model.py
@@ -466,6 +466,9 @@ class TestEncDecRNNTModel:
             'blank_index',
             'boosting_tree',
             'boosting_tree_alpha',
+            'preserve_frame_confidence',
+            'tdt_include_duration_confidence',
+            'confidence_method_cfg',
         ]
 
         result = assert_dataclass_signature_match(


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Adds **confidence scores to batched beam search** (`malsd_batch`) for RNNT/TDT, mirroring the existing greedy confidence path.

**Decoding:** When beam.preserve_frame_confidence=true, MALSD computes per-emission-step confidence from joint log-probs and stores it in BatchedBeamHyps (blanks included internally). Exported hypotheses get non_blank_step_confidence_precomputed (one score per non-blank token).

**Offline:** speech_to_text_eval.py, transcribe_speech.py, and chunked speech_to_text_streaming_infer_rnnt.py wire confidence via shared wire_confidence_cfg(); compute_confidence() produces token/word scores in the output jsonl.

**NeMo streaming inference:** Cache-aware beam state tracks per-token confidences across chunks; the BPE decoder publishes word-level "conf" in segment JSON files. Top-level jsonl stays pred_text only.

**Config:** beam.preserve_frame_confidence, beam.confidence_method_cfg (same pattern as greedy). 

**Not included:** Hypothesis.frame_confidence on beam export (only non-blank precomputed scores); does not include alignments structure. TDT exports token confidence only — duration confidence is skipped with a warning.

Builds on cache-aware streaming beam search (#15765).

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
