### PR TITLE
fix(asr): keep all subsegments in get_subsegment_dict (diarization dataset gen)

### DIFF
--- a/nemo/collections/asr/parts/utils/manifest_utils.py
+++ b/nemo/collections/asr/parts/utils/manifest_utils.py
@@ -193,8 +193,8 @@ def get_subsegment_dict(subsegments_manifest_file: str, window: float, shift: fl
                 _subsegment_dict[uniq_id] = {'ts': [], 'json_dic': []}
             for subsegment in subsegments:
                 start, dur = subsegment
-            _subsegment_dict[uniq_id]['ts'].append([round(start, deci), round(start + dur, deci)])
-            _subsegment_dict[uniq_id]['json_dic'].append(dic)
+                _subsegment_dict[uniq_id]['ts'].append([round(start, deci), round(start + dur, deci)])
+                _subsegment_dict[uniq_id]['json_dic'].append(dic)
     return _subsegment_dict
 
 

--- a/tests/collections/asr/utils/test_manifest_utils.py
+++ b/tests/collections/asr/utils/test_manifest_utils.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import pytest
+
+from nemo.collections.asr.parts.utils.manifest_utils import get_subsegment_dict
+from nemo.collections.asr.parts.utils.speaker_utils import get_subsegments_scriptable
+
+
+@pytest.mark.unit
+def test_get_subsegment_dict_keeps_all_subsegments(tmp_path):
+    """
+    Regression test: get_subsegment_dict must append one ('ts', 'json_dic') entry
+    per subsegment, not just the last one.
+
+    Previously the two ``.append(...)`` calls were indented outside the
+    ``for subsegment in subsegments`` loop, so ``start, dur`` only held the last
+    subsegment and every earlier subsegment was silently dropped.
+    """
+    window, shift, deci = 1.5, 0.75, 3
+    offset, duration = 0.0, 5.0
+
+    # Sanity: these parameters yield multiple subsegments (6), so the bug is observable.
+    expected_subsegments = get_subsegments_scriptable(offset=offset, window=window, shift=shift, duration=duration)
+    assert len(expected_subsegments) > 1
+
+    manifest_path = tmp_path / "subsegments_manifest.json"
+    entry = {
+        "audio_filepath": "/tmp/example.wav",
+        "offset": offset,
+        "duration": duration,
+        "uniq_id": "example",
+    }
+    manifest_path.write_text(json.dumps(entry) + "\n")
+
+    subsegment_dict = get_subsegment_dict(str(manifest_path), window=window, shift=shift, deci=deci)
+
+    assert set(subsegment_dict.keys()) == {"example"}
+    ts = subsegment_dict["example"]["ts"]
+    json_dic = subsegment_dict["example"]["json_dic"]
+
+    # One entry per subsegment (would be 1 with the bug).
+    assert len(ts) == len(expected_subsegments)
+    assert len(json_dic) == len(expected_subsegments)
+
+    expected_ts = [[round(start, deci), round(start + dur, deci)] for start, dur in expected_subsegments]
+    assert ts == expected_ts


### PR DESCRIPTION
# What does this PR do ?

Fixes a silent data-loss bug in `get_subsegment_dict`: all but the **last** subsegment of each manifest line are dropped, which silently shrinks speaker-diarization training datasets.

**Collection**: ASR / speaker tasks (`nemo/collections/asr/parts/utils/manifest_utils.py`)

# Changelog

- In `get_subsegment_dict`, the two `.append(...)` calls that record a subsegment's timestamp (`'ts'`) and json entry (`'json_dic'`) were indented at the **same level** as the enclosing `for subsegment in subsegments:` loop — i.e. outside it:

  ```python
  for subsegment in subsegments:
      start, dur = subsegment
  _subsegment_dict[uniq_id]['ts'].append([round(start, deci), round(start + dur, deci)])
  _subsegment_dict[uniq_id]['json_dic'].append(dic)
  ```

  So they ran once per manifest line instead of once per subsegment, and `start, dur` held only the **last** subsegment — every earlier subsegment was silently discarded. (The `for` loop was otherwise pointless, which confirms the appends were meant to live inside it.)
- Fix: indent the two appends into the loop so every subsegment is recorded.

# Usage

With `window=1.5, shift=0.75, deci=3` on a 5.0s segment, `get_subsegments_scriptable` yields 6 subsegments:

```
before (buggy): ts = [[3.75, 5.0]]                       # only the last subsegment
after  (fixed): ts = [[0.0, 1.5], [0.75, 2.25], [1.5, 3.0],
                      [2.25, 3.75], [3.0, 4.5], [3.75, 5.0]]   # all 6
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Speech/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? — added `tests/collections/asr/utils/test_manifest_utils.py`
- [ ] Did you add or update any necessary documentation? — n/a (internal bugfix)
- [ ] Does the PR affect components that are optional to install? — no

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

- Impact: callers `create_segment_manifest` -> `write_truncated_subsegments` and `scripts/speaker_tasks/create_diarization_train_dataset.py` build diarization training data; the bug silently dropped most subsegments per segment (e.g. 5 of every 6 above) with no error.
- Self-found (no pre-existing issue). Verified GPU-free: the new test drives `get_subsegment_dict` with a synthetic in-memory manifest and asserts one entry per subsegment (fails on old code, passes on the fix). I don't have a CUDA machine, so pass/fail was confirmed with a standalone replica of the loop; the in-repo test runs as a normal CPU unit test in CI.