### PR TITLE
[TTS] Whitelist TTS AudioTrimmer and ArtifactGenerator

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -236,6 +236,22 @@ def _is_target_allowed(target: str) -> bool:
             except (ImportError, TypeError):
                 return False
 
+        if target.startswith("nemo.collections.tts.parts.preprocessing."):
+            try:
+                from nemo.collections.tts.parts.preprocessing.audio_trimming import AudioTrimmer
+
+                return issubclass(obj, AudioTrimmer)
+            except (ImportError, TypeError):
+                return False
+
+        if target.startswith("nemo.collections.tts.parts.utils.callbacks"):
+            try:
+                from nemo.collections.tts.parts.utils.callbacks import ArtifactGenerator
+
+                return issubclass(obj, ArtifactGenerator)
+            except (ImportError, TypeError):
+                return False
+
         if target.startswith("nemo.collections.audio.parts.submodules.flow."):
             try:
                 from nemo.collections.audio.parts.submodules.flow import (


### PR DESCRIPTION
# What does this PR do ?

Fix audio codec training and tutorials by allowing relevant TTS utilities through `safe_instantiate`.

**Collection**: [TTS]

# Changelog

- Add AudioTrimmer subclasses to` safe_instantiate` checks.
- Add ArtifactGenerator subclasses to` safe_instantiate` checks.

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
