### PR TITLE
fix publish-hf-notebook-xet

### DIFF
--- a/tutorials/Publish_NeMo_Model_On_Hugging_Face_Hub.ipynb
+++ b/tutorials/Publish_NeMo_Model_On_Hugging_Face_Hub.ipynb
@@ -44,6 +44,20 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# huggingface_hub >= 1.0 defaults to Xet storage, whose dedup breaks the\n",
+        "# delete/recreate + re-upload flow below (HTTP 400: \"an LFS pointer pointed to\n",
+        "# a file that does not exist\"). Disable Xet to use reliable classic Git-LFS.\n",
+        "import os\n",
+        "\n",
+        "os.environ[\"HF_HUB_DISABLE_XET\"] = \"1\""
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "aS-Y5O_oGBTc"


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Description
Symptom: the manual upload_file step failed with "Your push was rejected because an LFS pointer pointed to a file that does not exist."

Problem: huggingface_hub ≥ 1.0 (in the 26.04 container) defaults to Xet storage. The notebook uploads the .nemo, then deletes and recreates the same repo, then re-uploads the same file. Xet deduplicates the re-upload against chunks from the now-deleted repo and skips the transfer (the tell: New Data Upload: 250kB for a 53 MB file). The commit then references an object the freshly recreated repo can't resolve, so the server rejects it. It's a server-side Xet consistency issue after delete+recreate, not a NeMo bug — reproduced live in the container.

Fix: one setup cell setting HF_HUB_DISABLE_XET=1, forcing reliable classic Git-LFS uploads.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
