### PR TITLE
Fix ASR transducer nemo checkpoint export

### DIFF
--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -16,7 +16,6 @@ import os
 import re
 import shutil
 import time
-from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -236,18 +235,11 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 return output
 
             self.previous_best_path = self.best_model_path
-            old_state_dict = deepcopy(pl_module.state_dict())
-            checkpoint = torch.load(maybe_injected_best_model_path, map_location='cpu')
-            if 'state_dict' in checkpoint:
-                checkpoint = checkpoint['state_dict']
-            # get a new instanace of the model
-            pl_module.load_state_dict(checkpoint, strict=True)
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()
             backup_path = self._backup_existing_nemo_ckpt(trainer)
             pl_module.save_to(save_path=app_state.model_restore_path)
             logging.info(f"New best .nemo model saved to: {app_state.model_restore_path}")
-            pl_module.load_state_dict(old_state_dict, strict=True)
         else:
             if torch.distributed.is_initialized():
                 torch.distributed.barrier()


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Avoid reloading the best checkpoint into the active model when exporting `.nemo` checkpoints.

**Collection**: ASR / Core checkpointing

# Changelog

- Save best `.nemo` exports directly from the current module when a new best checkpoint is detected.
- Remove the temporary checkpoint reload/restore path during `always_save_nemo`.

# Usage

No API changes.

```python
trainer.fit(model)
```

# Additional Information

- Issue: ASR_with_Transducers.ipynb fails during checkpoint save because NeMoModelCheckpoint reloads the best .ckpt into the live model before saving .nemo, and that reload hits pos_bias_u/v shape mismatches.