### PR TITLE
Switch to TinyLlama-1.1B-Chat-v1.0 to resolve auto-conversion exception (bug/6071397)

### DIFF
--- a/examples/speechlm2/conf/duplex_stt.yaml
+++ b/examples/speechlm2/conf/duplex_stt.yaml
@@ -1,6 +1,6 @@
 model:
   # Every name/path here starting with 'pretrained' is used to initialize the model weights.
-  pretrained_llm: TinyLlama/TinyLlama_v1.1
+  pretrained_llm: TinyLlama/TinyLlama-1.1B-Chat-v1.0
   pretrained_asr: nvidia/stt_en_fastconformer_hybrid_large_streaming_multi
   scoring_asr: stt_en_fastconformer_transducer_large  # used only in validation/evaluation
   source_sample_rate: 16000

--- a/examples/speechlm2/conf/s2s_duplex.yaml
+++ b/examples/speechlm2/conf/s2s_duplex.yaml
@@ -1,6 +1,6 @@
 model:
   # Every name/path here starting with 'pretrained' is used to initialize the model weights.
-  pretrained_llm: TinyLlama/TinyLlama_v1.1
+  pretrained_llm: TinyLlama/TinyLlama-1.1B-Chat-v1.0
   pretrained_audio_codec: ???  # to be released
   pretrained_asr: nvidia/stt_en_fastconformer_hybrid_large_streaming_multi
   scoring_asr: stt_en_fastconformer_transducer_large  # used only in validation/evaluation

--- a/examples/speechlm2/conf/s2s_duplex_speech_decoder.yaml
+++ b/examples/speechlm2/conf/s2s_duplex_speech_decoder.yaml
@@ -1,6 +1,6 @@
 model:
   # Every name/path here starting with 'pretrained' is used to initialize the model weights.
-  pretrained_llm: TinyLlama/TinyLlama_v1.1
+  pretrained_llm: TinyLlama/TinyLlama-1.1B-Chat-v1.0
   pretrained_audio_codec: ???  # to be released
   pretrained_asr: nvidia/stt_en_fastconformer_hybrid_large_streaming_multi
   scoring_asr: stt_en_fastconformer_transducer_large  # used only in validation/evaluation


### PR DESCRIPTION
Switch default checkpoint from TinyLlama/TinyLlama_v1.1 to TinyLlama/TinyLlama-1.1B-Chat-v1.0 to resolve unhandled transformers Hugging Face Hub exceptions.

The previous model checkpoint TinyLlama/TinyLlama_v1.1 causes the Hugging Face transformers library to crash or raise background thread exceptions regardless of the use_safetensors flag: 
- With use_safetensors=True: It fails explicitly trying to generate a Hub PR for weights conversion.
- With use_safetensors=False: It successfully downloads the weights but throws a fatal unhandled thread error (Exception in thread Thread-auto_conversion) due to failed background conversion attempts on unauthenticated systems.

`OSError: Could not create safetensors conversion PR. The repo does not appear to have a file named pytorch_model.bin or model.safetensors.
`