### PR TITLE
Fix/ctc segmentation tutorial deps

### DIFF
--- a/tools/ctc_segmentation/requirements.txt
+++ b/tools/ctc_segmentation/requirements.txt
@@ -1,3 +1,5 @@
 ctc_segmentation==1.7.4
 num2words
 numpy<2.0.0
+plotly
+wget

--- a/tools/ctc_segmentation/run_segmentation.sh
+++ b/tools/ctc_segmentation/run_segmentation.sh
@@ -78,9 +78,6 @@ if ! command -v num2words &> /dev/null; then
   exit 1
 fi
 
-# ctc_segmentation ships as a Python library, not a CLI executable, so we probe
-# it with an import check rather than `command -v` (which only passed on Colab via
-# a manual `ctc_segmentation -> python` symlink and always failed elsewhere).
 if ! python -c "import ctc_segmentation" &> /dev/null; then
   echo "ctc_segmentation could not be found"
   echo "please install using tools/ctc_segmentation/requirements.txt"

--- a/tools/ctc_segmentation/run_segmentation.sh
+++ b/tools/ctc_segmentation/run_segmentation.sh
@@ -78,7 +78,10 @@ if ! command -v num2words &> /dev/null; then
   exit 1
 fi
 
-if ! command -v ctc_segmentation &> /dev/null; then
+# ctc_segmentation ships as a Python library, not a CLI executable, so we probe
+# it with an import check rather than `command -v` (which only passed on Colab via
+# a manual `ctc_segmentation -> python` symlink and always failed elsewhere).
+if ! python -c "import ctc_segmentation" &> /dev/null; then
   echo "ctc_segmentation could not be found"
   echo "please install using tools/ctc_segmentation/requirements.txt"
   exit 1

--- a/tutorials/tools/CTC_Segmentation_Tutorial.ipynb
+++ b/tutorials/tools/CTC_Segmentation_Tutorial.ipynb
@@ -635,7 +635,7 @@
         "if 'google.colab' in str(get_ipython()):\n",
         "      !sudo ln -s /usr/local/bin/python /usr/local/bin/ctc_segmentation #for comatability with run_segmentation.sh\n",
         "\n",
-        "MODEL = \"QuartzNet15x5Base-En\" # \"stt_en_citrinet_512_gamma_0_25\"\n",
+        "MODEL = \"stt_en_citrinet_512\" # QuartzNet15x5Base-En was removed from NeMo (PR #15507); use a registered CTC model\n",
         "OUTPUT_DIR_2 = WORK_DIR + \"/en_output\"\n",
         "\n",
         "! rm -rf $OUTPUT_DIR_2\n",


### PR DESCRIPTION
# What does this PR do ?

Fixes the CTC Segmentation tutorial so it runs end-to-end outside Google Colab
(e.g. the NeMo container), where it currently fails.

**Collection**: ASR (tools/ctc_segmentation)

# Changelog

- `tools/ctc_segmentation/requirements.txt`: add `plotly` and `wget` — imported by
  the notebook (cell 3 / `plot_signal`, and the sample/script downloads) but missing
  from the manifest, causing `ModuleNotFoundError: No module named 'plotly'`.
- `tools/ctc_segmentation/run_segmentation.sh`: replace `command -v ctc_segmentation`
  with `python -c "import ctc_segmentation"`. `ctc_segmentation` is a library with no
  CLI, so the old check only passed on Colab via a manual `ctc_segmentation -> python`
  symlink and aborted everywhere else with "ctc_segmentation could not be found".
- `tutorials/tools/CTC_Segmentation_Tutorial.ipynb`: switch the English `MODEL` from
  the removed `QuartzNet15x5Base-En` (removed in #15507) to the registered
  `stt_en_citrinet_512`.

# Usage

```bash
bash tools/ctc_segmentation/run_segmentation.sh \
  --MODEL_NAME_OR_PATH=stt_en_citrinet_512 \
  --DATA_DIR=<data>/en --OUTPUT_DIR=<out>/en_output \
  --SCRIPTS_DIR=tools/ctc_segmentation/scripts \
  --MIN_SCORE=-2 --USE_NEMO_NORMALIZATION=False
```

**PR Type**:
- [x] Bugfix