### PR TITLE
Adding fix of asr_diar tutorial for r3.0.0

### DIFF
--- a/tutorials/speaker_tasks/ASR_with_SpeakerDiarization.ipynb
+++ b/tutorials/speaker_tasks/ASR_with_SpeakerDiarization.ipynb
@@ -193,7 +193,7 @@
         "DOMAIN_TYPE = \"meeting\" # Can be meeting or telephonic based on domain type of the audio file\n",
         "CONFIG_FILE_NAME = f\"diar_infer_{DOMAIN_TYPE}.yaml\"\n",
         "\n",
-        "CONFIG_URL = f\"https://raw.githubusercontent.com/NVIDIA/NeMo/main/examples/speaker_tasks/diarization/conf/inference/{CONFIG_FILE_NAME}\"\n",
+        "CONFIG_URL = f\"https://raw.githubusercontent.com/NVIDIA/NeMo/{BRANCH}/examples/speaker_tasks/diarization/conf/inference/{CONFIG_FILE_NAME}\"\n",
         "\n",
         "if not os.path.exists(os.path.join(data_dir,CONFIG_FILE_NAME)):\n",
         "    CONFIG = wget.download(CONFIG_URL, data_dir)\n",


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fix `CONFIG_URL` in `ASR_with_SpeakerDiarization.ipynb` to use the installed NeMo branch (`BRANCH` variable) instead of hardcoding `main`, preventing a `ConfigAttributeError` on `ctc_decoder_parameters` when running the notebook on r3.0.0.

**Collection**: `speaker_tasks`

# Changelog

- Fixed `CONFIG_URL` in `tutorials/speaker_tasks/ASR_with_SpeakerDiarization.ipynb` to interpolate `{BRANCH}` instead of hardcoding `main`, so the downloaded diarizer config matches the installed NeMo version

# Usage

```python
# Before (broken on r3.0.0):
CONFIG_URL = f"https://raw.githubusercontent.com/NVIDIA/NeMo/main/examples/speaker_tasks/diarization/conf/inference/{CONFIG_FILE_NAME}"

# After (fixed):
CONFIG_URL = f"https://raw.githubusercontent.com/NVIDIA/NeMo/{BRANCH}/examples/speaker_tasks/diarization/conf/inference/{CONFIG_FILE_NAME}"
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Fixes `ConfigAttributeError: Missing key ctc_decoder_parameters` in notebook cell In[20] on NeMo r3.0.0 (nemo-speech 26.06.rc3)
- Root cause: `main` branch `diar_infer_*.yaml` configs dropped `ctc_decoder_parameters`, but r3.0.0 code still requires it; pinning the URL to `{BRANCH}` fetches the correct config
- Regression distinct from nvbugs/6382092 (cpWER ImportError); this is a new earlier failure at the ASR decoder-timestamps setup cell
