### PR TITLE
Update language handling in Magpie eval

### DIFF
--- a/examples/tts/magpietts_inference.py
+++ b/examples/tts/magpietts_inference.py
@@ -55,7 +55,6 @@ Example usage:
 from __future__ import annotations
 
 import argparse
-import copy
 import json
 import os
 import random
@@ -241,12 +240,24 @@ def run_inference_and_evaluation(
 
         meta = dataset_meta_info[dataset]
         manifest_records = read_manifest(meta['manifest_path'])
-        language = meta.get('whisper_language', 'en')
 
-        # Prepare dataset metadata (remove evaluation-specific keys)
-        dataset_meta_for_dl = copy.deepcopy(meta)
-        for key in ["whisper_language", "load_cached_codes_if_available"]:
-            dataset_meta_for_dl.pop(key, None)
+        if 'asr_model' in meta:
+            asr_model_name = meta['asr_model']['name']
+            asr_model_type = meta['asr_model']['type']
+        else:
+            asr_model_name = eval_config.asr_model_name
+            asr_model_type = eval_config.asr_model_type
+
+        if 'language' in meta:
+            language = meta.get('language')
+        else:
+            language = eval_config.language
+
+        dataset_meta_for_dl = {
+            "manifest_path": meta["manifest_path"],
+            "audio_dir": meta["audio_dir"],
+            "language": language,
+        }
 
         # Setup output directories
         eval_dir = os.path.join(out_dir, f"{full_checkpoint_name}_{dataset}")
@@ -303,7 +314,8 @@ def run_inference_and_evaluation(
             # Run evaluation
             eval_config_for_dataset = EvaluationConfig(
                 sv_model=eval_config.sv_model,
-                asr_model_name=eval_config.asr_model_name,
+                asr_model_name=asr_model_name,
+                asr_model_type=asr_model_type,
                 eou_model_name=eval_config.eou_model_name,
                 language=language,
                 with_utmosv2=eval_config.with_utmosv2,
@@ -503,6 +515,12 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
         default=None,
         help='Comma-separated list of dataset names to process',
     )
+    data_group.add_argument(
+        '--tokenizer_name',
+        type=str,
+        default="english_phoneme",
+        help='Default tokenizer to use when a language or dataset specific tokenizer is not provided.',
+    )
     data_group.add_argument('--out_dir', type=str, required=True, help='Output directory')
     data_group.add_argument('--log_exp_name', action='store_true')
     data_group.add_argument('--clean_up_disk', action='store_true')
@@ -521,7 +539,22 @@ def _add_common_args(parser: argparse.ArgumentParser) -> None:
     eval_group = parser.add_argument_group('Evaluation')
     eval_group.add_argument('--run_evaluation', action='store_true', help='Run evaluation after inference')
     eval_group.add_argument('--sv_model', type=str, default="titanet", choices=["titanet", "wavlm"])
-    eval_group.add_argument('--asr_model_name', type=str, default="nvidia/parakeet-tdt-1.1b")
+    eval_group.add_argument(
+        '--asr_model_name',
+        type=str,
+        default='nvidia/parakeet-tdt-1.1b',
+        help="ASR model to use for WER calculation, when not provided in dataset config",
+    )
+    eval_group.add_argument(
+        '--asr_model_type',
+        type=str,
+        default='nemo',
+        choices=['nemo', 'nemo_with_prompt', 'whisper'],
+        help="Type of ASR model provided in 'asr_model_name'",
+    )
+    eval_group.add_argument(
+        '--language', type=str, default="en", help='Language to use, when not provided in dataset config'
+    )
     eval_group.add_argument(
         '--eou_model_name',
         type=str,
@@ -645,6 +678,7 @@ def _build_magpie_config(args) -> MagpieInferenceConfig:
         maskgit_noise_scale=args.maskgit_noise_scale,
         maskgit_fixed_schedule=args.maskgit_fixed_schedule,
         maskgit_sampling_type=args.maskgit_sampling_type,
+        default_tokenizer_name=args.tokenizer_name,
     )
 
 
@@ -657,6 +691,7 @@ def _build_easy_magpie_config(args) -> EasyMagpieInferenceConfig:
         phoneme_input_type=args.phoneme_input_type,
         phoneme_sampling_method=args.phoneme_sampling_method,
         dropout_text_input=args.dropout_text_input,
+        default_tokenizer_name=args.tokenizer_name,
     )
 
 
@@ -694,7 +729,9 @@ def main(argv=None):
     eval_config = EvaluationConfig(
         sv_model=args.sv_model,
         asr_model_name=args.asr_model_name,
+        asr_model_type=args.asr_model_type,
         eou_model_name=args.eou_model_name,
+        language=args.language,
         with_utmosv2=not args.disable_utmosv2,
         with_fcd=not args.disable_fcd,
         codec_model_path=args.codecmodel_path if not args.disable_fcd else None,

--- a/examples/tts/magpietts_inference.py
+++ b/examples/tts/magpietts_inference.py
@@ -216,9 +216,7 @@ def run_inference_and_evaluation(
         violin_plot_metrics.remove('utmosv2')
 
     # Build full checkpoint identifier (include MoE info if present)
-    full_checkpoint_name = (
-        f"{checkpoint_name}_{moe_info}{inference_config.build_identifier()}_SV_{eval_config.sv_model}"
-    )
+    full_checkpoint_name = f"{checkpoint_name}_{moe_info}{inference_config.build_identifier()}_SV_{eval_config.sv_model}_{eval_config.language}"
 
     # Tracking metrics across datasets
     ssim_per_dataset = []

--- a/examples/tts/magpietts_inference.py
+++ b/examples/tts/magpietts_inference.py
@@ -251,10 +251,13 @@ def run_inference_and_evaluation(
         else:
             language = eval_config.language
 
+        tokenizer_names = meta.get('tokenizer_names', None)
+
         dataset_meta_for_dl = {
             "manifest_path": meta["manifest_path"],
             "audio_dir": meta["audio_dir"],
             "language": language,
+            "tokenizer_names": tokenizer_names,
         }
 
         # Setup output directories

--- a/nemo/collections/tts/data/text_to_speech_dataset.py
+++ b/nemo/collections/tts/data/text_to_speech_dataset.py
@@ -47,8 +47,9 @@ from nemo.utils import logging
 class DatasetMeta:
     manifest_path: Path
     audio_dir: Path
-    feature_dir: Path = None
+    feature_dir: Optional[Path] = None
     sample_weight: float = 1.0
+    language: Optional[str] = None
     tokenizer_names: List[str] = None
 
 
@@ -59,7 +60,8 @@ class DatasetSample:
     audio_dir: Optional[Path]
     feature_dir: Optional[Path]
     text: str
-    speaker: str
+    language: Optional[str] = None
+    speaker: Optional[str] = None
     speaker_index: int = None
     tokenizer_names: List[str] = None
 
@@ -194,6 +196,13 @@ class TextToSpeechDataset(Dataset):
                 speaker = None
                 speaker_index = 0
 
+            if "language" in entry:
+                language = entry.get("language")
+            elif dataset.language:
+                language = dataset.language
+            else:
+                language = None
+
             sample = DatasetSample(
                 dataset_name=dataset_name,
                 manifest_entry=entry,
@@ -202,6 +211,7 @@ class TextToSpeechDataset(Dataset):
                 text=text,
                 speaker=speaker,
                 speaker_index=speaker_index,
+                language=language,
                 tokenizer_names=dataset.tokenizer_names,
             )
             samples.append(sample)
@@ -385,6 +395,7 @@ class MagpieTTSDataset(TextToSpeechDataset):
         phoneme_as_text_prob: float = 0.0,
         pronunciation_control_g2p: Dict = None,
         add_language_to_context_text: bool = False,
+        default_tokenizer_name: str = "english_phoneme",
     ):
         super().__init__(
             dataset_meta=dataset_meta,
@@ -423,6 +434,7 @@ class MagpieTTSDataset(TextToSpeechDataset):
         self.phoneme_as_text_prob = phoneme_as_text_prob
         self.pronunciation_control_g2p_config = pronunciation_control_g2p
         self.add_language_to_context_text = add_language_to_context_text
+        self.default_tokenizer_name = default_tokenizer_name
 
     def get_num_audio_samples_to_slice(self, duration, sample_rate):
         num_codec_frames = int(duration * sample_rate / self.codec_model_samples_per_frame)
@@ -443,11 +455,17 @@ class MagpieTTSDataset(TextToSpeechDataset):
             effective_duration_max = max(self.context_duration_min, effective_duration_max)
             return random.uniform(self.context_duration_min, effective_duration_max)
 
-        tokenizer_name = "english_phoneme"  # Default to english phoneme tokenizer
         if data.tokenizer_names is not None:
             # Pick a random tokenizer from the list of tokenizers
             tokenizer_name = random.choice(data.tokenizer_names)
-        language = data.manifest_entry.get('language', 'en')
+        else:
+            tokenizer_name = self.default_tokenizer_name
+
+        if data.language:
+            language = data.language
+        else:
+            language = 'en'
+
         tokens = tokenize_text_with_pronunciation_control(
             text_tokenizer=self.text_tokenizer,
             text_str=data.text,

--- a/nemo/collections/tts/models/easy_magpietts_inference.py
+++ b/nemo/collections/tts/models/easy_magpietts_inference.py
@@ -25,6 +25,7 @@ from omegaconf import DictConfig
 from torch import nn
 from transformers import AutoConfig, AutoModelForCausalLM
 
+from nemo.collections.audio.parts.utils.transforms import resample
 from nemo.collections.tts.data.text_to_speech_dataset_lhotse import setup_tokenizers
 from nemo.collections.tts.models import AudioCodecModel
 from nemo.collections.tts.modules import transformer_2501
@@ -2099,11 +2100,10 @@ class EasyMagpieTTSInferenceModel(ModelPT):
         audio, sr = sf.read(audio_path, dtype='float32')
         if len(audio.shape) > 1:
             audio = audio.mean(axis=1)
+        audio = torch.from_numpy(audio).unsqueeze(0)
         if sr != target_sample_rate:
-            import librosa
-
-            audio = librosa.resample(audio, orig_sr=sr, target_sr=target_sample_rate)
-        return torch.from_numpy(audio).unsqueeze(0)
+            audio = resample(waveform=audio, orig_freq=sr, new_freq=target_sample_rate)
+        return audio
 
     @staticmethod
     def _adjust_audio_to_duration_for_inference(

--- a/nemo/collections/tts/modules/magpietts_inference/evaluate_generated_audio.py
+++ b/nemo/collections/tts/modules/magpietts_inference/evaluate_generated_audio.py
@@ -29,13 +29,18 @@ import librosa
 import numpy as np
 import soundfile as sf
 import torch
-from transformers import Wav2Vec2FeatureExtractor, WavLMForXVector, WhisperForConditionalGeneration, WhisperProcessor
+from transformers import Wav2Vec2FeatureExtractor, WavLMForXVector
 
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.metrics.wer import word_error_rate_detail
 from nemo.collections.tts.metrics.eou_classifier import EoUClassification, EoUClassifier, EoUType
 from nemo.collections.tts.metrics.frechet_codec_distance import FrechetCodecDistance
-from nemo.collections.tts.parts.utils.tts_dataset_utils import get_text_processor
+from nemo.collections.tts.parts.utils.tts_dataset_utils import (
+    NemoTranscriber,
+    NemoTranscriberWithPrompt,
+    WhisperTranscriber,
+    get_text_processor,
+)
 from nemo.utils import logging
 
 # Optional import for UTMOSv2 (audio quality metric)
@@ -82,6 +87,13 @@ def load_evalset_config(config_path: Optional[str] = None, dataset_base_path: Op
         manifest_path = Path(info["manifest_path"])
         audio_dir = Path(info["audio_dir"])
 
+        asr_model_path = None
+        asr_model = info.get("asr_model")
+        if asr_model:
+            asr_model_name = asr_model["name"]
+            if asr_model_name.endswith(".nemo"):
+                asr_model_path = Path(asr_model_name)
+
         if dataset_base_path:
             # Replace relative paths with absolute paths where appropriate
             if not manifest_path.is_absolute():
@@ -92,11 +104,18 @@ def load_evalset_config(config_path: Optional[str] = None, dataset_base_path: Op
                 audio_dir = dataset_base_path / audio_dir
                 info["audio_dir"] = str(audio_dir)
 
+            if asr_model_path and not asr_model_path.is_absolute():
+                asr_model_path = dataset_base_path / asr_model_path
+                info["asr_model"]["name"] = str(asr_model_path)
+
         if not manifest_path.exists():
             raise ValueError(f"Manifest does not exist for dataset {dataset_name}: {manifest_path}")
 
         if not audio_dir.exists():
             raise ValueError(f"Audio directory does not exist for dataset {dataset_name}: {audio_dir}")
+
+        if asr_model_path and not asr_model_path.exists():
+            raise ValueError(f"ASR model file does not exist for dataset {dataset_name}: {asr_model_path}")
 
     return dataset_meta_info
 
@@ -150,48 +169,6 @@ def read_manifest(manifest_path):
     return records
 
 
-def transcribe_with_nemo_asr_batched(asr_model, audio_paths, batch_size=8, label=""):
-    """Transcribe multiple audio files with a NeMo ASR model in batches. Returns list of transcriptions (one per path)."""
-    all_transcriptions = []
-    for start in range(0, len(audio_paths), batch_size):
-        batch_paths = audio_paths[start : start + batch_size]
-        try:
-            with torch.inference_mode():
-                batch_results = asr_model.transcribe(batch_paths, batch_size=len(batch_paths), use_lhotse=False)
-            for r in batch_results:
-                all_transcriptions.append(r.text)
-        except Exception as e:
-            logging.info("Error during batched ASR ({} audio): {}".format(label, e))
-            all_transcriptions.extend([""] * len(batch_paths))
-    return all_transcriptions
-
-
-def transcribe_with_whisper_batched(
-    whisper_model, whisper_processor, audio_paths, language, device, batch_size=8, label=""
-):
-    """Transcribe multiple audio files with Whisper in batches. Returns list of transcriptions (one per path)."""
-    forced_decoder_ids = (
-        whisper_processor.get_decoder_prompt_ids(language=language, task="transcribe") if language else None
-    )
-    all_transcriptions = []
-    for start in range(0, len(audio_paths), batch_size):
-        batch_paths = audio_paths[start : start + batch_size]
-        try:
-            speech_arrays = [librosa.load(p, sr=16000)[0] for p in batch_paths]
-            inputs = whisper_processor(
-                speech_arrays, sampling_rate=16000, return_tensors="pt", padding=True
-            ).input_features
-            inputs = inputs.to(device)
-            with torch.inference_mode():
-                predicted_ids = whisper_model.generate(inputs, forced_decoder_ids=forced_decoder_ids)
-            transcriptions = whisper_processor.batch_decode(predicted_ids, skip_special_tokens=True)
-            all_transcriptions.extend(transcriptions)
-        except Exception as e:
-            logging.info("Error during batched Whisper ASR ({} audio): {}".format(label, e))
-            all_transcriptions.extend([""] * len(batch_paths))
-    return all_transcriptions
-
-
 def pad_audio_to_min_length(audio_np: np.ndarray, sampling_rate: int, min_seconds: float) -> np.ndarray:
     """
     Pad audio to make it at least `min_seconds` long by adding silence at the end if needed.
@@ -243,34 +220,12 @@ def compute_utmosv2_scores(audio_dir, device):
     return utmosv2_scores_dict
 
 
-def transcribed_batched(
-    audio_paths,
-    language,
-    asr_model,
-    whisper_model,
-    whisper_processor,
-    device,
-    asr_batch_size,
-    label="",
-):
-    """Transcribe a list of audio files using NeMo ASR (English) or Whisper (other languages)."""
-    if language == "en":
-        texts = transcribe_with_nemo_asr_batched(asr_model, audio_paths, batch_size=asr_batch_size, label=label)
-    else:
-        texts = transcribe_with_whisper_batched(
-            whisper_model, whisper_processor, audio_paths, language, device, batch_size=asr_batch_size, label=label
-        )
-
-    return texts
-
-
 def load_evaluation_models(
-    language="en", sv_model_type="titanet", asr_model_name="stt_en_conformer_transducer_large", device="cuda"
+    sv_model_type="titanet", asr_model_name="stt_en_conformer_transducer_large", asr_model_type="nemo", device="cuda"
 ):
     """Load ASR and speaker verification models used for evaluation.
 
     Args:
-        language: Language code. "en" uses a NeMo ASR model; other languages use Whisper.
         sv_model_type: Speaker verification model type ("wavlm" or "titanet").
         asr_model_name: Name of the NeMo ASR model (used only when language is "en").
         device: Device to place models on.
@@ -286,18 +241,14 @@ def load_evaluation_models(
         'feature_extractor': None,
     }
 
-    if language == "en":
-        if os.path.isfile(asr_model_name) and asr_model_name.endswith('.nemo'):
-            models['asr_model'] = nemo_asr.models.ASRModel.restore_from(restore_path=asr_model_name).to(device).eval()
-        elif asr_model_name.startswith("nvidia/") or asr_model_name in ["stt_en_conformer_transducer_large"]:
-            models['asr_model'] = nemo_asr.models.ASRModel.from_pretrained(model_name=asr_model_name).to(device).eval()
-        else:
-            raise ValueError(f"ASR model {asr_model_name} not supported")
+    if asr_model_type == "nemo":
+        models['asr_model'] = NemoTranscriber(model_name=asr_model_name, device=device)
+    elif asr_model_type == "nemo_with_prompt":
+        models['asr_model'] = NemoTranscriberWithPrompt(model_name=asr_model_name, device=device)
+    elif asr_model_type == "whisper":
+        models['asr_model'] = WhisperTranscriber(model_name=asr_model_name, device=device)
     else:
-        models['whisper_processor'] = WhisperProcessor.from_pretrained("openai/whisper-large-v3")
-        models['whisper_model'] = (
-            WhisperForConditionalGeneration.from_pretrained("openai/whisper-large-v3").to(device).eval()
-        )
+        raise ValueError(f"Unknown ASR model type {asr_model_name}")
 
     if sv_model_type == "wavlm":
         models['feature_extractor'] = Wav2Vec2FeatureExtractor.from_pretrained('microsoft/wavlm-base-plus-sv')
@@ -344,6 +295,7 @@ def evaluate_dir(
     language="en",
     sv_model_type="titanet",
     asr_model_name="stt_en_conformer_transducer_large",
+    asr_model_type="nemo",
     with_utmosv2=True,
     asr_batch_size=32,
     eou_batch_size=32,
@@ -377,11 +329,9 @@ def evaluate_dir(
     context_audio_paths = [_resolve_path(audio_dir, r.get('context_audio_filepath')) for r in records]
 
     # 2. Load models
-    models = load_evaluation_models(language, sv_model_type, asr_model_name, device)
+    models = load_evaluation_models(sv_model_type, asr_model_name, asr_model_type, device)
 
     asr_model = models['asr_model']
-    whisper_model = models['whisper_model']
-    whisper_processor = models['whisper_processor']
     feature_extractor = models['feature_extractor']
     speaker_verification_model = models['sv_model']
     speaker_verification_model_alternate = models['sv_model_alternate']
@@ -410,29 +360,11 @@ def evaluate_dir(
 
     # Transcribe predicted audios
     text_processor = get_text_processor(language)
-    pred_texts = transcribed_batched(
-        audio_file_lists,
-        language,
-        asr_model,
-        whisper_model,
-        whisper_processor,
-        device,
-        asr_batch_size,
-        label="predicted",
-    )
+    pred_texts = asr_model.transcribe(audio_paths=audio_file_lists, language=language, batch_size=asr_batch_size)
     pred_texts = [text_processor.process_text_for_wer(text) for text in pred_texts]
     # Transcribe ground truth audios
     if len(gt_audio_paths) > 0:
-        gt_audio_texts = transcribed_batched(
-            gt_audio_paths,
-            language,
-            asr_model,
-            whisper_model,
-            whisper_processor,
-            device,
-            asr_batch_size,
-            label="ground truth",
-        )
+        gt_audio_texts = asr_model.transcribe(audio_paths=gt_audio_paths, language=language, batch_size=asr_batch_size)
         gt_audio_texts = [text_processor.process_text_for_wer(text) for text in gt_audio_texts]
     else:
         gt_audio_texts = [None] * len(records)
@@ -598,6 +530,7 @@ def evaluate(
     language="en",
     sv_model_type="titanet",
     asr_model_name="stt_en_conformer_transducer_large",
+    asr_model_type="nemo",
     with_utmosv2=True,
     with_fcd=True,
     codec_model_path=None,
@@ -635,6 +568,7 @@ def evaluate(
         language=language,
         sv_model_type=sv_model_type,
         asr_model_name=asr_model_name,
+        asr_model_type=asr_model_type,
         with_utmosv2=with_utmosv2,
         asr_batch_size=asr_batch_size,
         eou_batch_size=eou_batch_size,
@@ -776,7 +710,7 @@ def main():
     parser.add_argument('--manifest_path', type=str, default=None)
     parser.add_argument('--audio_dir', type=str, default=None)
     parser.add_argument('--generated_audio_dir', type=str, default=None)
-    parser.add_argument('--whisper_language', type=str, default="en")
+    parser.add_argument('--language', type=str, default="en")
     parser.add_argument('--evalset', type=str, default=None)
     args = parser.parse_args()
 
@@ -790,7 +724,7 @@ def main():
         args.manifest_path,
         args.audio_dir,
         args.generated_audio_dir,
-        args.whisper_language,
+        args.language,
         sv_model_type="wavlm",
         asr_model_name="nvidia/parakeet-ctc-0.6b",
     )

--- a/nemo/collections/tts/modules/magpietts_inference/evaluation.py
+++ b/nemo/collections/tts/modules/magpietts_inference/evaluation.py
@@ -48,6 +48,7 @@ class EvaluationConfig:
 
     sv_model: str = "titanet"
     asr_model_name: str = "nvidia/parakeet-tdt-1.1b"
+    asr_model_type: str = "nemo"
     eou_model_name: str = "facebook/wav2vec2-base-960h"
     language: str = "en"
     with_utmosv2: bool = True
@@ -90,6 +91,7 @@ def evaluate_generated_audio_dir(
         language=config.language,
         sv_model_type=config.sv_model,
         asr_model_name=config.asr_model_name,
+        asr_model_type=config.asr_model_type,
         with_utmosv2=config.with_utmosv2,
         with_fcd=config.with_fcd,
         codec_model_path=config.codec_model_path,

--- a/nemo/collections/tts/modules/magpietts_inference/inference.py
+++ b/nemo/collections/tts/modules/magpietts_inference/inference.py
@@ -63,6 +63,7 @@ class BaseInferenceConfig(abc.ABC):
     batch_size: int = 32
     use_cfg: bool = False
     use_local_transformer: bool = False
+    default_tokenizer_name: str = "english_phoneme"
 
     @abc.abstractmethod
     def build_identifier(self) -> str:
@@ -722,6 +723,7 @@ class EasyMagpieInferenceRunner(BaseInferenceRunner):
             context_duration_max=context_duration_max,
             ignore_phoneme_languages=self.model.cfg.get('ignore_phoneme_languages', []),
             add_language_to_context_text=self.model.add_language_to_context_text,
+            default_tokenizer_name=self.config.default_tokenizer_name,
         )
         dataset.text_tokenizer = self.model.tokenizer
 

--- a/nemo/collections/tts/modules/magpietts_inference/inference.py
+++ b/nemo/collections/tts/modules/magpietts_inference/inference.py
@@ -131,7 +131,6 @@ class MagpieInferenceConfig(BaseInferenceConfig):
         parts.extend(
             [
                 f"LT_{self.use_local_transformer}",
-                f"MaskGit_{self.maskgit_n_steps}_{self.maskgit_sampling_type}",
                 self._format_layer_list(self.maskgit_fixed_schedule),
                 f"EOS_{self.model_inference_parameters.eos_detection_method}",
                 f"IgnoreFST_{self.model_inference_parameters.ignore_finished_sentence_tracking}",

--- a/nemo/collections/tts/parts/utils/tts_dataset_utils.py
+++ b/nemo/collections/tts/parts/utils/tts_dataset_utils.py
@@ -29,7 +29,11 @@ import torch
 from einops import rearrange
 from scipy import ndimage
 from torch.special import gammaln
+from transformers import WhisperForConditionalGeneration, WhisperProcessor
 
+from nemo.collections.asr.models import ASRModel, EncDecHybridRNNTCTCBPEModelWithPrompt
+from nemo.collections.asr.models.hybrid_rnnt_ctc_bpe_models_prompt import HybridRNNTCTCPromptTranscribeConfig
+from nemo.collections.asr.parts.mixins.transcription import TranscribeConfig
 from nemo.collections.asr.parts.preprocessing.segment import AudioSegment
 from nemo.collections.audio.parts.utils.transforms import resample
 from nemo.collections.common.parts.utils import mask_sequence_tensor
@@ -973,3 +977,109 @@ def get_text_processor(language: str) -> TextProcessor:
     else:
         logging.info(f"Text processing not implemented for language {language}; using default processor")
         return DefaultTextProcessor()
+
+
+class Transcriber(ABC):
+    """Interface for transcribing TTS outputs with different ASR models"""
+
+    @abstractmethod
+    def transcribe(self, audio_paths: List[Path], batch_size: int, language: Optional[str]) -> List[str]:
+        """
+        Run batch transcription of a list of audio files.
+
+        Args:
+            audio_paths: list of paths to audio files to transcribe
+            batch_size: batch size to use for inference
+            language: optional language of input audio
+
+        Returns:
+            List with transcribed text for each audio path
+        """
+        pass
+
+
+class NemoTranscriber(Transcriber):
+    """Transcriber for NeMo ASR models"""
+
+    def __init__(self, device, model_name="stt_en_conformer_transducer_large"):
+        if model_name.endswith('.nemo'):
+            model = ASRModel.restore_from(restore_path=model_name)
+        else:
+            model = ASRModel.from_pretrained(model_name=model_name)
+
+        self.model = model.to(device).eval()
+
+    def transcribe(self, audio_paths: List[Path], batch_size: int, language: Optional[str]) -> List[str]:
+        override_config = TranscribeConfig(batch_size=batch_size, use_lhotse=False)
+        transcribe_results = self.model.transcribe(audio_paths, override_config=override_config)
+        transcriptions = [result.text for result in transcribe_results]
+        return transcriptions
+
+
+class NemoTranscriberWithPrompt(Transcriber):
+    """Transcriber for NeMo ASR models that accept language as an optional prompt"""
+
+    def __init__(self, device, model_name):
+        if model_name.endswith('.nemo'):
+            model = ASRModel.restore_from(restore_path=model_name)
+        else:
+            model = ASRModel.from_pretrained(model_name=model_name)
+
+        self.model = model.to(device).eval()
+        if not isinstance(self.model, EncDecHybridRNNTCTCBPEModelWithPrompt):
+            raise ValueError(f"Model {model_name} does not support prompting")
+
+        self.language_prompt_map = {
+            "en": "en-US",
+            "ar": "ar",
+            "ko": "ko-KR",
+            "hi": "hi-IN",
+            "zh": "zh-CN",
+            "it": "it-IT",
+            "es": "es-ES",
+            "de": "de-DE",
+            "fr": "fr-FR",
+            "ja": "ja-JP",
+        }
+
+    def transcribe(self, audio_paths: List[Path], batch_size: int, language: Optional[str]) -> List[str]:
+        if language:
+            prompt_lang = self.language_prompt_map[language]
+            override_config = HybridRNNTCTCPromptTranscribeConfig(
+                batch_size=batch_size, use_lhotse=False, target_lang=prompt_lang
+            )
+        else:
+            override_config = HybridRNNTCTCPromptTranscribeConfig(batch_size=batch_size, use_lhotse=False)
+
+        transcribe_results = self.model.transcribe(audio_paths, override_config=override_config)
+        transcriptions = [result.text for result in transcribe_results]
+        return transcriptions
+
+
+class WhisperTranscriber(Transcriber):
+    """Transcriber for Whisper ASR models"""
+
+    def __init__(self, device, model_name="openai/whisper-large-v3"):
+        self.processor = WhisperProcessor.from_pretrained(model_name)
+        self.model = WhisperForConditionalGeneration.from_pretrained(model_name).to(device).eval()
+        self.input_sample_rate = 16000
+
+    def transcribe(self, audio_paths: List[Path], language: str, batch_size: int) -> List[str]:
+        if language:
+            forced_decoder_ids = self.processor.get_decoder_prompt_ids(language=language, task="transcribe")
+        else:
+            forced_decoder_ids = None
+
+        all_transcriptions = []
+        for start in range(0, len(audio_paths), batch_size):
+            batch_paths = audio_paths[start : start + batch_size]
+            speech_arrays = [librosa.load(p, sr=self.input_sample_rate)[0] for p in batch_paths]
+            inputs = self.processor(
+                speech_arrays, sampling_rate=self.input_sample_rate, return_tensors="pt", padding=True
+            ).input_features
+            inputs = inputs.half().to(self.model.device)
+            with torch.inference_mode():
+                predicted_ids = self.model.generate(inputs, forced_decoder_ids=forced_decoder_ids)
+            transcriptions = self.processor.batch_decode(predicted_ids, skip_special_tokens=True)
+            all_transcriptions.extend(transcriptions)
+        return all_transcriptions


### PR DESCRIPTION
# What does this PR do ?

Refactor Magpie evaluation scripts to allow for easy configuration of multi-lingual datasets

**Collection**: [TTS]

# Changelog

- Add "language" field to evaluation manifest. The code now chooses the language for each utterance by first using the value inside the utterance manifest data, then falling back to dataset language, then falling back to default_language in the CLI arguments.
- Add interface around ASR model, making it easy to use different ASR models from different frameworks during evaluation.
- Add "asr_model" field to evaluation manifest, making it possible to specify different ASR models for different datasets during one evaluation.
- Add "tokenizer_name" argument, replacing previous hardcoding of "english_phoneme" as default. Easy Magpie currently uses `--tokenizer_name="nemotron_nano_30b"` for evaluation in all languages.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
