### PR TITLE
Temporarily pin SALM Automodel dispatcher to torch

### DIFF
--- a/examples/speechlm2/conf/salm_automodel.yaml
+++ b/examples/speechlm2/conf/salm_automodel.yaml
@@ -75,15 +75,17 @@ model:
 
   # Automodel backend dispatch. Selects the kernel/backend for each major module
   # in the LLM (attention, linear, rms_norm, MoE experts/dispatcher). Defaults
-  # come from Automodel's BackendConfig and auto-select TE/DeepEP when available;
-  # override here to pin a specific backend (e.g. attn=sdpa to bypass TE).
-  # automodel_backend:
+  # come from Automodel's BackendConfig and auto-select TE/DeepEP when available.
+  # TODO (Dongji): This is a temporary release unblock. Remove the override once
+  # BackendConfig checks NVLINK/NVSHMEM topology before selecting DeepEP.
+  automodel_backend:
+    dispatcher: torch           # Set to "deepep" only if your GPUs have NVLINK/NVSHMEM
+  # Optional overrides for other backends (e.g. attn=sdpa to bypass TE):
   #   attn: te                  # "te" | "sdpa" | "flex"
   #   linear: te                # "torch" | "te"
   #   rms_norm: torch_fp32      # "torch" | "torch_fp32" | "te"
   #   rope_fusion: true         # Fused RoPE (requires TE)
   #   experts: torch_mm         # MoE expert GEMM: "torch" | "te" | "gmm" | "torch_mm"
-  #   dispatcher: deepep        # MoE token dispatcher: "torch" | "deepep" | "hybridep" | "uccl_ep"
   #   dispatcher_num_sms: 20    # SM count for DeepEP/UCCL-EP kernels
   #   fake_balanced_gate: false # Replace learned Gate with balanced fake gate (debug/bench)
   #   fake_gate_noise: 0.0      # [0, 1] — noise for FakeBalancedGate routing

--- a/tests/collections/speechlm2/test_example_configs.py
+++ b/tests/collections/speechlm2/test_example_configs.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+from omegaconf import OmegaConf
+
+
+REPO_ROOT = Path(__file__).parents[3]
+
+
+def test_salm_automodel_uses_portable_moe_dispatcher():
+    cfg = OmegaConf.load(REPO_ROOT / "examples/speechlm2/conf/salm_automodel.yaml")
+
+    assert cfg.model.automodel_backend.dispatcher == "torch"


### PR DESCRIPTION
## What changed

- Pin `examples/speechlm2/conf/salm_automodel.yaml` to `automodel_backend.dispatcher: torch`.
- Document DeepEP as an explicit opt-in for GPUs with NVLINK/NVSHMEM.
- Add a focused config regression test.
- Add `TODO (Dongji)` to remove the override once Automodel performs topology-aware dispatcher selection.

## Why

This is a temporary fix to unblock the release.

Automodel's `BackendConfig` currently selects DeepEP when the package is installed and CUDA is available. It does not validate whether the GPU topology supports DeepEP. On PCIe-only systems, SALM MoE expert-parallel training can therefore enter DeepEP kernels and fail with an unexplained CUDA `unspecified launch failure` / `EPException`.

The long-term fix belongs in Automodel: select DeepEP only when the required NVLINK/NVSHMEM topology is available, otherwise fall back to Torch with a warning.

## Impact

The example now uses the portable Torch dispatcher by default. Systems with compatible NVLINK/NVSHMEM topology can opt into DeepEP with:

```bash
model.automodel_backend.dispatcher=deepep
```

## Validation

Using `nvcr.io/nvidian/nemo-speech:26.06.rc4` on a two-GPU PCIe-only host:

- Default `BackendConfig` resolved to `dispatcher=deepep`.
- Automodel DeepEP dispatch reproduced `intranode.cu:126 'unspecified launch failure'` and `deep_ep.cpp:147 'unspecified launch failure'`, followed by `EPException` / `SIGABRT`.
- The portable Automodel Torch `GroupedExperts` forward/backward path passed on both ranks.
- The patched YAML resolved to `dispatcher=torch`.
- Focused config test passed: `pytest -q --confcutdir=tests/collections/speechlm2 tests/collections/speechlm2/test_example_configs.py`.
- `git diff --check`, Black, isort, and Python compilation passed.

The original 8x H200 QA case should still be rerun in the release environment.
