### PR TITLE
Fix cpWER imports in ASR diarization tutorial for r3.0.0

### DIFF
--- a/tutorials/speaker_tasks/ASR_with_SpeakerDiarization.ipynb
+++ b/tutorials/speaker_tasks/ASR_with_SpeakerDiarization.ipynb
@@ -597,7 +597,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from nemo.collections.asr.metrics.der import concat_perm_word_error_rate\n",
+        "from nemo.collections.asr.metrics.cpwer import concat_perm_word_error_rate\n",
         "from nemo.collections.asr.metrics.wer import word_error_rate\n",
         "from nemo.collections.asr.parts.utils.diarization_utils import convert_word_dict_seq_to_text, convert_ctm_to_text\n",
         "# Provide a list containing the paths to the reference CTM files\n",
@@ -630,7 +630,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from nemo.collections.asr.metrics.der import concat_perm_word_error_rate\n",
+        "from nemo.collections.asr.metrics.cpwer import concat_perm_word_error_rate\n",
         "from nemo.collections.asr.metrics.wer import word_error_rate\n",
         "\n",
         "cpWER, concat_hyp, concat_ref = concat_perm_word_error_rate([spk_hypothesis], [spk_reference])\n",


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fix the ASR with Speaker Diarization tutorial on `r3.0.0` by importing `concat_perm_word_error_rate` from its current `nemo.collections.asr.metrics.cpwer` module.

**Collection**: ASR / Speaker Tasks

# Changelog

- Update both `concat_perm_word_error_rate` imports in `ASR_with_SpeakerDiarization.ipynb`.
- Replace the stale `nemo.collections.asr.metrics.der` import with `nemo.collections.asr.metrics.cpwer`.
- Preserve all other release-specific notebook content unchanged.

# Usage

```python
from nemo.collections.asr.metrics.cpwer import concat_perm_word_error_rate
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? No automated test was added because this is a notebook-only import correction. The notebook JSON structure and Git diff were validated.
- [x] Did you add or update any necessary documentation? The affected tutorial notebook is updated directly.
- [x] Does the PR affect components that are optional to install? No.
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries? Not applicable.
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Target branch: `r3.0.0`
- Found during the NeMo Speech 26.06 QA release run 13900, testcase `speech_asr_with_speaker_diarization_nb`.
- The Pyannote-removal refactor in `e1a7de040f` moved `concat_perm_word_error_rate` from `der.py` to `cpwer.py`, but the tutorial imports were not updated.
- Previously masked by `nvbugs/6434403`.
- QA result: https://dlfwqa.nvidia.com/domino/test-results/234568
