### PR TITLE
fix: report ASR model type instead of name in unknown type error

### DIFF
--- a/nemo/collections/tts/modules/magpietts_inference/evaluate_generated_audio.py
+++ b/nemo/collections/tts/modules/magpietts_inference/evaluate_generated_audio.py
@@ -256,7 +256,7 @@ def load_evaluation_models(
     elif asr_model_type == "whisper":
         models['asr_model'] = WhisperTranscriber(model_name=asr_model_name, device=device)
     else:
-        raise ValueError(f"Unknown ASR model type {asr_model_name}")
+        raise ValueError(f"Unknown ASR model type {asr_model_type}")
 
     if sv_model_type == "wavlm":
         models['feature_extractor'] = Wav2Vec2FeatureExtractor.from_pretrained('microsoft/wavlm-base-plus-sv')

--- a/tests/collections/tts/modules/magpietts_inference/test_evaluate_generated_audio.py
+++ b/tests/collections/tts/modules/magpietts_inference/test_evaluate_generated_audio.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for MagpieTTS generated audio evaluation utilities.
+"""
+
+import pytest
+
+from nemo.collections.tts.modules.magpietts_inference.evaluate_generated_audio import load_evaluation_models
+
+
+class TestLoadEvaluationModels:
+    """Tests for load_evaluation_models."""
+
+    def test_unknown_asr_model_type_error_includes_type(self):
+        """Unknown asr_model_type should be reported in the error message, not the model name."""
+        with pytest.raises(ValueError, match="Unknown ASR model type invalid_type"):
+            load_evaluation_models(asr_model_type="invalid_type", asr_model_name="some_model_name")


### PR DESCRIPTION
When `load_evaluation_models` receives an unsupported `asr_model_type`, the error message was printing the model name/path instead of the invalid type, making debugging harder.

- Fixed the interpolation in `nemo/collections/tts/modules/magpietts_inference/evaluate_generated_audio.py`
- Added a unit test verifying the error message contains the invalid type value

Tested:
```bash
uv run python -m pytest tests/collections/tts/modules/magpietts_inference/test_evaluate_generated_audio.py -v
# 1 passed
```

cc @blisc for TTS review