### PR TITLE
[r3.0.0] Fix SDE_HowTo_v2 notebook: replace removed QuartzNet15x5Base-En (fix_6411583)

### DIFF
--- a/tutorials/tools/SDE_HowTo_v2.ipynb
+++ b/tutorials/tools/SDE_HowTo_v2.ipynb
@@ -154,11 +154,11 @@
         "id": "rYe0xVTzjbhQ"
       },
       "source": [
-        "To compare two models, JSON file should contain predictions from 1st (e.g., `QuartzNet15x5`) and 2nd (e.g., `Conformer-CTC Small`) models.\n",
+        "To compare two models, JSON file should contain predictions from 1st (e.g., `Citrinet-256`) and 2nd (e.g., `Conformer-CTC Small`) models.\n",
         "\n",
         "NeMo includes a Python script for ASR inference: [`transcribe_speech.py`](https://github.com/NVIDIA/NeMo/blob/main/examples/asr/transcribe_speech.py).\n",
         "\n",
-        "`transcribe_speech.py` accepts `append_pred` flag that allows saving an ASR transcript in the JSON file with a given custom field (like `pred_text_QN`). `pred_name_postfix` parameter defines the custom field's name. In this example it is set to the abbreviated model name `QN`."
+        "`transcribe_speech.py` accepts `append_pred` flag that allows saving an ASR transcript in the JSON file with a given custom field (like `pred_text_CitNet`). `pred_name_postfix` parameter defines the custom field's name. In this example it is set to the abbreviated model name `CitNet`."
       ]
     },
     {
@@ -171,13 +171,13 @@
       "outputs": [],
       "source": [
         "!python3 ./NeMo/examples/asr/transcribe_speech.py \\\n",
-        "pretrained_name=\"QuartzNet15x5Base-En\" \\\n",
+        "pretrained_name=\"stt_en_citrinet_256\" \\\n",
         "dataset_manifest=./test_other.json \\\n",
-        "output_filename=\"test_other_QN.json\" \\\n",
+        "output_filename=\"test_other_CitNet.json\" \\\n",
         "batch_size=8 \\\n",
         "cuda=0 amp=True \\\n",
         "append_pred=True \\\n",
-        "pred_name_postfix=\"QN\""
+        "pred_name_postfix=\"CitNet\""
       ]
     },
     {
@@ -187,9 +187,9 @@
         "id": "OfhJrSkvqrs6"
       },
       "source": [
-        "`transcribe_speech.py` also reports overall WER for the given dataset. In our case, QuartzNet's WER is 10.0%.\n",
+        "`transcribe_speech.py` also reports overall WER for the given dataset. In our case, Citrinet-256's WER is 10.0%.\n",
         "\n",
-        "Here is the first line of the newly created `test_other_QN.json` manifest file with QuartzNet's predictions:"
+        "Here is the first line of the newly created `test_other_CitNet.json` manifest file with Citrinet-256's predictions:"
       ]
     },
     {
@@ -201,7 +201,7 @@
       },
       "outputs": [],
       "source": [
-        "!head -n 1 test_other_QN.json"
+        "!head -n 1 test_other_CitNet.json"
       ]
     },
     {
@@ -225,8 +225,8 @@
       "source": [
         "!python ./NeMo/examples/asr/transcribe_speech.py \\\n",
         "pretrained_name=\"stt_en_conformer_ctc_small\" \\\n",
-        "dataset_manifest=./test_other_QN.json \\\n",
-        "output_filename=\"test_other_QN_Conf_small.json\" \\\n",
+        "dataset_manifest=./test_other_CitNet.json \\\n",
+        "output_filename=\"test_other_CitNet_Conf_small.json\" \\\n",
         "batch_size=8 \\\n",
         "cuda=0 amp=True \\\n",
         "append_pred=True \\\n",
@@ -242,8 +242,8 @@
       "source": [
         "Conformer's WER  is 8.1%.\n",
         "\n",
-        "Here is the first line of `test_other_QN_Conf_small.json` manifest file with transcripts by both ASR models\n",
-        "- `pred_text_QN` by QuartzNet\n",
+        "Here is the first line of `test_other_CitNet_Conf_small.json` manifest file with transcripts by both ASR models\n",
+        "- `pred_text_CitNet` by Citrinet-256\n",
         "- `pred_text_conf_s` by Conformer-Small"
       ]
     },
@@ -256,7 +256,7 @@
       },
       "outputs": [],
       "source": [
-        "!head -n 1 test_other_QN_Conf_small.json"
+        "!head -n 1 test_other_CitNet_Conf_small.json"
       ]
     },
     {
@@ -282,8 +282,8 @@
         "\n",
         "In this tutorial, we use Google Colab. So we need to get a proxy link to the instance.\n",
         "\n",
-        "When running locally, you just running command \"python3 ./NeMo/tools/speech_data_explorer/data_explorer.py test_other_QN_Conf_small.json --port=8050 \\\n",
-        "-nc pred_text_QN pred_text_conf_s\" and conndect by provided link in your browser"
+        "When running locally, you just running command \"python3 ./NeMo/tools/speech_data_explorer/data_explorer.py test_other_CitNet_Conf_small.json --port=8050 \\\n",
+        "-nc pred_text_CitNet pred_text_conf_s\" and conndect by provided link in your browser"
       ]
     },
     {
@@ -320,10 +320,10 @@
         "    command = [\n",
         "        \"python3\",\n",
         "        \"./NeMo/tools/speech_data_explorer/data_explorer.py\",\n",
-        "        \"test_other_QN_Conf_small.json\",\n",
+        "        \"test_other_CitNet_Conf_small.json\",\n",
         "        f\"--port={PORT}\",\n",
         "        \"-nc\",\n",
-        "        \"pred_text_QN\",\n",
+        "        \"pred_text_CitNet\",\n",
         "        \"pred_text_conf_s\"\n",
         "    ]\n",
         "    try:\n",
@@ -363,8 +363,8 @@
       },
       "outputs": [],
       "source": [
-        "# !python3 ./NeMo/tools/speech_data_explorer/data_explorer.py test_other_QN_Conf_small.json --port=8050 \\\n",
-        "# -nc pred_text_QN pred_text_conf_s"
+        "# !python3 ./NeMo/tools/speech_data_explorer/data_explorer.py test_other_CitNet_Conf_small.json --port=8050 \\\n",
+        "# -nc pred_text_CitNet pred_text_conf_s"
       ]
     },
     {
@@ -422,7 +422,7 @@
         "\n",
         "In each mode, the dataset is visualized as an interactive scatterplot. Each marker represents a data unit (either a word, or an utterance). X-coordinate encodes a selected metric for one model, Y-coordinate does the same for the other model.\n",
         "\n",
-        "By default, word level comparison is selected on `Comparison tool` page. In second (2) and third (3) box you can choose what will be shown on the axes of the scatterplot (that is, metrics for 1st and 2nd models). In our example, it is word level accuracy for QuartzNet and Conformer-Small: `accuracy_model_pred_text_{model_name}`."
+        "By default, word level comparison is selected on `Comparison tool` page. In second (2) and third (3) box you can choose what will be shown on the axes of the scatterplot (that is, metrics for 1st and 2nd models). In our example, it is word level accuracy for Citrinet-256 and Conformer-Small: `accuracy_model_pred_text_{model_name}`."
       ]
     },
     {
@@ -645,10 +645,10 @@
       "source": [
         "Using the {wer_model_1} != {wer_model_2} query you can remove all sentences/words that have the same WER, this can be very convenient if the models you are comparing are similar.\n",
         "\n",
-        "In the following example, you can see how QuartzNet and Conformer-Small transcribe the same utterance:\n",
+        "In the following example, you can see how Citrinet-256 and Conformer-Small transcribe the same utterance:\n",
         "\n",
         "*   reference transcript is `the school of the wilderness`\n",
-        "*   QuartzNet's transcript is `the school of the wearerness` (the error in the last word)\n",
+        "*   Citrinet-256's transcript is `the school of the wearerness` (the error in the last word)\n",
         "*   Conformer-Small's transcript is `the score of the word in its` (almost completely wrong prediction)\n",
         "\n"
       ]
@@ -740,7 +740,7 @@
         "id": "2wOPEk4ktKrb"
       },
       "source": [
-        "This part of the graph shows an enlarged view in coordinates (0, 100). That is, words correctly recognized by the Conformer-Small and not recognized by QuartzNet."
+        "This part of the graph shows an enlarged view in coordinates (0, 100). That is, words correctly recognized by the Conformer-Small and not recognized by Citrinet-256."
       ]
     },
     {
@@ -760,7 +760,7 @@
         "id": "IjXTQJZuC3Z-"
       },
       "source": [
-        "Let's write down words recognized only by QuartzNet and words recognized only by Conformer-Small:"
+        "Let's write down words recognized only by Citrinet-256 and words recognized only by Conformer-Small:"
       ]
     },
     {
@@ -775,7 +775,7 @@
         "import pandas as pd\n",
         "\n",
         "data = {\n",
-        "    \"QuartzNet_words\": [\"allspice\", \"southwark\", \"dante\", \"panada\", \"favour\", \"vapours\", \"fuchs\", \"battlefields\", \"morrel\", \"postscript\"],\n",
+        "    \"CitNet_words\": [\"allspice\", \"southwark\", \"dante\", \"panada\", \"favour\", \"vapours\", \"fuchs\", \"battlefields\", \"morrel\", \"postscript\"],\n",
         "    \"Conformer_words\": [\"gothic\", \"tablespoons\", \"heidelberg\", \"bough\", \"nocturnal\", \"meekin\", \"-\", \"-\", \"-\", \"-\"]\n",
         "}\n",
         "\n",
@@ -923,7 +923,7 @@
         "id": "jyX2PVgovdjj"
       },
       "source": [
-        "In this case, the speaker does not really pause between `over` and `all`, and QuartzNet transcribes it as a single word."
+        "In this case, the speaker does not really pause between `over` and `all`, and Citrinet-256 transcribes it as a single word."
       ]
     },
     {


### PR DESCRIPTION
## Backport to r3.0.0 
Cherry-pick of the main-line fix #15897 (commit 98a00a8).

## What
`tutorials/tools/SDE_HowTo_v2.ipynb` called `QuartzNet15x5Base-En`, removed from the r3.0.0 pretrained-model registry → transcription cell hard-fails. Found during NeMo Speech 26.06 QA (manual notebook list).

## Fix
Swap to `stt_en_citrinet_256` (still-registered compact CTC model; keeps the two-architecture comparison vs `stt_en_conformer_ctc_small`), relabel `QN`→`CitNet` / `QuartzNet`→`Citrinet-256`. One file, 26/26 lines. `BRANCH='r3.0.0'` retained.

## Verified
Model confirmed in registry; real GPU transcription passes (NGC download → EncDecCTCModelBPE load → transcribe), no removed-model error.

Ref: fix_6411583. Forward-fix on main: #15897.