### PR TITLE
ci: use NVIDIA inference for Claude review

### DIFF
--- a/.github/workflows/claude-answer.yml
+++ b/.github/workflows/claude-answer.yml
@@ -56,10 +56,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           prompt: |
             You are a helpful assistant for the NeMo repository.
             Answer the user's question based on the issue description, comments, and the codebase.
             Be concise and provide code references where relevant.
             Do NOT make any code changes or create PRs — only answer the question.
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
+          claude_args: --model "${{ vars.CLAUDE_MODEL }}"

--- a/.github/workflows/claude-babysit-pr.yml
+++ b/.github/workflows/claude-babysit-pr.yml
@@ -41,7 +41,7 @@
 # Additionally, speech_team members can @claude in a PR review comment on a
 # babysitter-enabled PR to ask questions or request changes.
 #
-# Required secrets: ANTHROPIC_API_KEY, ORG_TEAM_READ_TOKEN, NEMO_RELABEL_TOKEN
+# Required secrets: NVIDIA_INFERENCE_URL, NVIDIA_INFERENCE_KEY, ORG_TEAM_READ_TOKEN, NEMO_RELABEL_TOKEN
 
 name: Claude Code — PR Babysitter
 
@@ -208,10 +208,14 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           # No prompt — Claude reads the @claude mention and responds in context
-          claude_args: "--max-turns 15 --model claude-sonnet-4-6"
+          claude_args: "--max-turns 15 --model ${{ vars.CLAUDE_MODEL }}"
 
   # ---- CI failure: investigate, propose a plan, DO NOT push ----
 
@@ -275,8 +279,12 @@ jobs:
           ref: ${{ needs.check-label-for-ci.outputs.head_ref }}
 
       - uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           prompt: |
             The CI workflow "${{ github.event.workflow_run.name }}" just failed
             on PR #${{ needs.check-label-for-ci.outputs.pr_number }}.
@@ -313,7 +321,7 @@ jobs:
                DO NOT include the `<!-- babysit-plan -->` marker. Instead post
                a comment that mentions @${{ needs.check-label-for-ci.outputs.author_login }}
                describing what you found and asking for help.
-          claude_args: "--max-turns 10 --model claude-sonnet-4-6"
+          claude_args: "--max-turns 10 --model ${{ vars.CLAUDE_MODEL }}"
 
       - name: Mark plan awaiting approval (or stop if Claude gave up)
         env:
@@ -406,8 +414,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           prompt: |
             Decide whether the PR author has approved the fix plan, then act.
 
@@ -433,7 +444,7 @@ jobs:
                - NEITHER: post a short PR comment asking for an explicit
                  approve/reject. Do NOT change labels.
             5. Do not push any code. Do not edit files in the repository.
-          claude_args: "--max-turns 8 --model claude-sonnet-4-6"
+          claude_args: "--max-turns 8 --model ${{ vars.CLAUDE_MODEL }}"
 
   # ---- Execute the approved plan (the only job allowed to push code) ----
 
@@ -528,8 +539,12 @@ jobs:
 
       - uses: anthropics/claude-code-action@v1
         if: steps.authz.outputs.authorized == 'true' && steps.plan.outputs.found == 'true'
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
           prompt: |
             The PR author has approved your previously posted fix plan. Execute it now.
 
@@ -544,7 +559,7 @@ jobs:
                code has moved on, the reproduction no longer triggers the bug):
                post a PR comment mentioning @${{ github.event.pull_request.user.login }}
                explaining what changed and DO NOT push.
-          claude_args: "--max-turns 10 --model claude-sonnet-4-6"
+          claude_args: "--max-turns 10 --model ${{ vars.CLAUDE_MODEL }}"
 
       - name: Re-trigger CI or stop loop
         if: steps.authz.outputs.authorized == 'true' && steps.plan.outputs.found == 'true'

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -58,6 +58,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: anthropics/claude-code-action@v1
         id: claude
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
+          DISABLE_PROMPT_CACHING: "1"
         with:
           prompt: |
             You are a developer working on the NeMo repository.
@@ -89,7 +93,8 @@ jobs:
               ```
 
             
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic_api_key: ${{ secrets.NVIDIA_INFERENCE_KEY }}
+          claude_args: --model "${{ vars.CLAUDE_MODEL }}"
 
       - name: Label PR with agent-contribution
         if: steps.claude.outputs.branch_name

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -30,8 +30,9 @@ jobs:
 
   claude-review:
     needs: acknowledge
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.88.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
     with:
+      model: ${{ vars.CLAUDE_MODEL }}
       prompt: |
         You are doing a light code review. Keep it concise and actionable.
 
@@ -55,4 +56,5 @@ jobs:
         It's perfectly acceptable to not have anything to comment on.
         If you do not have anything to comment on, post "LGTM".
     secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      NVIDIA_INFERENCE_URL: ${{ secrets.NVIDIA_INFERENCE_URL }}
+      NVIDIA_INFERENCE_KEY: ${{ secrets.NVIDIA_INFERENCE_KEY }}


### PR DESCRIPTION
# What does this PR do ?

Updates Speech Claude automation workflows to use the NVIDIA inference endpoint/key and the released FW-CI-templates `v1.7.0` reusable review workflow.

**Collection**: CI workflows

# Changelog

- Bump `_claude_review.yml` usage to `NVIDIA-NeMo/FW-CI-templates@v1.7.0`.
- Pass `vars.CLAUDE_MODEL` to the reusable review workflow.
- Pass `secrets.NVIDIA_INFERENCE_URL` and `secrets.NVIDIA_INFERENCE_KEY` instead of `secrets.ANTHROPIC_API_KEY`.
- Update direct Claude action workflows (`claude-answer.yml`, `claude-fix.yml`, `claude-babysit-pr.yml`) with the NVIDIA inference base URL/key and model variable.

# Usage

N/A. CI workflow configuration only.

# GitHub Actions CI

Workflow YAML was parsed locally; no product tests are needed for this CI-only change.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Did you write any new necessary tests? N/A, workflow secret/tag update only.
- [x] Did you add or update any necessary documentation? N/A.

# Additional Information

- Linear: AUT-644