### PR TITLE
fix(asr): keep the digit "0" in convert_num_to_words (WER groundtruth cleaning)

### DIFF
--- a/nemo/collections/asr/parts/utils/eval_utils.py
+++ b/nemo/collections/asr/parts/utils/eval_utils.py
@@ -131,6 +131,11 @@ def convert_num_to_words(_str: str, langid: str = "en") -> str:
         for word in words:
             if word.isdigit():
                 num = int(word)
+                if num == 0:
+                    # `while num` below is skipped for 0 (it is falsy), which would silently drop
+                    # the token; emit "zero" explicitly so a standalone "0" is not lost.
+                    out_str += num_to_words[0] + " "
+                    continue
                 while num:
                     digit = num % 10
                     digit_word = num_to_words[digit]

--- a/tests/collections/asr/utils/test_eval_utils.py
+++ b/tests/collections/asr/utils/test_eval_utils.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo.collections.asr.parts.utils.eval_utils import clean_label, convert_num_to_words
+
+
+class TestConvertNumToWords:
+    @pytest.mark.unit
+    def test_standalone_zero_is_not_dropped(self):
+        # Regression: `while num` is skipped for 0 (falsy), so a standalone "0" used to be
+        # silently dropped, corrupting the text (and, in WER eval, the reference word count).
+        assert convert_num_to_words("0").split() == ["zero"]
+        assert convert_num_to_words("the answer is 0").split() == ["the", "answer", "is", "zero"]
+        assert convert_num_to_words("5 0 3").split() == ["five", "zero", "three"]
+
+    @pytest.mark.unit
+    def test_nonzero_digits_unchanged(self):
+        assert convert_num_to_words("2").split() == ["two"]
+        assert convert_num_to_words("10").split() == ["one", "zero"]
+        assert convert_num_to_words("2 apples").split() == ["two", "apples"]
+        assert convert_num_to_words("no digits here").split() == ["no", "digits", "here"]
+
+    @pytest.mark.unit
+    def test_clean_label_keeps_zero(self):
+        # clean_label converts numbers by default (num_to_words=True); the standalone "0" must
+        # survive groundtruth cleaning used by cal_write_wer(clean_groundtruth_text=True).
+        assert clean_label("The answer is 0") == "the answer is zero"


### PR DESCRIPTION
# What does this PR do ?

Fixes a silent word-drop in `convert_num_to_words()`: a standalone `"0"` token is deleted instead of becoming `"zero"`, which corrupts groundtruth text (and the WER denominator) during evaluation.

**Collection**: ASR (`nemo/collections/asr/parts/utils/eval_utils.py`)

# Changelog

- `convert_num_to_words` builds each number digit-by-digit with `while num:`. When a token is the bare string `"0"`, `num = 0` is falsy, so the loop body never runs and the token produces **no** output — it is silently dropped. Every other digit works, and `"0"` embedded in a larger number (`"10"`, `"100"`) works because the loop is entered by the nonzero leading digit.
- This is reached by default in WER evaluation: `clean_label(_str, num_to_words=True, ...)` defaults `num_to_words=True` and is applied to the reference in `cal_write_wer(..., clean_groundtruth_text=True)`. So a reference like `"the answer is 0"` becomes `"the answer is"` — the reference loses a word, changing both its content and the WER/CER denominator.
- Fix: emit `"zero"` explicitly for the `num == 0` case; all other inputs are unchanged (minimal, behavior-preserving). Note: leading-zero handling (`"007"` -> `"seven"`) is a separate pre-existing quirk and is intentionally left untouched to keep this change single-purpose.

# Usage

```python
from nemo.collections.asr.parts.utils.eval_utils import convert_num_to_words, clean_label

convert_num_to_words("the answer is 0")   # before: "the answer is"        after: "the answer is zero"
convert_num_to_words("5 0 3")             # before: "five  three"          after: "five  zero three"
clean_label("The answer is 0")            # before: "the answer is"        after: "the answer is zero"
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — added `tests/collections/asr/utils/test_eval_utils.py`
- [ ] Did you add or update any necessary documentation? — n/a (internal bugfix)
- [ ] Does the PR affect components that are optional to install? — no

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Self-found (no pre-existing issue). Verified GPU-free: the fix is pure string logic; the new test compares on tokens (robust to the function's pre-existing internal spacing) and fails on the old code, passes on the fix. I don't have a CUDA machine so I confirmed pass/fail with a standalone replica of the function; the in-repo test runs as a normal CPU unit test in CI.