### PR TITLE
docs: qualify SALM Automodel parallelism support

### DIFF
--- a/docs/source/speechlm2/training_and_scaling.rst
+++ b/docs/source/speechlm2/training_and_scaling.rst
@@ -101,8 +101,10 @@ AutomodelParallelStrategy (SALMAutomodel)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For ``SALMAutomodel``, the collection provides ``AutomodelParallelStrategy`` which
-delegates device mesh creation and parallelism to NeMo Automodel. This strategy
-supports FSDP2, TP, PP, CP, EP (MoE), and HSDP.
+delegates device mesh creation and parallelism to NeMo Automodel. The strategy can
+construct device meshes for FSDP2, TP, PP, CP, EP (MoE), and HSDP, but actual
+support depends on the selected LLM architecture, backend, and combination of
+parallelism axes.
 
 .. code-block:: yaml
 
@@ -164,6 +166,16 @@ optimizations:
 * **DeepEP** (Deep Expert Parallelism): An efficient all-to-all communication
   primitive for routing tokens to experts across GPUs, significantly reducing the
   communication overhead of Expert Parallelism.
+
+.. important::
+   For the native Nemotron-V3 backbone, the validated ``SALMAutomodel``
+   parallelism axes are FSDP2, EP, and CP. CP requires packed sequences and
+   Transformer Engine attention, as described in the Context Parallelism
+   section below.
+
+   Nemotron-V3 does not provide a TP plan, so set ``tp_size: 1``. HSDP is not
+   supported in this path, so set ``dp_replicate_size: 1``. PP has not been
+   validated for this SpeechLM2 configuration, so set ``pp_size: 1``.
 
 Example: training SALMAutomodel with Nemotron Nano V3 on 8 GPUs with EP=8:
 


### PR DESCRIPTION
## What changed

- Clarify that `AutomodelParallelStrategy` can construct meshes for FSDP2, TP, PP, CP, EP, and HSDP, while actual support remains model-, backend-, and combination-dependent.
- Document the validated native Nemotron-V3 SALMAutomodel envelope: FSDP2, EP, and CP with packed sequences and Transformer Engine attention.
- Direct users to keep `tp_size`, `dp_replicate_size`, and the currently unvalidated `pp_size` at 1 for this configuration.

## Why

The previous blanket support statement drove QA and users toward unsupported Nemotron-V3 configurations. Nemotron-V3 has no TP plan, while the SALMAutomodel HSDP path is unsupported and currently fails with an opaque DeviceMesh error. PP is capability-signaled by Automodel but has no SpeechLM2 training validation.

This is a documentation correction only; it does not change parallelism behavior. The HSDP validation/runtime issue remains separate.

## Validation

- `sphinx-lint docs/source/speechlm2/training_and_scaling.rst` — no problems found
- `git diff --check`

Related: internal bug 6437904.
