### PR TITLE
fix(core): stop run_nvrtc corrupting the interned bytes singleton

### DIFF
--- a/nemo/core/utils/cuda_python_utils.py
+++ b/nemo/core/utils/cuda_python_utils.py
@@ -255,18 +255,23 @@ def run_nvrtc(kernel_string: str, kernel_name: bytes, program_name: bytes):
     assert_drv(err)
     err, size = nvrtc.nvrtcGetProgramLogSize(prog)
     assert_drv(err)
-    buf = b" " * size
+    # NVRTC writes the log (a C string, incl. its NUL terminator) into this buffer, so it must be
+    # mutable. A `b" " * size` bytes object is immutable, and for an empty log (size == 1) CPython
+    # returns the interned, process-wide 1-byte singleton `b" "` -- writing the NUL into it would
+    # corrupt every `b" "` / `bytes([32])` / 1-byte slice in the whole process. Use a bytearray.
+    buf = bytearray(size)
     (err,) = nvrtc.nvrtcGetProgramLog(prog, buf)
     assert_drv(err)
 
     # Get PTX from compilation
     err, ptxSize = nvrtc.nvrtcGetPTXSize(prog)
     assert_drv(err)
-    ptx = b" " * ptxSize
+    # Same reasoning as the log buffer above: NVRTC writes into this buffer, so it must be mutable.
+    ptx = bytearray(ptxSize)
     (err,) = nvrtc.nvrtcGetPTX(prog, ptx)
     assert_drv(err)
 
-    ptx = np.char.array(ptx)
+    ptx = np.char.array(bytes(ptx))
     err, module = cuda.cuModuleLoadData(ptx.ctypes.data)
     assert_drv(err)
     err, kernel = cuda.cuModuleGetFunction(module, kernel_name)

--- a/tests/core/test_cuda_python_utils.py
+++ b/tests/core/test_cuda_python_utils.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+def test_run_nvrtc_uses_mutable_output_buffers(monkeypatch):
+    """Regression test for the ``run_nvrtc`` interned-bytes-singleton corruption.
+
+    ``run_nvrtc`` used to allocate its NVRTC output buffers as ``b" " * size``. NVRTC writes the
+    compile log / PTX (a C string, including its NUL terminator) straight into that buffer, but a
+    ``bytes`` object is immutable. Worse, for an empty compile log ``size == 1`` and CPython's
+    ``b" " * 1`` returns the interned, process-wide 1-byte singleton ``b" "`` -- so NVRTC's NUL
+    write would turn every ``b" "`` / ``bytes([32])`` / 1-byte space slice in the whole process
+    into ``b"\\x00"`` permanently.
+
+    The fix allocates the buffers as ``bytearray(size)`` (mutable and never interned). This test
+    fakes the NVRTC/CUDA bindings -- no GPU required -- and emulates NVRTC writing into the buffer
+    via ``memoryview`` (which fails on an immutable ``bytes`` buffer, exactly as the old code was
+    broken) to assert the buffers handed to NVRTC are mutable and the interned singleton is intact.
+    """
+    from nemo.core.utils import cuda_python_utils
+
+    if not cuda_python_utils.CUDA_PYTHON_AVAILABLE:
+        pytest.skip("cuda-python is required to test run_nvrtc")
+
+    captured = {}
+    fake_ptx = b"//fake-ptx"
+
+    class FakeNvrtc:
+        def nvrtcCreateProgram(self, src, name, num_headers, headers, include_names):
+            return (0, "prog")
+
+        def nvrtcCompileProgram(self, prog, num_opts, opts):
+            return (0,)
+
+        def nvrtcGetProgramLogSize(self, prog):
+            # Empty log -> size 1 -> the buggy `b" " * 1` would return the interned singleton.
+            return (0, 1)
+
+        def nvrtcGetProgramLog(self, prog, buf):
+            captured["log_buf"] = buf
+            # Emulate NVRTC writing the C-string NUL terminator; raises on an immutable bytes buffer.
+            memoryview(buf)[-1] = 0
+            return (0,)
+
+        def nvrtcGetPTXSize(self, prog):
+            return (0, len(fake_ptx) + 1)
+
+        def nvrtcGetPTX(self, prog, ptx):
+            captured["ptx_buf"] = ptx
+            mv = memoryview(ptx)
+            mv[: len(fake_ptx)] = fake_ptx
+            mv[-1] = 0
+            return (0,)
+
+    class FakeCuda:
+        def cuModuleLoadData(self, ptr):
+            return (0, "module")
+
+        def cuModuleGetFunction(self, module, name):
+            return (0, "kernel")
+
+    monkeypatch.setattr(cuda_python_utils, "assert_drv", lambda err: None)
+    monkeypatch.setattr(cuda_python_utils, "nvrtc", FakeNvrtc())
+    monkeypatch.setattr(cuda_python_utils, "cuda", FakeCuda())
+
+    sentinel = b" "  # the interned 1-byte singleton the bug would clobber process-wide
+
+    kernel = cuda_python_utils.run_nvrtc('extern "C" __global__ void k(){}\n', b"k", b"k.cu")
+
+    assert kernel == "kernel"
+    # NVRTC output buffers must be mutable; the old `b" " * size` produced an immutable bytes
+    # object (and, for size == 1, the shared interned singleton).
+    assert isinstance(captured["log_buf"], bytearray)
+    assert isinstance(captured["ptx_buf"], bytearray)
+    # The interned 1-byte space must be untouched.
+    assert sentinel == b" " and sentinel[0] == 0x20
+    assert bytes([32]) == b" "


### PR DESCRIPTION
# What does this PR do ?

Fixes a process-wide memory-corruption bug in `run_nvrtc()`: it allocated NVRTC output buffers as immutable `b" " * size`, and for an empty compile log (`size == 1`) CPython returns the **interned, process-wide 1-byte singleton `b" "`**. NVRTC then writes its C-string NUL terminator into that shared object, turning **every `b" "` / `bytes([32])` / 1-byte space slice in the whole process into `b"\x00"` permanently**. Fix: use a mutable `bytearray`.

**Collection**: core (`nemo/core/utils/cuda_python_utils.py`)

# Changelog

- `nemo/core/utils/cuda_python_utils.py`: allocate the NVRTC log buffer and PTX buffer as `bytearray(size)` / `bytearray(ptxSize)` instead of `b" " * size` (mutable, never interned).
- Convert with `bytes(ptx)` before `np.char.array(...)` so downstream behavior is byte-for-byte identical (passing a `bytearray` directly to `np.char.array` would be misinterpreted as a sequence of ints).
- `tests/core/test_cuda_python_utils.py` (new): GPU-free regression test that fakes the NVRTC/CUDA bindings and emulates NVRTC writing into the buffer via `memoryview`; asserts the buffers are mutable and the interned singleton is intact. Fails on the old code (`TypeError: cannot modify read-only memory`), passes on the fix. Skips when `cuda-python` is unavailable, matching `tests/collections/asr/decoding/test_cuda_graph_rnnt_greedy_decoding.py`.

# Usage

Reproduction (self-contained, no GPU / no NeMo import — just `cuda-python`), from #15790:

```python
from cuda.bindings import nvrtc
err, prog = nvrtc.nvrtcCreateProgram(b'extern "C" __global__ void k(){}\n', b"k.cu", 0, [], [])
(err,) = nvrtc.nvrtcCompileProgram(prog, 0, [])
err, size = nvrtc.nvrtcGetProgramLogSize(prog)   # == 1 for a clean compile
buf = b" " * size                                # the interned singleton b" "
(err,) = nvrtc.nvrtcGetProgramLog(prog, buf)     # NVRTC writes NUL into it
print(bytes([32]))                               # -> b'\x00'  (b" " is now corrupted process-wide)
```

# GitHub Actions CI

CI has not been triggered yet (external fork). A maintainer can start it with `/ok to test <sha>` / "Approve and run" and the **Run CICD** label.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — added `tests/core/test_cuda_python_utils.py`
- [ ] Did you add or update any necessary documentation? — n/a (internal bugfix)
- [x] Does the PR affect components that are optional to install? (cuda-python)
  - [x] Reviewer: import guards are unchanged — `run_nvrtc` stays behind `@cuda_python_required`, and the new test `pytest.skip`s when `cuda-python` is unavailable.

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Fixes #15790
- Verification note: I do not have a CUDA machine, so I confirmed the bug mechanism and the test's pass/fail behavior with a standalone replica of the buffer handling; the in-repo test is expected to run under CI where `cuda-python` is present.
- cc @nithinraok (NeMo core) per the review guidelines.