### PR TITLE
Disable RNNT CUDA graphs in Multilang ASR notebook

### DIFF
--- a/tutorials/asr/Multilang_ASR.ipynb
+++ b/tutorials/asr/Multilang_ASR.ipynb
@@ -140,7 +140,7 @@
    "source": [
     "import nemo.collections.asr as nemo_asr\n",
     "import os\n",
-    "from omegaconf import OmegaConf\n",
+    "from omegaconf import OmegaConf, open_dict\n",
     "\n",
     "# Allow loading trusted checkpoints that hold non-tensor objects (torch>=2.6 weights_only default).\n",
     "os.environ[\"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD\"] = \"1\""
@@ -580,7 +580,10 @@
    },
    "outputs": [],
    "source": [
-    "asr_model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(model_name=\"stt_enes_conformer_transducer_large\")"
+    "asr_model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(model_name=\"stt_enes_conformer_transducer_large\")\n",
+    "with open_dict(asr_model.cfg.decoding):\n",
+    "    asr_model.cfg.decoding.greedy.use_cuda_graph_decoder = False\n",
+    "asr_model.change_decoding_strategy(asr_model.cfg.decoding, verbose=False)"
    ]
   },
   {
@@ -939,7 +942,10 @@
    },
    "outputs": [],
    "source": [
-    "asr_model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(model_name=\"stt_en_conformer_transducer_small\")"
+    "asr_model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(model_name=\"stt_en_conformer_transducer_small\")\n",
+    "with open_dict(asr_model.cfg.decoding):\n",
+    "    asr_model.cfg.decoding.greedy.use_cuda_graph_decoder = False\n",
+    "asr_model.change_decoding_strategy(asr_model.cfg.decoding, verbose=False)"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do ?

Disable RNNT CUDA graph decoding in `Multilang_ASR.ipynb` before RNNT transcription so later checkpoint restores in the same notebook process continue to work.

**Collection**: ASR tutorials

# Changelog

- Import `open_dict` for safe decoding config updates.
- Disable `use_cuda_graph_decoder` for the multilingual RNNT model before transcription.
- Disable `use_cuda_graph_decoder` for the English RNNT model before transcription.

# Usage

N/A; notebook-only fix.

# Additional Information

- Related to ASR notebook checkpoint restore failures after RNNT transcription.