### PR TITLE
SpeechLM2: add verified finite AMI DPO recipe

### DIFF
--- a/examples/speechlm2/README_dpo.md
+++ b/examples/speechlm2/README_dpo.md
@@ -12,6 +12,10 @@ an adapter/updater outside the owning package.
 trajectory as inputs rather than hard-coded program state:
 
 - strict source DCP: Hero2 step 14400;
+- the configured ASR archive is used only to construct the perception schema;
+  `init_from_checkpoint` is disabled and the strict Hero2 step-14400 DCP
+  immediately replaces all temporary construction weights before reference
+  capture or an update;
 - one direct finite Lhotse JSONL of 4,350 preference cuts;
 - ten ordered source shards of 435 pairs and two explicit passes (20 updates);
 - no shuffle and no cycling; every rank reads only its assigned audio slots;
@@ -57,11 +61,15 @@ historical-r5 config remains the full 20-update trajectory.
 
 ## Evidence produced by a run
 
-The run writes `TRAJECTORY.json`, one `steps/sNN.json` per optimizer update,
-and `global_compact.json`.  A scheduled checkpoint has both a model DCP and a
-model-plus-AdamW DCP.  `CHECKPOINT_READY.json` is emitted only after every rank
-can observe the two DCP metadata files.  Treat a checkpoint without that file
-as incomplete.
+Before any reference forward, the run writes `MODEL_AUTHORITY.json`: it binds
+the source DCP metadata SHA-256, requires a strict no-missing/no-unexpected
+model-state load on every rank, and records compact preconstruction/post-DCP
+state receipts. It is the proof that temporary ASR construction weights do not
+remain an initialization authority. The run then writes `TRAJECTORY.json`, one
+`steps/sNN.json` per optimizer update, and `global_compact.json`. A scheduled
+checkpoint has both a model DCP and a model-plus-AdamW DCP.
+`CHECKPOINT_READY.json` is emitted only after every rank can observe the two
+DCP metadata files. Treat a checkpoint without that file as incomplete.
 
 The source data and source checkpoint are substitutable configuration inputs.
 An actual replay must record its source revision, effective config, data

--- a/examples/speechlm2/README_dpo.md
+++ b/examples/speechlm2/README_dpo.md
@@ -26,7 +26,7 @@ trajectory as inputs rather than hard-coded program state:
 - standard DPO `-logsigmoid(beta * ((pi_c-ref_c) - (pi_r-ref_r)))`, beta .20;
 - grad-enabled initial-policy reference log probabilities, detached once and
   reused for the second ordered pass;
-- a named 269-tensor / 1,074,327,616-scalar FP32 mutation surface, no LoRA,
+- a named 269-tensor / 1,074,318,016-scalar FP32 mutation surface, no LoRA,
   PEFT, or adapters; and
 - AdamW (`lr=2.5e-6`, betas `.9,.95`, eps `1e-8`, zero weight decay) on one
   eight-GPU node.

--- a/examples/speechlm2/README_dpo.md
+++ b/examples/speechlm2/README_dpo.md
@@ -17,6 +17,8 @@ trajectory as inputs rather than hard-coded program state:
 - no shuffle and no cycling; every rank reads only its assigned audio slots;
 - same-audio `chosen`/`rejected` pairs, bound to the one direct-Lhotse
   recording whose ID and staged filename equal the manifest's audio identity;
+- either a legacy string prompt or a structured `{system, user}` prompt; the
+  latter is rendered as separate dialog turns and is never flattened;
 - standard DPO `-logsigmoid(beta * ((pi_c-ref_c) - (pi_r-ref_r)))`, beta .20;
 - grad-enabled initial-policy reference log probabilities, detached once and
   reused for the second ordered pass;

--- a/examples/speechlm2/README_dpo.md
+++ b/examples/speechlm2/README_dpo.md
@@ -80,3 +80,31 @@ The source data and source checkpoint are substitutable configuration inputs.
 An actual replay must record its source revision, effective config, data
 receipt, output root, and matched AMI/Full-HF evaluation artifact alongside
 these files.
+
+## Standard r22 serving export and evaluation
+
+`salm_dpo_export.py` converts only a durable `CHECKPOINT_READY` model DCP into
+a fresh indexed safetensors directory.  It requires the training
+`TRAJECTORY.json`, the immutable Hero2 serving baseline, and a fresh output
+directory.  The exporter verifies the full tensor namespace and shapes,
+requires precisely the trajectory's 269 BF16-to-FP32 selected tensors, and
+round-trips each emitted tensor byte-for-byte before it writes
+`EVAL_MODEL_READY.json`.  All served weights come from the candidate DCP; the
+baseline supplies only `config.json` (with bootstrap state removed) and
+tokenizer/generation assets.
+
+```bash
+python examples/speechlm2/salm_dpo_export.py \
+  --candidate-dcp=/durable/run/checkpoints/s08/model_weights.dcp \
+  --trajectory=/durable/run/TRAJECTORY.json \
+  --serving-baseline=/immutable/hero2/eval-step-14400 \
+  --output=/durable/evaluation/s08/model
+```
+
+Use the tracked `serve_salm_dpo_hero2_vllm_r22.sh` as the server entrypoint
+for official NeMo-Skills `ns_eval`.  It installs the readable, pinned r22
+NeMo source non-editably and invokes the stock NeMo-Skills vLLM server.  It
+does not copy model/source files, compose an alternate TransformerEncoder,
+set `PYTHONPATH`, or score outputs itself.  The evaluation workflow records
+the r22 source path and its TransformerEncoder SHA-256 and retains the exact
+OpenASR AMI and Full-HF prompt/decoder/scorer configuration.

--- a/examples/speechlm2/README_dpo.md
+++ b/examples/speechlm2/README_dpo.md
@@ -102,9 +102,14 @@ python examples/speechlm2/salm_dpo_export.py \
 ```
 
 Use the tracked `serve_salm_dpo_hero2_vllm_r22.sh` as the server entrypoint
-for official NeMo-Skills `ns_eval`.  It installs the readable, pinned r22
-NeMo source non-editably and invokes the stock NeMo-Skills vLLM server.  It
-does not copy model/source files, compose an alternate TransformerEncoder,
-set `PYTHONPATH`, or score outputs itself.  The evaluation workflow records
-the r22 source path and its TransformerEncoder SHA-256 and retains the exact
-OpenASR AMI and Full-HF prompt/decoder/scorer configuration.
+for official NeMo-Skills `ns_eval`.  It verifies the immutable r22 source
+fingerprint, stages only its normal package inputs into a fresh writable
+job-local package artifact (the source mount remains untouched), and
+non-editably installs that artifact before invoking the stock NeMo-Skills
+vLLM server.  It does not compose an alternate TransformerEncoder, set
+`PYTHONPATH`, overlay files into an installed package, or score outputs
+itself.  `--verify-r22-package-install` is the focused regression: it proves
+that the staged artifact installs and imports from an isolated venv.  The
+evaluation workflow records the r22 source path, server fingerprint,
+TransformerEncoder SHA-256, and exact OpenASR AMI/Full-HF
+prompt/decoder/scorer configuration.

--- a/examples/speechlm2/README_dpo.md
+++ b/examples/speechlm2/README_dpo.md
@@ -1,0 +1,67 @@
+# Finite direct-Lhotse SpeechLM2 DPO
+
+`salm_dpo_train.py` is a normal NeMo-Speech Lightning entrypoint for an
+explicitly finite, same-audio ASR preference trajectory.  It is designed to
+make the data, model, update, and checkpoint contracts visible in review; it
+does not reuse experiment-local launchers, import hooks, runtime patching, or
+an adapter/updater outside the owning package.
+
+## Hero2 historical-r5 replay contract
+
+`conf/salm_dpo_hero2_ami_historical_r5.yaml` expresses the historical
+trajectory as inputs rather than hard-coded program state:
+
+- strict source DCP: Hero2 step 14400;
+- one direct finite Lhotse JSONL of 4,350 preference cuts;
+- ten ordered source shards of 435 pairs and two explicit passes (20 updates);
+- no shuffle and no cycling; every rank reads only its assigned audio slots;
+- same-audio `chosen`/`rejected` pairs, bound to the one direct-Lhotse
+  recording whose ID and staged filename equal the manifest's audio identity;
+- standard DPO `-logsigmoid(beta * ((pi_c-ref_c) - (pi_r-ref_r)))`, beta .20;
+- grad-enabled initial-policy reference log probabilities, detached once and
+  reused for the second ordered pass;
+- a named 269-tensor / 1,074,327,616-scalar FP32 mutation surface, no LoRA,
+  PEFT, or adapters; and
+- AdamW (`lr=2.5e-6`, betas `.9,.95`, eps `1e-8`, zero weight decay) on one
+  eight-GPU node.
+
+The loader pads the five short rank-local schedules with zero-weight copies so
+that each rank executes 55 forwards per update.  It applies scale `8/435` to
+each active pair before Lightning's distributed gradient reduction, producing
+the global mean of exactly 435 pairs.  This retains the bounded-memory update
+shape of the historical trajectory while relying on Lightning for backward,
+gradient clipping, optimizer stepping, and global-step tracking.
+
+## Launch
+
+Install the tracked NeMo-Speech revision as the normal package in the chosen
+container, then invoke the entrypoint with a new output root:
+
+```bash
+torchrun --standalone --nproc-per-node=8 examples/speechlm2/salm_dpo_train.py \
+  dpo.output_root=/durable/new-hero2-r5-replay
+```
+
+Do not use an editable checkout or a `PYTHONPATH` overlay as a substitute for
+the tracked source package in an experiment.  The effective resolved config is
+written to the fresh output root before model construction.
+
+For a real one-update integration smoke, retain the complete 4,350-row direct
+Lhotse input and override only `trainer.max_steps=1`,
+`dpo.expected_updates=1`, and `dpo.checkpoint_steps=[1]`.  That run still
+captures all initial reference scalars using the production path; it merely
+stops after the first ordered 435-pair optimizer update.  The checked-in
+historical-r5 config remains the full 20-update trajectory.
+
+## Evidence produced by a run
+
+The run writes `TRAJECTORY.json`, one `steps/sNN.json` per optimizer update,
+and `global_compact.json`.  A scheduled checkpoint has both a model DCP and a
+model-plus-AdamW DCP.  `CHECKPOINT_READY.json` is emitted only after every rank
+can observe the two DCP metadata files.  Treat a checkpoint without that file
+as incomplete.
+
+The source data and source checkpoint are substitutable configuration inputs.
+An actual replay must record its source revision, effective config, data
+receipt, output root, and matched AMI/Full-HF evaluation artifact alongside
+these files.

--- a/examples/speechlm2/README_dpo.md
+++ b/examples/speechlm2/README_dpo.md
@@ -36,7 +36,12 @@ that each rank executes 55 forwards per update.  It applies scale `8/435` to
 each active pair before Lightning's distributed gradient reduction, producing
 the global mean of exactly 435 pairs.  This retains the bounded-memory update
 shape of the historical trajectory while relying on Lightning for backward,
-gradient clipping, optimizer stepping, and global-step tracking.
+optimizer stepping, and global-step tracking. The DPO model invokes the
+inherited `SALMAutomodel.configure_gradient_clipping(..., 1.0, "norm")` once
+immediately before AdamW; that existing upstream path is mesh-aware for the
+LLM/perception DTensor layouts. It writes a data-free per-selected-gradient
+mesh/placement receipt before the clip, so the 269-tensor grouping is visible
+in every real-update run.
 
 ## Launch
 

--- a/examples/speechlm2/conf/salm_dpo_hero2_ami_historical_r5.yaml
+++ b/examples/speechlm2/conf/salm_dpo_hero2_ami_historical_r5.yaml
@@ -1,0 +1,45 @@
+# Native SpeechLM2 DPO replay contract for the historical Hero2 r5 trajectory.
+# Every model/data location is an explicit, substitutable input.  The source
+# model DCP is the sole model-weight authority after normal architecture setup.
+
+trainer:
+  devices: 8
+  num_nodes: 1
+  precision: bf16-true
+  max_steps: 20
+
+model:
+  base_experiment_config: /lustre/fsw/portfolios/llmservice/users/kdhawan/project/nemotron-transcribe/0712-hero2-plusgranaryv2-mlrope-nsv-sotmst-nrt-16node/exp_config.yaml
+
+dpo:
+  source_checkpoint: /lustre/fsw/portfolios/llmservice/users/kdhawan/project/nemotron-transcribe/0712-hero2-plusgranaryv2-mlrope-nsv-sotmst-nrt-16node/checkpoints/step=14400.ckpt
+  output_root: ???
+  seed: 20260720
+  beta: 0.2
+  learning_rate: 2.5e-6
+  gradient_clip_norm: 1.0
+  pairs_per_update: 435
+  source_shards: 10
+  world_size: 8
+  explicit_passes: 2
+  expected_updates: 20
+  checkpoint_steps: [1, 8, 10, 12, 14, 16, 18, 20]
+  optimizer:
+    name: torch.optim.AdamW
+    betas: [0.9, 0.95]
+    eps: 1.0e-8
+    weight_decay: 0.0
+    foreach: false
+    fused: false
+  lora: false
+  peft: false
+  adapters: false
+
+data:
+  cuts_path: /lustre/fs1/portfolios/nemotron/projects/nemotron_speechprod_asr/users/vmendelev/runs/N3NT-fixes/AMI_short/data/AMI_train_fb_v3_mixed4350_v1/dataset_r1/lhotse/finite_lhotse.jsonl
+  expected_rows: 4350
+  pairs_per_update: 435
+  source_shards: 10
+  world_size: 8
+  shuffle: false
+  cycle: false

--- a/examples/speechlm2/conf/salm_dpo_hero2_ami_historical_r5.yaml
+++ b/examples/speechlm2/conf/salm_dpo_hero2_ami_historical_r5.yaml
@@ -7,6 +7,9 @@ trainer:
   num_nodes: 1
   precision: bf16-true
   max_steps: 20
+  # The DPO model performs the historical norm-1.0 clip explicitly immediately
+  # before AdamW.step(); Lightning must not register a second clip.
+  gradient_clip_val: null
 
 model:
   base_experiment_config: /lustre/fsw/portfolios/llmservice/users/kdhawan/project/nemotron-transcribe/0712-hero2-plusgranaryv2-mlrope-nsv-sotmst-nrt-16node/exp_config.yaml

--- a/examples/speechlm2/salm_dpo_export.py
+++ b/examples/speechlm2/salm_dpo_export.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Export a durable SpeechLM2 DPO model checkpoint for standard vLLM evaluation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import traceback
+from pathlib import Path
+
+from nemo.collections.speechlm2.dpo.export import DEFAULT_SHARD_BYTES, export_dcp_to_hf
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--candidate-dcp", required=True, type=Path)
+    parser.add_argument("--serving-baseline", required=True, type=Path)
+    parser.add_argument("--trajectory", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--shard-bytes", default=DEFAULT_SHARD_BYTES, type=int)
+    parser.add_argument("--failure-report", type=Path)
+    args = parser.parse_args()
+    try:
+        report = export_dcp_to_hf(
+            candidate_dcp=args.candidate_dcp,
+            serving_baseline=args.serving_baseline,
+            trajectory=args.trajectory,
+            output=args.output,
+            shard_bytes=args.shard_bytes,
+        )
+    except BaseException as error:
+        if args.failure_report is not None:
+            args.failure_report.parent.mkdir(parents=True, exist_ok=True)
+            args.failure_report.write_text(
+                json.dumps(
+                    {
+                        "schema": "speechlm2.dpo.full-dcp-serving-export-failure.v1",
+                        "status": "failed",
+                        "candidate_dcp": str(args.candidate_dcp),
+                        "output": str(args.output),
+                        "error_type": type(error).__name__,
+                        "error": str(error),
+                        "traceback": traceback.format_exc(),
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        raise
+    print(json.dumps(report, indent=2, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/speechlm2/salm_dpo_train.py
+++ b/examples/speechlm2/salm_dpo_train.py
@@ -50,7 +50,11 @@ def _prepare_model_config(cfg):
         trainer.logger = False
         trainer.log_every_n_steps = 1
         trainer.use_distributed_sampler = False
-        trainer.gradient_clip_val = cfg.dpo.gradient_clip_norm
+        # Lightning disallows trainer-managed clipping for manual optimization.
+        # DPOSALMAutomodel applies the historical global-norm clip explicitly
+        # immediately before AdamW.step(), so preserve that mechanism while
+        # disabling the incompatible Trainer-level duplicate.
+        trainer.gradient_clip_val = 0.0
     return model, trainer
 
 

--- a/examples/speechlm2/salm_dpo_train.py
+++ b/examples/speechlm2/salm_dpo_train.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Train a finite direct-Lhotse SpeechLM2 DPO trajectory.
+
+Example:
+    torchrun --standalone --nproc-per-node=8 examples/speechlm2/salm_dpo_train.py \
+      dpo.output_root=/path/to/fresh/output
+
+All algorithmic settings are in the YAML.  This entrypoint performs no runtime
+source rewriting, package copying, import-hook installation, or compatibility
+overlay.  The NeMo-Speech source used to execute it must be the tracked source
+snapshot described by the run provenance.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import torch
+from lightning.pytorch import Trainer, seed_everything
+from omegaconf import OmegaConf, open_dict
+
+from nemo.collections.speechlm2.dpo import DPOSALMAutomodel, FiniteLhotsePreferenceDataModule
+from nemo.core.config import hydra_runner
+from nemo.utils.trainer_utils import resolve_trainer_cfg
+
+
+def _prepare_model_config(cfg):
+    base = OmegaConf.load(cfg.model.base_experiment_config)
+    OmegaConf.resolve(base)
+    model = OmegaConf.create(OmegaConf.to_container(base.model, resolve=True))
+    with open_dict(model):
+        model.init_from_checkpoint = None
+        # The strict DCP below is the single model-weight authority.  These
+        # settings construct the architecture without loading the stale 5600
+        # training checkpoint or ASR archive weights before that strict load.
+        model.pretrained_llm_weights = True
+        model.pretrained_asr_weights = False
+        model.init_configure_model = False
+        model.torch_dtype = "bfloat16"
+        model.dpo = OmegaConf.to_container(cfg.dpo, resolve=True)
+    trainer = OmegaConf.create(OmegaConf.to_container(base.trainer, resolve=True))
+    with open_dict(trainer):
+        trainer.devices = cfg.trainer.devices
+        trainer.num_nodes = cfg.trainer.num_nodes
+        trainer.precision = cfg.trainer.precision
+        trainer.max_steps = cfg.trainer.max_steps
+        trainer.enable_checkpointing = False
+        trainer.logger = False
+        trainer.log_every_n_steps = 1
+        trainer.use_distributed_sampler = False
+        trainer.gradient_clip_val = cfg.dpo.gradient_clip_norm
+    return model, trainer
+
+
+@hydra_runner(config_path="conf", config_name="salm_dpo_hero2_ami_historical_r5")
+def main(cfg) -> None:
+    OmegaConf.resolve(cfg)
+    if not torch.cuda.is_available():
+        raise RuntimeError("SpeechLM2 DPO requires CUDA")
+    torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+    if not torch.distributed.is_initialized():
+        torch.distributed.init_process_group(backend="nccl")
+    seed_everything(int(cfg.dpo.seed), workers=True)
+    root = Path(str(cfg.dpo.output_root))
+    if torch.distributed.get_rank() == 0:
+        if root.exists():
+            raise FileExistsError(f"DPO output root must be fresh: {root}")
+        root.mkdir(parents=True)
+        OmegaConf.save(cfg, root / "effective_config.yaml")
+    torch.distributed.barrier()
+    model_cfg, trainer_cfg = _prepare_model_config(cfg)
+    trainer = Trainer(**resolve_trainer_cfg(trainer_cfg))
+    with trainer.init_module():
+        model = DPOSALMAutomodel(OmegaConf.to_container(model_cfg, resolve=True))
+    datamodule = FiniteLhotsePreferenceDataModule(cfg.data)
+    trainer.fit(model, datamodule=datamodule)
+    torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/speechlm2/salm_dpo_train.py
+++ b/examples/speechlm2/salm_dpo_train.py
@@ -32,11 +32,14 @@ def _prepare_model_config(cfg):
     model = OmegaConf.create(OmegaConf.to_container(base.model, resolve=True))
     with open_dict(model):
         model.init_from_checkpoint = None
-        # The strict DCP below is the single model-weight authority.  These
-        # settings construct the architecture without loading the stale 5600
-        # training checkpoint or ASR archive weights before that strict load.
+        # The strict DCP below is the single final model-weight authority.
+        # Avoid the stale 5600 training checkpoint, but retain the configured
+        # ASR archive during construction: it supplies the perception
+        # preprocessor/encoder schema absent from the experiment YAML.  The
+        # strict Hero2 step-14400 DCP immediately overwrites those temporary
+        # construction weights before references or updates are permitted.
         model.pretrained_llm_weights = True
-        model.pretrained_asr_weights = False
+        model.pretrained_asr_weights = True
         model.init_configure_model = False
         model.torch_dtype = "bfloat16"
         model.dpo = OmegaConf.to_container(cfg.dpo, resolve=True)

--- a/examples/speechlm2/salm_dpo_train.py
+++ b/examples/speechlm2/salm_dpo_train.py
@@ -57,7 +57,7 @@ def _prepare_model_config(cfg):
         # DPOSALMAutomodel applies the historical global-norm clip explicitly
         # immediately before AdamW.step(), so preserve that mechanism while
         # disabling the incompatible Trainer-level duplicate.
-        trainer.gradient_clip_val = 0.0
+        trainer.gradient_clip_val = cfg.trainer.gradient_clip_val
     return model, trainer
 
 

--- a/examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh
+++ b/examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh
@@ -57,6 +57,9 @@ stage_verified_r22_package() {
     chmod -R u+w "$stage_root/source"
     staged_fingerprint="$(fingerprint_r22_server_source "$stage_root/source")"
     test "$staged_fingerprint" = "$expected"
+    R22_SOURCE_FINGERPRINT="$source_fingerprint"
+    R22_STAGED_FINGERPRINT="$staged_fingerprint"
+    export R22_SOURCE_FINGERPRINT R22_STAGED_FINGERPRINT
     printf 'R22_NEMO_PACKAGE_ARTIFACT source_fingerprint=%s stage_fingerprint=%s source=%s staged=%s\n' \
         "$source_fingerprint" "$staged_fingerprint" "$source" "$stage_root/source"
 }
@@ -80,10 +83,33 @@ import pathlib
 import nemo
 location = pathlib.Path(nemo.__file__).resolve()
 target = pathlib.Path(__import__('sys').prefix).resolve()
-if target not in location.parents:
+    if target not in location.parents:
     raise SystemExit(f"r22 package did not import from staged install target: {location}")
 print(f"R22_NEMO_PACKAGE_INSTALL_REGRESSION passed import={location}")
 PY
+    if test -n "${R22_PACKAGE_INSTALL_RECEIPT:-}"; then
+        python3 - "$R22_PACKAGE_INSTALL_RECEIPT" "$R22_SOURCE_FINGERPRINT" "$R22_STAGED_FINGERPRINT" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(
+    json.dumps(
+        {
+            "passed": True,
+            "source_fingerprint": sys.argv[2],
+            "staged_fingerprint": sys.argv[3],
+            "mode": "isolated_venv_noneditable_install",
+        },
+        sort_keys=True,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+PY
+    fi
     exit 0
 fi
 

--- a/examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh
+++ b/examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh
@@ -1,19 +1,93 @@
 #!/usr/bin/env bash
 # Serve a tracked Hero2 DPO export with the established r22 vLLM NeMo source.
-# The source is installed directly and non-editably: this script never copies,
-# rewrites, overlays, or patches either source tree or the model directory.
+#
+# ``R22_NEMO_SOURCE`` is intentionally a read-only provenance input.  Setuptools
+# writes egg-info while building an ordinary wheel, so it cannot be installed
+# in-place.  We first make an *explicit, verified, job-local package artifact*,
+# then non-editably install that artifact.  The immutable source is never
+# modified, no files are overlaid into an installed package, and this script
+# never changes the model directory.
 set -euo pipefail
 
 : "${R22_NEMO_SOURCE:?R22_NEMO_SOURCE must point to the readable r22 NeMo source}"
 : "${R22_TRANSFORMER_ENCODER_SHA256:?R22_TRANSFORMER_ENCODER_SHA256 must pin r22 TransformerEncoder}"
+: "${R22_NEMO_SERVER_FINGERPRINT_SHA256:?R22_NEMO_SERVER_FINGERPRINT_SHA256 must pin the r22 serving source}"
 
-transformer="$R22_NEMO_SOURCE/nemo/collections/asr/modules/transformer_encoder.py"
-test -r "$transformer"
-test "$(sha256sum "$transformer" | awk '{print $1}')" = "$R22_TRANSFORMER_ENCODER_SHA256"
-test -r "$R22_NEMO_SOURCE/setup.py"
-test -r "$R22_NEMO_SOURCE/pyproject.toml"
+fingerprint_r22_server_source() {
+    local root="$1"
+    local rel actual
+    while IFS= read -r rel; do
+        test -r "$root/$rel"
+        actual="$(sha256sum "$root/$rel" | awk '{print $1}')"
+        printf '%s  %s\n' "$actual" "$rel"
+    done <<'EOF' | sha256sum | awk '{print $1}'
+setup.py
+pyproject.toml
+nemo/collections/asr/modules/transformer_encoder.py
+nemo/collections/speechlm2/models/salm.py
+nemo/collections/speechlm2/vllm/salm/__init__.py
+EOF
+}
 
-python3 -m pip install --no-deps "$R22_NEMO_SOURCE"
+stage_verified_r22_package() {
+    local source="$R22_NEMO_SOURCE"
+    local expected="$R22_NEMO_SERVER_FINGERPRINT_SHA256"
+    local source_fingerprint stage_root staged_fingerprint
+    source_fingerprint="$(fingerprint_r22_server_source "$source")"
+    test "$source_fingerprint" = "$expected"
+    test "$(sha256sum "$source/nemo/collections/asr/modules/transformer_encoder.py" | awk '{print $1}')" = "$R22_TRANSFORMER_ENCODER_SHA256"
+
+    stage_root="$(mktemp -d "${TMPDIR:-/tmp}/r22-nemo-package.XXXXXX")"
+    R22_STAGE_ROOT="$stage_root"
+    export R22_STAGE_ROOT
+    # This is an isolated package-input artifact, not an in-place workaround.
+    # These are every source input used by setuptools for the normal r22 wheel;
+    # deliberately omit r22's unrelated build/tests/examples trees so each
+    # serving rank does not stage stale build products.
+    mkdir -p "$stage_root/source"
+    cp -a "$source/setup.py" "$source/pyproject.toml" "$source/README.md" "$source/MANIFEST.in" "$stage_root/source/"
+    mkdir -p "$stage_root/source/nemo"
+    # SSHFS metadata latency dominates a serial recursive copy.  These are
+    # disjoint top-level package entries, so bounded parallel staging changes
+    # no bytes or package semantics.
+    find "$source/nemo" -mindepth 1 -maxdepth 1 ! -name collections -print0 | xargs -0 -r -n 1 -P 8 cp -a -t "$stage_root/source/nemo"
+    mkdir -p "$stage_root/source/nemo/collections"
+    find "$source/nemo/collections" -mindepth 1 -maxdepth 1 -print0 | xargs -0 -r -n 1 -P 8 cp -a -t "$stage_root/source/nemo/collections"
+    cp -a "$source/requirements" "$stage_root/source/"
+    chmod -R u+w "$stage_root/source"
+    staged_fingerprint="$(fingerprint_r22_server_source "$stage_root/source")"
+    test "$staged_fingerprint" = "$expected"
+    printf 'R22_NEMO_PACKAGE_ARTIFACT source_fingerprint=%s stage_fingerprint=%s source=%s staged=%s\n' \
+        "$source_fingerprint" "$staged_fingerprint" "$source" "$stage_root/source"
+}
+
+cleanup_stage() {
+    if test -n "${R22_STAGE_ROOT:-}"; then
+        rm -rf "$R22_STAGE_ROOT"
+    fi
+}
+trap cleanup_stage EXIT
+
+stage_verified_r22_package
+
+if test "${1:-}" = "--verify-r22-package-install"; then
+    target="$(mktemp -d "${TMPDIR:-/tmp}/r22-nemo-install-test.XXXXXX")"
+    trap 'rm -rf "${target:-}"; cleanup_stage' EXIT
+    python3 -m venv "$target/venv"
+    "$target/venv/bin/python" -m pip install --no-deps --force-reinstall "$R22_STAGE_ROOT/source"
+    "$target/venv/bin/python" - <<'PY'
+import pathlib
+import nemo
+location = pathlib.Path(nemo.__file__).resolve()
+target = pathlib.Path(__import__('sys').prefix).resolve()
+if target not in location.parents:
+    raise SystemExit(f"r22 package did not import from staged install target: {location}")
+print(f"R22_NEMO_PACKAGE_INSTALL_REGRESSION passed import={location}")
+PY
+    exit 0
+fi
+
+python3 -m pip install --no-deps --force-reinstall "$R22_STAGE_ROOT/source"
 export VLLM_PLUGINS=nemo_speechlm
 export VLLM_NO_USAGE_STATS=1
 export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-/tmp/triton_jit_cache}"

--- a/examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh
+++ b/examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh
@@ -73,22 +73,9 @@ trap cleanup_stage EXIT
 
 stage_verified_r22_package
 
-if test "${1:-}" = "--verify-r22-package-install"; then
-    target="$(mktemp -d "${TMPDIR:-/tmp}/r22-nemo-install-test.XXXXXX")"
-    trap 'rm -rf "${target:-}"; cleanup_stage' EXIT
-    python3 -m venv "$target/venv"
-    "$target/venv/bin/python" -m pip install --no-deps --force-reinstall "$R22_STAGE_ROOT/source"
-    "$target/venv/bin/python" - <<'PY'
-import pathlib
-import nemo
-location = pathlib.Path(nemo.__file__).resolve()
-target = pathlib.Path(__import__('sys').prefix).resolve()
-    if target not in location.parents:
-    raise SystemExit(f"r22 package did not import from staged install target: {location}")
-print(f"R22_NEMO_PACKAGE_INSTALL_REGRESSION passed import={location}")
-PY
-    if test -n "${R22_PACKAGE_INSTALL_RECEIPT:-}"; then
-        python3 - "$R22_PACKAGE_INSTALL_RECEIPT" "$R22_SOURCE_FINGERPRINT" "$R22_STAGED_FINGERPRINT" <<'PY'
+write_install_receipt() {
+    test -n "${R22_PACKAGE_INSTALL_RECEIPT:-}" || return 0
+    python3 - "$R22_PACKAGE_INSTALL_RECEIPT" "$1" "$2" "$3" "$R22_SOURCE_FINGERPRINT" "$R22_STAGED_FINGERPRINT" <<'PY'
 import json
 import pathlib
 import sys
@@ -98,9 +85,11 @@ path.parent.mkdir(parents=True, exist_ok=True)
 path.write_text(
     json.dumps(
         {
-            "passed": True,
-            "source_fingerprint": sys.argv[2],
-            "staged_fingerprint": sys.argv[3],
+            "passed": sys.argv[2] == "true",
+            "phase": sys.argv[3],
+            "detail": sys.argv[4],
+            "source_fingerprint": sys.argv[5],
+            "staged_fingerprint": sys.argv[6],
             "mode": "isolated_venv_noneditable_install",
         },
         sort_keys=True,
@@ -109,7 +98,33 @@ path.write_text(
     encoding="utf-8",
 )
 PY
+}
+
+if test "${1:-}" = "--verify-r22-package-install"; then
+    target="$(mktemp -d "${TMPDIR:-/tmp}/r22-nemo-install-test.XXXXXX")"
+    trap 'rm -rf "${target:-}"; cleanup_stage' EXIT
+    python3 -m venv "$target/venv"
+    pip_log="$target/pip-install.log"
+    set +e
+    "$target/venv/bin/python" -m pip install --no-deps --force-reinstall "$R22_STAGE_ROOT/source" >"$pip_log" 2>&1
+    install_status=$?
+    set -e
+    if test "$install_status" -ne 0; then
+        write_install_receipt false pip_install "$(tail -80 "$pip_log")"
+        exit "$install_status"
     fi
+    import_log="$target/import.log"
+    set +e
+    "$target/venv/bin/python" -c 'import pathlib, sys, nemo; location = pathlib.Path(nemo.__file__).resolve(); target = pathlib.Path(sys.prefix).resolve(); assert target in location.parents, f"r22 package did not import from staged install target: {location}"; print(location)' >"$import_log" 2>&1
+    import_status=$?
+    set -e
+    if test "$import_status" -ne 0; then
+        write_install_receipt false import "$(tail -80 "$import_log")"
+        exit "$import_status"
+    fi
+    location="$(cat "$import_log")"
+    write_install_receipt true import "$location"
+    printf 'R22_NEMO_PACKAGE_INSTALL_REGRESSION passed import=%s\n' "$location"
     exit 0
 fi
 

--- a/examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh
+++ b/examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Serve a tracked Hero2 DPO export with the established r22 vLLM NeMo source.
+# The source is installed directly and non-editably: this script never copies,
+# rewrites, overlays, or patches either source tree or the model directory.
+set -euo pipefail
+
+: "${R22_NEMO_SOURCE:?R22_NEMO_SOURCE must point to the readable r22 NeMo source}"
+: "${R22_TRANSFORMER_ENCODER_SHA256:?R22_TRANSFORMER_ENCODER_SHA256 must pin r22 TransformerEncoder}"
+
+transformer="$R22_NEMO_SOURCE/nemo/collections/asr/modules/transformer_encoder.py"
+test -r "$transformer"
+test "$(sha256sum "$transformer" | awk '{print $1}')" = "$R22_TRANSFORMER_ENCODER_SHA256"
+test -r "$R22_NEMO_SOURCE/setup.py"
+test -r "$R22_NEMO_SOURCE/pyproject.toml"
+
+python3 -m pip install --no-deps "$R22_NEMO_SOURCE"
+export VLLM_PLUGINS=nemo_speechlm
+export VLLM_NO_USAGE_STATS=1
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-/tmp/triton_jit_cache}"
+exec python3 -m nemo_skills.inference.server.serve_vllm "$@"

--- a/nemo/collections/speechlm2/dpo/__init__.py
+++ b/nemo/collections/speechlm2/dpo/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Native Direct Preference Optimization support for SpeechLM2.
+
+The implementation intentionally lives next to :class:`SALMAutomodel`: data
+loading, pair formatting, reference capture, objective computation, and the
+Lightning update lifecycle are normal package code rather than launch-time
+overlays or experiment-local adapters.
+"""
+
+from nemo.collections.speechlm2.dpo.data import FiniteLhotsePreferenceDataModule
+from nemo.collections.speechlm2.dpo.model import DPOSALMAutomodel
+
+__all__ = ["DPOSALMAutomodel", "FiniteLhotsePreferenceDataModule"]

--- a/nemo/collections/speechlm2/dpo/data.py
+++ b/nemo/collections/speechlm2/dpo/data.py
@@ -1,0 +1,198 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Finite direct-Lhotse preference data contract for SpeechLM2 DPO."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from lightning import LightningDataModule
+from torch.utils.data import DataLoader, IterableDataset
+
+
+@dataclass(frozen=True)
+class PreferencePair:
+    pair_id: str
+    source_id: str
+    prompt: str
+    chosen: str
+    rejected: str
+    audio: torch.Tensor
+    active: bool
+
+
+@dataclass(frozen=True)
+class PreferenceBatch:
+    global_step: int
+    dpo_pass: int
+    source_shard: int
+    pairs: tuple[PreferencePair, ...]
+
+
+def _stable_hash(value: Any) -> str:
+    return hashlib.sha256(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _preference(cut: Any) -> dict[str, Any]:
+    supervisions = list(getattr(cut, "supervisions", ()) or ())
+    if len(supervisions) != 1:
+        raise ValueError(f"{getattr(cut, 'id', '<unknown>')}: expected exactly one supervision")
+    value = dict(getattr(supervisions[0], "custom", {}) or {}).get("dpo_preference")
+    if not isinstance(value, dict):
+        raise ValueError(f"{cut.id}: missing supervision.custom.dpo_preference")
+    return value
+
+
+def _validate(cut: Any, value: dict[str, Any]) -> None:
+    required = ("record_id", "source_id", "prompt", "chosen", "rejected", "audio_sha256")
+    missing = [key for key in required if not str(value.get(key, "")).strip()]
+    if missing:
+        raise ValueError(f"{cut.id}: missing DPO fields {missing}")
+    checks = {
+        "cut_id": str(cut.id) == str(value["record_id"]),
+        "ordered": str(value["chosen"]).strip() != str(value["rejected"]).strip(),
+        "same_audio_control": value.get("same_audio_rejected_control") is True,
+        "hard_valid": value.get("hard_invalid") is False,
+    }
+    if not all(checks.values()):
+        raise ValueError(f"{cut.id}: invalid DPO pair contract {checks}")
+    recording = getattr(cut, "recording", None)
+    sources = list(getattr(recording, "sources", ()) or ())
+    audio_id = str(value["audio_sha256"])
+    if (
+        recording is None
+        or str(getattr(recording, "id", "")) != audio_id
+        or len(sources) != 1
+        or Path(str(getattr(sources[0], "source", ""))).stem != audio_id
+    ):
+        raise ValueError(f"{cut.id}: Lhotse recording does not bind the declared audio identity")
+
+
+class FiniteLhotsePreferenceCorpus:
+    """Read each direct Lhotse preference cut exactly once on its owning rank."""
+
+    def __init__(self, cfg: Any) -> None:
+        self.path = Path(str(cfg.cuts_path))
+        self.expected_rows = int(cfg.expected_rows)
+        self.pairs_per_update = int(cfg.pairs_per_update)
+        self.source_shards = int(cfg.source_shards)
+        self.world_size = int(cfg.world_size)
+        self.shuffle = bool(cfg.shuffle)
+        self.cycle = bool(cfg.cycle)
+        if self.shuffle or self.cycle:
+            raise ValueError("DPO finite Lhotse contract requires shuffle=false and cycle=false")
+        if self.expected_rows != self.pairs_per_update * self.source_shards:
+            raise ValueError("expected_rows must equal pairs_per_update * source_shards")
+        if not self.path.is_file():
+            raise FileNotFoundError(self.path)
+
+    def load_rank_shards(self, rank: int) -> tuple[list[list[PreferencePair]], dict[str, Any]]:
+        from lhotse import CutSet
+
+        cuts = CutSet.from_file(self.path)
+        local: list[list[PreferencePair]] = [[] for _ in range(self.source_shards)]
+        ids: list[str] = []
+        reads = 0
+        for position, cut in enumerate(cuts):
+            if position >= self.expected_rows:
+                raise ValueError(f"finite Lhotse source has more than {self.expected_rows} rows")
+            value = _preference(cut)
+            _validate(cut, value)
+            pair_id = str(value["record_id"])
+            ids.append(pair_id)
+            reads += 1
+            if position % self.world_size != rank:
+                continue
+            waveform = np.asarray(cut.load_audio(), dtype=np.float32)
+            if waveform.ndim == 2:
+                waveform = waveform[0] if waveform.shape[0] == 1 else waveform.mean(axis=0)
+            waveform = np.ascontiguousarray(waveform.reshape(-1), dtype=np.float32)
+            if not waveform.size or not np.isfinite(waveform).all():
+                raise ValueError(f"{pair_id}: invalid decoded waveform")
+            # Both completions below receive this one decoded tensor.  The
+            # manifest's audio digest identifies the staged recording (checked
+            # in ``_validate``).  It is deliberately not recomputed after WAV
+            # decoding: the historical staging digest predates PCM rounding.
+            local[position // self.pairs_per_update].append(
+                PreferencePair(
+                    pair_id=pair_id,
+                    source_id=str(value["source_id"]),
+                    prompt=str(value["prompt"]),
+                    chosen=str(value["chosen"]),
+                    rejected=str(value["rejected"]),
+                    audio=torch.from_numpy(waveform),
+                    active=True,
+                )
+            )
+        if reads != self.expected_rows or len(set(ids)) != self.expected_rows:
+            raise ValueError(f"finite Lhotse corpus mismatch: reads={reads} unique_ids={len(set(ids))}")
+        expected_rank_counts = [len(range(rank, self.pairs_per_update, self.world_size)) for rank in range(self.world_size)]
+        wanted = expected_rank_counts[rank]
+        if any(len(shard) != wanted for shard in local):
+            raise ValueError(f"rank {rank} did not receive the expected direct-Lhotse slots")
+        padded: list[list[PreferencePair]] = []
+        for shard in local:
+            entries = list(shard)
+            while len(entries) < (self.pairs_per_update + self.world_size - 1) // self.world_size:
+                last = entries[-1]
+                entries.append(PreferencePair(**{**last.__dict__, "active": False}))
+            padded.append(entries)
+        return padded, {
+            "cuts_path": str(self.path), "direct": True, "shuffle": False, "cycle": False, "pair_reads": reads,
+            "exhausted_exactly": True, "active_pair_ids_sha256": _stable_hash(ids), "source_shards": self.source_shards,
+            "pairs_per_update": self.pairs_per_update, "rank": rank, "rank_local_slots": len(padded[0]),
+        }
+
+
+class _Schedule(IterableDataset):
+    def __init__(self, shards: list[list[PreferencePair]]) -> None:
+        super().__init__()
+        self.shards = shards
+
+    def __iter__(self) -> Iterator[PreferenceBatch]:
+        for dpo_pass in (1, 2):
+            for source_shard, pairs in enumerate(self.shards, 1):
+                yield PreferenceBatch(
+                    global_step=(dpo_pass - 1) * len(self.shards) + source_shard,
+                    dpo_pass=dpo_pass,
+                    source_shard=source_shard,
+                    pairs=tuple(pairs),
+                )
+
+
+class FiniteLhotsePreferenceDataModule(LightningDataModule):
+    """A finite, ordered, noncycling two-pass DPO schedule over direct Lhotse."""
+
+    def __init__(self, cfg: Any) -> None:
+        super().__init__()
+        self.cfg = cfg
+        self.corpus = FiniteLhotsePreferenceCorpus(cfg)
+        self.shards: list[list[PreferencePair]] | None = None
+        self.receipt: dict[str, Any] | None = None
+
+    def setup(self, stage: str | None = None) -> None:
+        del stage
+        if self.shards is not None:
+            return
+        world_size = dist.get_world_size() if dist.is_available() and dist.is_initialized() else 1
+        rank = dist.get_rank() if dist.is_available() and dist.is_initialized() else 0
+        if world_size != self.corpus.world_size:
+            raise RuntimeError(f"DPO config world_size={self.corpus.world_size}, runtime={world_size}")
+        self.shards, self.receipt = self.corpus.load_rank_shards(rank)
+
+    def train_dataloader(self) -> DataLoader:
+        if self.shards is None:
+            raise RuntimeError("call setup before train_dataloader")
+        return DataLoader(_Schedule(self.shards), batch_size=None, num_workers=0)
+
+    def local_shards(self) -> list[list[PreferencePair]]:
+        if self.shards is None:
+            raise RuntimeError("data module has not been set up")
+        return self.shards

--- a/nemo/collections/speechlm2/dpo/data.py
+++ b/nemo/collections/speechlm2/dpo/data.py
@@ -17,7 +17,11 @@ from lightning import LightningDataModule
 from torch.utils.data import DataLoader, IterableDataset
 
 
-@dataclass(frozen=True)
+# Lightning's stock BF16 precision plugin reconstructs every dataclass in a
+# batch while converting tensor fields.  These are transport objects, not
+# semantic immutability guards; keeping them mutable preserves every field and
+# ordering while allowing that normal framework path.
+@dataclass
 class PreferencePair:
     pair_id: str
     source_id: str
@@ -28,7 +32,7 @@ class PreferencePair:
     active: bool
 
 
-@dataclass(frozen=True)
+@dataclass
 class PreferenceBatch:
     global_step: int
     dpo_pass: int

--- a/nemo/collections/speechlm2/dpo/data.py
+++ b/nemo/collections/speechlm2/dpo/data.py
@@ -8,7 +8,7 @@ import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, Mapping
 
 import numpy as np
 import torch
@@ -21,7 +21,7 @@ from torch.utils.data import DataLoader, IterableDataset
 class PreferencePair:
     pair_id: str
     source_id: str
-    prompt: str
+    prompt: str | dict[str, str]
     chosen: str
     rejected: str
     audio: torch.Tensor
@@ -51,8 +51,17 @@ def _preference(cut: Any) -> dict[str, Any]:
 
 
 def _validate(cut: Any, value: dict[str, Any]) -> None:
-    required = ("record_id", "source_id", "prompt", "chosen", "rejected", "audio_sha256")
+    required = ("record_id", "source_id", "chosen", "rejected", "audio_sha256")
     missing = [key for key in required if not str(value.get(key, "")).strip()]
+    prompt = value.get("prompt")
+    if isinstance(prompt, str):
+        prompt_ok = bool(prompt.strip())
+    elif isinstance(prompt, Mapping):
+        prompt_ok = isinstance(prompt.get("system", ""), str) and isinstance(prompt.get("user"), str) and bool(prompt["user"].strip())
+    else:
+        prompt_ok = False
+    if not prompt_ok:
+        missing.append("prompt")
     if missing:
         raise ValueError(f"{cut.id}: missing DPO fields {missing}")
     checks = {
@@ -124,7 +133,7 @@ class FiniteLhotsePreferenceCorpus:
                 PreferencePair(
                     pair_id=pair_id,
                     source_id=str(value["source_id"]),
-                    prompt=str(value["prompt"]),
+                    prompt=value["prompt"] if isinstance(value["prompt"], str) else dict(value["prompt"]),
                     chosen=str(value["chosen"]),
                     rejected=str(value["rejected"]),
                     audio=torch.from_numpy(waveform),

--- a/nemo/collections/speechlm2/dpo/data.py
+++ b/nemo/collections/speechlm2/dpo/data.py
@@ -36,6 +36,19 @@ class PreferenceBatch:
     pairs: tuple[PreferencePair, ...]
 
 
+def rank_active_slots(*, pairs_per_update: int, world_size: int) -> tuple[int, ...]:
+    """Return the fixed within-update active-slot count for every rank.
+
+    Each source shard has its own zero-based 435-pair schedule.  Thus rank
+    ownership restarts at every shard, exactly as the historical 435→440 slot
+    schedule does; ownership must not rotate with the global manifest offset.
+    """
+
+    if pairs_per_update <= 0 or world_size <= 0:
+        raise ValueError("pairs_per_update and world_size must be positive")
+    return tuple(len(range(rank, pairs_per_update, world_size)) for rank in range(world_size))
+
+
 def _stable_hash(value: Any) -> str:
     return hashlib.sha256(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
@@ -117,7 +130,14 @@ class FiniteLhotsePreferenceCorpus:
             pair_id = str(value["record_id"])
             ids.append(pair_id)
             reads += 1
-            if position % self.world_size != rank:
+            shard_index = position // self.pairs_per_update
+            within_shard_index = position % self.pairs_per_update
+            # Restart rank ownership for each ordered source shard.  The
+            # 435-pair historical schedule maps local positions 0..434 to
+            # ranks 0..7, then pads to 440 slots (55/rank) with five inactive
+            # positions.  Global modulo would rotate the five padding slots
+            # between source shards and no longer match that schedule.
+            if within_shard_index % self.world_size != rank:
                 continue
             waveform = np.asarray(cut.load_audio(), dtype=np.float32)
             if waveform.ndim == 2:
@@ -129,7 +149,7 @@ class FiniteLhotsePreferenceCorpus:
             # manifest's audio digest identifies the staged recording (checked
             # in ``_validate``).  It is deliberately not recomputed after WAV
             # decoding: the historical staging digest predates PCM rounding.
-            local[position // self.pairs_per_update].append(
+            local[shard_index].append(
                 PreferencePair(
                     pair_id=pair_id,
                     source_id=str(value["source_id"]),
@@ -142,7 +162,9 @@ class FiniteLhotsePreferenceCorpus:
             )
         if reads != self.expected_rows or len(set(ids)) != self.expected_rows:
             raise ValueError(f"finite Lhotse corpus mismatch: reads={reads} unique_ids={len(set(ids))}")
-        expected_rank_counts = [len(range(rank, self.pairs_per_update, self.world_size)) for rank in range(self.world_size)]
+        expected_rank_counts = rank_active_slots(
+            pairs_per_update=self.pairs_per_update, world_size=self.world_size
+        )
         wanted = expected_rank_counts[rank]
         if any(len(shard) != wanted for shard in local):
             raise ValueError(f"rank {rank} did not receive the expected direct-Lhotse slots")

--- a/nemo/collections/speechlm2/dpo/export.py
+++ b/nemo/collections/speechlm2/dpo/export.py
@@ -1,0 +1,329 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Export a complete DPO model DCP as an indexed HuggingFace safetensors model.
+
+This is the serving bridge for the finite SpeechLM2 DPO recipe.  It is a
+normal, offline conversion in the owning package: every served tensor is read
+from the candidate model DCP, and the immutable Hero2 serving directory is
+used only for non-weight HuggingFace assets and a namespace/type contract.
+"""
+
+from __future__ import annotations
+
+import gc
+import hashlib
+import json
+import os
+import shutil
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+from torch.distributed.checkpoint import FileSystemReader, load
+
+from nemo.collections.speechlm2.dpo.surface import selected_parameter_names
+
+
+DEFAULT_SHARD_BYTES = 4 * 1024**3
+ASSET_FILES = ("generation_config.json", "tokenizer.json", "tokenizer_config.json")
+SAFE_TO_TORCH = {
+    "BOOL": torch.bool,
+    "U8": torch.uint8,
+    "I8": torch.int8,
+    "I16": torch.int16,
+    "I32": torch.int32,
+    "I64": torch.int64,
+    "F16": torch.float16,
+    "BF16": torch.bfloat16,
+    "F32": torch.float32,
+    "F64": torch.float64,
+}
+
+
+@dataclass(frozen=True)
+class TensorSpec:
+    shape: tuple[int, ...]
+    dtype: torch.dtype
+    payload_bytes: int
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _tensor_bytes(shape: tuple[int, ...], dtype: torch.dtype) -> int:
+    count = 1
+    for dimension in shape:
+        count *= dimension
+    return count * torch.empty((), dtype=dtype).element_size()
+
+
+def dcp_state_specs(checkpoint: Path) -> tuple[dict[str, TensorSpec], list[str]]:
+    """Read only DCP metadata; model values remain on Lustre until export."""
+
+    metadata_path = checkpoint / ".metadata"
+    if not metadata_path.is_file():
+        raise FileNotFoundError(metadata_path)
+    metadata = FileSystemReader(str(checkpoint)).read_metadata().state_dict_metadata
+    specs: dict[str, TensorSpec] = {}
+    extra_state: list[str] = []
+    for full_name, item in metadata.items():
+        if not full_name.startswith("state_dict."):
+            raise RuntimeError(f"unexpected non-model DCP key: {full_name}")
+        name = full_name.removeprefix("state_dict.")
+        if name.endswith("._extra_state"):
+            extra_state.append(name)
+            continue
+        if not hasattr(item, "size") or not hasattr(item, "properties"):
+            raise RuntimeError(f"non-tensor model DCP key: {full_name}")
+        shape = tuple(int(value) for value in item.size)
+        dtype = item.properties.dtype
+        specs[name] = TensorSpec(shape, dtype, _tensor_bytes(shape, dtype))
+    if not specs:
+        raise RuntimeError("DCP contains no model tensors")
+    return dict(sorted(specs.items())), sorted(extra_state)
+
+
+def read_surface_contract(trajectory: Path) -> tuple[str, ...]:
+    """Require the exact selected FP32 surface recorded by the training run."""
+
+    if not trajectory.is_file():
+        raise FileNotFoundError(trajectory)
+    payload = json.loads(trajectory.read_text(encoding="utf-8"))
+    surface = payload.get("surface")
+    names = surface.get("names") if isinstance(surface, dict) else None
+    expected = selected_parameter_names()
+    if (
+        not isinstance(names, list)
+        or tuple(names) != expected
+        or surface.get("tensor_count") != len(expected)
+        or surface.get("scalar_count") is None
+        or surface.get("dtypes") != ["torch.float32"]
+        or payload.get("lora") is not False
+    ):
+        raise RuntimeError("trajectory does not declare the exact Hero2 DPO FP32 surface")
+    return expected
+
+
+def _baseline_specs(baseline: Path) -> tuple[dict[str, TensorSpec], dict[str, Path]]:
+    """Read a standard single-file or indexed safetensors serving baseline."""
+
+    single = baseline / "model.safetensors"
+    index = baseline / "model.safetensors.index.json"
+    locations: dict[str, Path] = {}
+    if single.is_file():
+        with safe_open(single, framework="pt", device="cpu") as model:
+            locations = {name: single for name in model.keys()}
+    elif index.is_file():
+        payload = json.loads(index.read_text(encoding="utf-8"))
+        weights = payload.get("weight_map")
+        if not isinstance(weights, dict) or not weights:
+            raise RuntimeError(f"invalid safetensors index: {index}")
+        for name, filename in weights.items():
+            candidate = baseline / str(filename)
+            if candidate.parent != baseline or not candidate.is_file():
+                raise FileNotFoundError(candidate)
+            locations[str(name)] = candidate
+    else:
+        raise FileNotFoundError(single)
+
+    specs: dict[str, TensorSpec] = {}
+    by_file: dict[Path, list[str]] = {}
+    for name, path in locations.items():
+        by_file.setdefault(path, []).append(name)
+    for path, names in by_file.items():
+        with safe_open(path, framework="pt", device="cpu") as model:
+            for name in names:
+                tensor = model.get_slice(name)
+                dtype = SAFE_TO_TORCH.get(tensor.get_dtype())
+                if dtype is None:
+                    raise RuntimeError(f"unsupported safetensors dtype for {name}")
+                shape = tuple(int(value) for value in tensor.get_shape())
+                specs[name] = TensorSpec(shape, dtype, _tensor_bytes(shape, dtype))
+    return dict(sorted(specs.items())), locations
+
+
+def check_serving_contract(
+    *,
+    candidate: dict[str, TensorSpec],
+    baseline: dict[str, TensorSpec],
+    selected_fp32: tuple[str, ...],
+) -> dict[str, Any]:
+    """Reject namespace, shape, and precision drift before serving conversion."""
+
+    candidate_names = set(candidate)
+    baseline_names = set(baseline)
+    if candidate_names != baseline_names:
+        raise RuntimeError(
+            "candidate/baseline tensor namespace differs: "
+            f"missing={sorted(baseline_names - candidate_names)[:8]} "
+            f"unexpected={sorted(candidate_names - baseline_names)[:8]}"
+        )
+    selected = set(selected_fp32)
+    if not selected <= candidate_names:
+        raise RuntimeError("selected training surface is absent from model DCP")
+    promoted: set[str] = set()
+    for name in sorted(candidate_names):
+        source = candidate[name]
+        template = baseline[name]
+        if source.shape != template.shape:
+            raise RuntimeError(f"candidate/baseline shape differs: {name}")
+        if source.dtype == template.dtype:
+            continue
+        if name in selected and template.dtype is torch.bfloat16 and source.dtype is torch.float32:
+            promoted.add(name)
+            continue
+        raise RuntimeError(
+            f"candidate/baseline dtype differs outside declared BF16->FP32 surface: {name} "
+            f"({template.dtype} -> {source.dtype})"
+        )
+    if promoted != selected:
+        raise RuntimeError(
+            "candidate FP32 surface differs from trajectory: "
+            f"missing={sorted(selected - promoted)[:8]} unexpected={sorted(promoted - selected)[:8]}"
+        )
+    return {
+        "serving_tensor_count": len(candidate),
+        "extra_state_excluded": None,
+        "fp32_surface_tensor_count": len(promoted),
+        "fp32_surface_names_sha256": hashlib.sha256("\n".join(sorted(promoted)).encode()).hexdigest(),
+    }
+
+
+def shard_plan(specs: dict[str, TensorSpec], shard_bytes: int) -> list[list[str]]:
+    if shard_bytes <= 0:
+        raise ValueError("shard_bytes must be positive")
+    plan: list[list[str]] = []
+    active: list[str] = []
+    active_bytes = 0
+    for name, spec in specs.items():
+        if spec.payload_bytes > shard_bytes:
+            raise RuntimeError(f"tensor exceeds shard capacity: {name}")
+        if active and active_bytes + spec.payload_bytes > shard_bytes:
+            plan.append(active)
+            active, active_bytes = [], 0
+        active.append(name)
+        active_bytes += spec.payload_bytes
+    if active:
+        plan.append(active)
+    return plan
+
+
+def _copy_assets(baseline: Path, output: Path) -> dict[str, str]:
+    config_source = baseline / "config.json"
+    if not config_source.is_file():
+        raise FileNotFoundError(config_source)
+    config = json.loads(config_source.read_text(encoding="utf-8"))
+    config.pop("init_from_checkpoint", None)
+    config_output = output / "config.json"
+    config_output.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    assets = {"config.json": sha256_file(config_output)}
+    for filename in ASSET_FILES:
+        source = baseline / filename
+        if not source.is_file():
+            raise FileNotFoundError(source)
+        destination = output / filename
+        shutil.copyfile(source, destination)
+        assets[filename] = sha256_file(destination)
+    return assets
+
+
+def _write_shards(
+    *, checkpoint: Path, output: Path, specs: dict[str, TensorSpec], plan: list[list[str]]
+) -> tuple[dict[str, str], list[dict[str, Any]]]:
+    weight_map: dict[str, str] = {}
+    records: list[dict[str, Any]] = []
+    for index, names in enumerate(plan, start=1):
+        filename = f"model-{index:05d}-of-{len(plan):05d}.safetensors"
+        temporary = output / f".{filename}.tmp"
+        destination = output / filename
+        tensors = {
+            name: torch.empty(specs[name].shape, dtype=specs[name].dtype, device="cpu")
+            for name in names
+        }
+        load({"state_dict": tensors}, checkpoint_id=str(checkpoint), no_dist=True)
+        save_file(dict(sorted(tensors.items())), temporary)
+        os.replace(temporary, destination)
+        payload_bytes = sum(specs[name].payload_bytes for name in names)
+        with destination.open("rb") as handle:
+            header_bytes = struct.unpack("<Q", handle.read(8))[0]
+        if destination.stat().st_size != 8 + header_bytes + payload_bytes:
+            raise RuntimeError(f"invalid safetensors payload size: {filename}")
+        with safe_open(destination, framework="pt", device="cpu") as served:
+            if set(served.keys()) != set(names):
+                raise RuntimeError(f"served shard key mismatch: {filename}")
+            for name in names:
+                value = served.get_tensor(name)
+                if value.shape != tensors[name].shape or value.dtype != tensors[name].dtype:
+                    raise RuntimeError(f"served tensor metadata mismatch: {name}")
+                if not torch.equal(value, tensors[name]):
+                    raise RuntimeError(f"served tensor value mismatch: {name}")
+        weight_map.update({name: filename for name in names})
+        records.append(
+            {
+                "name": filename,
+                "tensor_count": len(names),
+                "payload_bytes": payload_bytes,
+                "sha256": sha256_file(destination),
+            }
+        )
+        del tensors
+        gc.collect()
+    if set(weight_map) != set(specs):
+        raise RuntimeError("export omitted or duplicated candidate tensors")
+    return dict(sorted(weight_map.items())), records
+
+
+def export_dcp_to_hf(
+    *, candidate_dcp: Path, serving_baseline: Path, trajectory: Path, output: Path, shard_bytes: int = DEFAULT_SHARD_BYTES
+) -> dict[str, Any]:
+    """Convert a durable DPO DCP to a fresh, fully candidate-weighted HF directory."""
+
+    if output.exists():
+        raise FileExistsError(f"fresh output directory required: {output}")
+    candidate, extra_state = dcp_state_specs(candidate_dcp)
+    selected = read_surface_contract(trajectory)
+    baseline, _ = _baseline_specs(serving_baseline)
+    contract = check_serving_contract(candidate=candidate, baseline=baseline, selected_fp32=selected)
+    contract["extra_state_excluded"] = len(extra_state)
+    plan = shard_plan(candidate, shard_bytes)
+    output.mkdir(parents=True)
+    try:
+        assets = _copy_assets(serving_baseline, output)
+        weights, shards = _write_shards(checkpoint=candidate_dcp, output=output, specs=candidate, plan=plan)
+        (output / "model.safetensors.index.json").write_text(
+            json.dumps({"metadata": {"total_size": sum(spec.payload_bytes for spec in candidate.values())}, "weight_map": weights}, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        report = {
+            "schema": "speechlm2.dpo.full-dcp-serving-export.v1",
+            "status": "ready",
+            "candidate_dcp": str(candidate_dcp),
+            "candidate_metadata_sha256": sha256_file(candidate_dcp / ".metadata"),
+            "training_trajectory": str(trajectory),
+            "training_trajectory_sha256": sha256_file(trajectory),
+            "serving_baseline": str(serving_baseline),
+            "asset_sha256": assets,
+            "contract": contract,
+            "shard_count": len(shards),
+            "shards": shards,
+            "checks": {
+                "every_served_weight_comes_from_candidate_dcp": True,
+                "all_served_tensors_exactly_round_trip": True,
+                "exact_declared_fp32_training_surface_preserved": True,
+                "no_adapter_or_lora_merge": True,
+            },
+        }
+        (output / "EVAL_MODEL_READY.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return report
+    except BaseException:
+        shutil.rmtree(output, ignore_errors=True)
+        raise

--- a/nemo/collections/speechlm2/dpo/model.py
+++ b/nemo/collections/speechlm2/dpo/model.py
@@ -105,6 +105,52 @@ def _local(value: torch.Tensor) -> torch.Tensor:
     return to_local() if callable(to_local) else value
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _state_contract_digest(state: Mapping[str, Any]) -> str:
+    """Digest keys, dtypes, and shapes without copying model weights to host."""
+
+    contract: list[tuple[str, str, tuple[int, ...]]] = []
+    for name, value in sorted(state.items()):
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(f"DPO model state {name!r} is not a tensor")
+        contract.append((name, str(value.dtype), tuple(int(item) for item in value.shape)))
+    return hashlib.sha256(json.dumps(contract, separators=(",", ":")).encode()).hexdigest()
+
+
+def _state_sample_digest(state: Mapping[str, Any]) -> str:
+    """Small content receipt over every rank-local model-state tensor.
+
+    The strict DCP load below is the authority proof.  This digest is a cheap
+    corroborating receipt that construction weights and post-DCP state are not
+    silently conflated; it deliberately avoids a multi-tens-of-GB host copy.
+    """
+
+    digest = hashlib.sha256()
+    for name, value in sorted(state.items()):
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(f"DPO model state {name!r} is not a tensor")
+        local = _local(value).detach().reshape(-1)
+        digest.update(name.encode())
+        digest.update(str(local.dtype).encode())
+        digest.update(str(tuple(int(item) for item in local.shape)).encode())
+        if local.numel():
+            indices = torch.tensor(
+                sorted({0, int(local.numel()) // 2, int(local.numel()) - 1}),
+                device=local.device,
+                dtype=torch.long,
+            )
+            sample = local.index_select(0, indices).contiguous().view(torch.uint8).cpu()
+            digest.update(memoryview(sample.numpy()))
+    return digest.hexdigest()
+
+
 class DPOSALMAutomodel(SALMAutomodel):
     """SALMAutomodel with standard manual-optimization DPO update semantics.
 
@@ -129,20 +175,66 @@ class DPOSALMAutomodel(SALMAutomodel):
         self._output_root = Path(str(self.cfg.dpo.output_root))
         self._initial_checkpoint = Path(str(self.cfg.dpo.source_checkpoint))
         self._metrics: list[dict[str, Any]] = []
+        self._authority_confirmed = False
 
     def configure_model(self, *args: Any, **kwargs: Any) -> None:
+        if self.cfg.get("init_from_checkpoint", None) is not None:
+            raise RuntimeError("DPO model construction must not load an experiment checkpoint before the strict source DCP")
         super().configure_model(*args, **kwargs)
         if getattr(self, "_dpo_checkpoint_loaded", False):
             return
         from torch.distributed.checkpoint import load
 
-        if not self._initial_checkpoint.joinpath(".metadata").is_file():
-            raise FileNotFoundError(self._initial_checkpoint / ".metadata")
+        metadata_path = self._initial_checkpoint / ".metadata"
+        if not metadata_path.is_file():
+            raise FileNotFoundError(metadata_path)
+        # All temporary LLM/ASR construction state is overwritten through this
+        # complete model state dict before any reference or optimizer path.
+        construction_state = self.state_dict()
+        construction_contract = _state_contract_digest(construction_state)
+        construction_sample = _state_sample_digest(construction_state)
         state = {"state_dict": self.state_dict()}
         load(state, checkpoint_id=str(self._initial_checkpoint))
         incompatible = self.load_state_dict(state["state_dict"], strict=True)
         if incompatible.missing_keys or incompatible.unexpected_keys:
             raise RuntimeError(f"strict Hero2 model DCP load failed: {incompatible}")
+        post_dcp_state = self.state_dict()
+        post_dcp_sample = _state_sample_digest(post_dcp_state)
+        local_receipt = {
+            "rank": int(self.global_rank),
+            "model_state_key_count": len(post_dcp_state),
+            "model_state_contract_digest": _state_contract_digest(post_dcp_state),
+            "construction_state_contract_digest": construction_contract,
+            "construction_state_sample_digest_rank_local": construction_sample,
+            "post_dcp_state_sample_digest_rank_local": post_dcp_sample,
+            "construction_sample_changed": construction_sample != post_dcp_sample,
+            "missing_keys": list(incompatible.missing_keys),
+            "unexpected_keys": list(incompatible.unexpected_keys),
+        }
+        receipts: list[dict[str, Any] | None] = [None] * (dist.get_world_size() if dist.is_initialized() else 1)
+        if dist.is_initialized():
+            dist.all_gather_object(receipts, local_receipt)
+        else:
+            receipts[0] = local_receipt
+        if any(receipt is None or receipt["missing_keys"] or receipt["unexpected_keys"] for receipt in receipts):
+            raise RuntimeError("strict Hero2 DCP authority receipt is incomplete")
+        if self.global_rank == 0:
+            _write_json(
+                self._output_root / "MODEL_AUTHORITY.json",
+                {
+                    "schema": "speechlm2.dpo.model-authority.v1",
+                    "source_checkpoint": str(self._initial_checkpoint),
+                    "source_dcp_metadata_sha256": _sha256_file(metadata_path),
+                    "init_from_checkpoint": self.cfg.get("init_from_checkpoint", None),
+                    "temporary_asr_construction_only": True,
+                    "strict_dcp_load_before_reference": True,
+                    "all_model_state_keys_overwritten_by_source_dcp": True,
+                    "rank_receipts": receipts,
+                },
+            )
+        if dist.is_initialized():
+            dist.barrier()
+        self._authority_confirmed = True
         self._dpo_checkpoint_loaded = True
 
     def configure_optimizers(self):
@@ -163,6 +255,8 @@ class DPOSALMAutomodel(SALMAutomodel):
 
     def on_fit_start(self) -> None:
         super().on_fit_start()
+        if not self._authority_confirmed or not (self._output_root / "MODEL_AUTHORITY.json").is_file():
+            raise RuntimeError("DPO references are forbidden before strict source-DCP authority receipt")
         data_module = self.trainer.datamodule
         shards = data_module.local_shards()
         self._capture_initial_references(shards)

--- a/nemo/collections/speechlm2/dpo/model.py
+++ b/nemo/collections/speechlm2/dpo/model.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Native Lightning DPO model for finite same-audio SpeechLM preference pairs."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from contextlib import nullcontext
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch.distributed.tensor.parallel import loss_parallel
+
+from nemo.collections.common.prompts import PromptFormatter
+from nemo.collections.speechlm2.dpo.data import PreferenceBatch, PreferencePair
+from nemo.collections.speechlm2.dpo.objective import dpo_pair_objective
+from nemo.collections.speechlm2.dpo.surface import configure_partial_acoustic_surface, named_selected_parameters
+from nemo.collections.speechlm2.models.salm_automodel import SALMAutomodel
+
+
+@dataclass(frozen=True)
+class _EncodedCompletion:
+    input_ids: tuple[int, ...]
+    completion_mask: tuple[bool, ...]
+    answer_tokens: int
+
+
+def _field(value: Any, names: tuple[str, ...]) -> Any:
+    for name in names:
+        if isinstance(value, dict) and name in value:
+            return value[name]
+        if hasattr(value, name):
+            return getattr(value, name)
+    return None
+
+
+def _ids(value: Any) -> list[int]:
+    return torch.as_tensor(value).detach().cpu().to(torch.long).reshape(-1).tolist()
+
+
+def _encode_completion(formatter: Any, *, prompt: str, completion: str, audio_tag: str, audio_tag_id: int) -> _EncodedCompletion:
+    prompt = prompt if audio_tag in prompt else f"{audio_tag}\n{prompt}"
+    failures: list[str] = []
+    for style, user, assistant, empty in (
+        ("slots", {"role": "user", "slots": {"message": prompt}}, {"role": "assistant", "slots": {"message": completion}}, {"role": "assistant", "slots": {"message": ""}}),
+        ("content", {"role": "user", "content": prompt}, {"role": "assistant", "content": completion}, {"role": "assistant", "content": ""}),
+    ):
+        try:
+            try:
+                encoded = formatter.encode_dialog(turns=[user, assistant], enable_thinking=False)
+            except TypeError:
+                encoded = formatter.encode_dialog(turns=[user, assistant])
+            input_ids = _ids(_field(encoded, ("input_ids",)))
+            raw_mask = _field(encoded, ("mask", "loss_mask", "answer_mask", "labels_mask"))
+            mask = [] if raw_mask is None else [bool(x) for x in torch.as_tensor(raw_mask).detach().cpu().reshape(-1).tolist()]
+            if len(mask) != len(input_ids) or not any(mask):
+                try:
+                    prefix = formatter.encode_dialog(turns=[user, empty], enable_thinking=False)
+                except TypeError:
+                    prefix = formatter.encode_dialog(turns=[user, empty])
+                prefix_ids = _ids(_field(prefix, ("input_ids",)))
+                shared = next((index for index, pair in enumerate(zip(input_ids, prefix_ids)) if pair[0] != pair[1]), min(len(input_ids), len(prefix_ids)))
+                mask = [index >= shared for index in range(len(input_ids))]
+            if not any(mask) or audio_tag_id not in input_ids:
+                raise ValueError("empty completion mask or absent audio locator")
+            return _EncodedCompletion(tuple(input_ids), tuple(mask), sum(mask))
+        except Exception as error:  # noqa: BLE001
+            failures.append(f"{style}:{type(error).__name__}:{error}")
+    raise RuntimeError("prompt formatter failed to encode DPO completion: " + " | ".join(failures))
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _local(value: torch.Tensor) -> torch.Tensor:
+    to_local = getattr(value, "to_local", None)
+    return to_local() if callable(to_local) else value
+
+
+class DPOSALMAutomodel(SALMAutomodel):
+    """SALMAutomodel with standard manual-optimization DPO update semantics.
+
+    Reference values are captured exactly once through the grad-enabled policy
+    path before the first AdamW update, detached to FP32 scalars, and reused
+    for both explicit ordered passes.  Manual optimization exists only to
+    retain r2's bounded 55-pair FSDP accumulation; optimizer, backward,
+    clipping, checkpoint, and distributed state remain native Lightning/PyTorch
+    lifecycle operations.
+    """
+
+    def __init__(self, cfg: dict[str, Any]) -> None:
+        super().__init__(cfg)
+        self.automatic_optimization = False
+        self._surface = None
+        self._references: dict[int, list[tuple[float, float]]] = {}
+        self._encoded: dict[str, tuple[_EncodedCompletion, _EncodedCompletion]] = {}
+        self._checkpoint_steps = {int(step) for step in self.cfg.dpo.checkpoint_steps}
+        self._expected_updates = int(self.cfg.dpo.expected_updates)
+        if not 1 <= self._expected_updates <= 2 * int(self.cfg.dpo.source_shards):
+            raise ValueError("DPO expected_updates must be within the finite two-pass schedule")
+        self._output_root = Path(str(self.cfg.dpo.output_root))
+        self._initial_checkpoint = Path(str(self.cfg.dpo.source_checkpoint))
+        self._metrics: list[dict[str, Any]] = []
+
+    def configure_model(self, *args: Any, **kwargs: Any) -> None:
+        super().configure_model(*args, **kwargs)
+        if getattr(self, "_dpo_checkpoint_loaded", False):
+            return
+        from torch.distributed.checkpoint import load
+
+        if not self._initial_checkpoint.joinpath(".metadata").is_file():
+            raise FileNotFoundError(self._initial_checkpoint / ".metadata")
+        state = {"state_dict": self.state_dict()}
+        load(state, checkpoint_id=str(self._initial_checkpoint))
+        incompatible = self.load_state_dict(state["state_dict"], strict=True)
+        if incompatible.missing_keys or incompatible.unexpected_keys:
+            raise RuntimeError(f"strict Hero2 model DCP load failed: {incompatible}")
+        self._dpo_checkpoint_loaded = True
+
+    def configure_optimizers(self):
+        self._surface = configure_partial_acoustic_surface(self)
+        dpo = self.cfg.dpo
+        optimizer = torch.optim.AdamW(
+            list(named_selected_parameters(self)),
+            lr=float(dpo.learning_rate),
+            betas=tuple(float(item) for item in dpo.optimizer.betas),
+            eps=float(dpo.optimizer.eps),
+            weight_decay=float(dpo.optimizer.weight_decay),
+            foreach=bool(dpo.optimizer.foreach),
+            fused=bool(dpo.optimizer.fused),
+        )
+        if len(optimizer.param_groups) != 1 or len(optimizer.param_groups[0]["params"]) != 269:
+            raise RuntimeError("AdamW does not own the declared 269-tensor DPO surface")
+        return optimizer
+
+    def on_fit_start(self) -> None:
+        super().on_fit_start()
+        data_module = self.trainer.datamodule
+        shards = data_module.local_shards()
+        self._capture_initial_references(shards)
+        if self.global_rank == 0:
+            _write_json(
+                self._output_root / "TRAJECTORY.json",
+                {
+                    "schema": "speechlm2.dpo.finite_lhotse.v1", "reference_path": "grad_enabled_policy_detached_once",
+                    "lhotse": data_module.receipt, "global_updates": self._expected_updates, "explicit_passes": 2,
+                    "checkpoint_steps": sorted(self._checkpoint_steps), "surface": self._surface.__dict__, "lora": False,
+                },
+            )
+
+    def _encoded_pair(self, pair: PreferencePair) -> tuple[_EncodedCompletion, _EncodedCompletion]:
+        if pair.pair_id not in self._encoded:
+            formatter = PromptFormatter.resolve(self.cfg.prompt_format)(self.tokenizer)
+            self._encoded[pair.pair_id] = (
+                _encode_completion(formatter, prompt=pair.prompt, completion=pair.chosen, audio_tag=self.audio_locator_tag, audio_tag_id=int(self.audio_locator_tag_id)),
+                _encode_completion(formatter, prompt=pair.prompt, completion=pair.rejected, audio_tag=self.audio_locator_tag, audio_tag_id=int(self.audio_locator_tag_id)),
+            )
+        return self._encoded[pair.pair_id]
+
+    def _completion_logprob(self, encoded: _EncodedCompletion, audio: torch.Tensor) -> torch.Tensor:
+        device = self.device
+        batch = {
+            "input_ids": torch.tensor([encoded.input_ids], dtype=torch.long, device=device),
+            "loss_mask": torch.tensor([encoded.completion_mask], dtype=torch.bool, device=device),
+            "audios": audio.reshape(1, -1).to(device=device, dtype=torch.float32),
+            "audio_lens": torch.tensor([audio.numel()], dtype=torch.long, device=device),
+        }
+        # This code deliberately does not enter no_grad: reference capture must
+        # exercise the same grad-enabled policy path as the DPO branch.
+        prepared = self.prepare_inputs(batch)
+        with torch.autocast(device_type=device.type, dtype=torch.bfloat16) if device.type == "cuda" else nullcontext():
+            outputs = self(prepared["input_embeds"], attention_mask=prepared["attention_mask"], **prepared.get("llm_kwargs", {}))
+        targets = prepared["target_ids"]
+        with loss_parallel():
+            losses = F.cross_entropy(outputs["logits"].float().reshape(-1, outputs["logits"].size(-1)), targets.reshape(-1), reduction="none", ignore_index=-100).reshape(targets.shape)
+        mask = targets != -100
+        if not bool(mask.any()):
+            raise RuntimeError("DPO completion contains no target tokens after native prepare_inputs")
+        return -(losses * mask).sum()
+
+    def _policy_pair(self, pair: PreferencePair) -> tuple[torch.Tensor, torch.Tensor]:
+        chosen, rejected = self._encoded_pair(pair)
+        return self._completion_logprob(chosen, pair.audio), self._completion_logprob(rejected, pair.audio)
+
+    def _force_reshard(self) -> None:
+        modules: list[torch.nn.Module] = []
+        seen: set[int] = set()
+        for _, module in self.named_modules():
+            get_state = getattr(module, "_get_fsdp_state", None)
+            if callable(get_state) and (group := getattr(get_state(), "_fsdp_param_group", None)) is not None and id(group) not in seen:
+                seen.add(id(group))
+                modules.append(module)
+        for module in reversed(modules):
+            module.reshard()
+
+    def _capture_initial_references(self, shards: list[list[PreferencePair]]) -> None:
+        self.eval()
+        for source_shard, pairs in enumerate(shards, 1):
+            values: list[tuple[float, float]] = []
+            for pair in pairs:
+                chosen, rejected = self._policy_pair(pair)
+                if not chosen.requires_grad or not rejected.requires_grad:
+                    raise RuntimeError("initial DPO reference was not captured through the grad-enabled policy path")
+                values.append((float(chosen.detach().float().cpu()), float(rejected.detach().float().cpu())))
+                del chosen, rejected
+            self._references[source_shard] = values
+            self._force_reshard()
+        if len(self._references) != len(shards):
+            raise RuntimeError("incomplete initial DPO reference cache")
+
+    def _digest_surface(self) -> str:
+        digest = hashlib.sha256()
+        for parameter in named_selected_parameters(self):
+            value = _local(parameter).detach().contiguous().view(torch.uint8).cpu()
+            digest.update(memoryview(value.numpy()))
+        return digest.hexdigest()
+
+    def training_step(self, batch: PreferenceBatch, batch_idx: int):
+        del batch_idx
+        if batch.global_step != len(self._metrics) + 1:
+            raise RuntimeError("finite DPO update schedule drift")
+        references = self._references.get(batch.source_shard)
+        if references is None or len(references) != len(batch.pairs):
+            raise RuntimeError("DPO reference-cache/source-shard mismatch")
+        # Retain Lightning's optimizer wrapper so its normal manual-optimization
+        # bookkeeping advances ``trainer.global_step`` once per AdamW update.
+        optimizer = self.optimizers()
+        optimizer.zero_grad(set_to_none=True)
+        self.eval()
+        scale = float(self.cfg.dpo.world_size) / float(self.cfg.dpo.pairs_per_update)
+        before = self._digest_surface()
+        local_loss_sum = 0.0
+        local_margin_sum = 0.0
+        local_active = 0
+        for pair, reference in zip(batch.pairs, references, strict=True):
+            chosen, rejected = self._policy_pair(pair)
+            ref_chosen = torch.tensor(reference[0], dtype=torch.float32, device=self.device)
+            ref_rejected = torch.tensor(reference[1], dtype=torch.float32, device=self.device)
+            objective = dpo_pair_objective(
+                chosen_policy_logp=chosen, rejected_policy_logp=rejected,
+                chosen_reference_logp=ref_chosen, rejected_reference_logp=ref_rejected, beta=float(self.cfg.dpo.beta),
+            )
+            loss = objective.loss * (scale if pair.active else 0.0)
+            self.manual_backward(loss)
+            if pair.active:
+                local_loss_sum += float(objective.loss.detach().cpu())
+                local_margin_sum += float(objective.margin.detach().cpu())
+                local_active += 1
+            del chosen, rejected, objective, loss
+            self._force_reshard()
+        grads = [parameter.grad for parameter in named_selected_parameters(self) if parameter.grad is not None]
+        if not grads or not all(bool(torch.isfinite(_local(grad)).all()) for grad in grads):
+            raise RuntimeError("DPO backward produced missing or nonfinite gradients")
+        self.clip_gradients(optimizer, gradient_clip_val=float(self.cfg.dpo.gradient_clip_norm), gradient_clip_algorithm="norm")
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+        self._force_reshard()
+        after = self._digest_surface()
+        changed = before != after
+        health = torch.tensor([local_loss_sum, local_margin_sum, float(local_active)], device=self.device, dtype=torch.float64)
+        if dist.is_initialized():
+            dist.all_reduce(health, op=dist.ReduceOp.SUM)
+        if int(health[2].item()) != int(self.cfg.dpo.pairs_per_update) or not changed:
+            raise RuntimeError("DPO update did not cover exactly one shard or did not move selected parameters")
+        record = {
+            "global_step": batch.global_step, "dpo_pass": batch.dpo_pass, "source_shard": batch.source_shard,
+            "active_pairs": int(health[2].item()), "mean_loss": float(health[0].item() / health[2].item()),
+            "mean_margin": float(health[1].item() / health[2].item()), "surface_digest_before": before,
+            "surface_digest_after": after, "surface_changed": changed,
+        }
+        self._metrics.append(record)
+        self.log("dpo/loss", record["mean_loss"], on_step=True, prog_bar=True, batch_size=1)
+        self.log("dpo/margin", record["mean_margin"], on_step=True, batch_size=1)
+        if self.global_rank == 0:
+            _write_json(self._output_root / "steps" / f"s{batch.global_step:02d}.json", record)
+        return record
+
+    def on_train_batch_end(self, outputs: Any, batch: PreferenceBatch, batch_idx: int) -> None:
+        del outputs, batch_idx
+        if batch.global_step not in self._checkpoint_steps:
+            return
+        from torch.distributed.checkpoint import save
+
+        destination = self._output_root / "checkpoints" / f"s{batch.global_step:02d}"
+        if self.global_rank == 0:
+            destination.mkdir(parents=True, exist_ok=False)
+        if dist.is_initialized():
+            dist.barrier()
+        optimizer = self.optimizers().optimizer
+        save({"state_dict": self.state_dict()}, checkpoint_id=str(destination / "model_weights.dcp"))
+        save({"model": self.state_dict(), "optimizer": optimizer.state_dict()}, checkpoint_id=str(destination / "training_state.dcp"))
+        if dist.is_initialized():
+            dist.barrier()
+        local_ready = all(
+            path.is_file()
+            for path in (
+                destination / "model_weights.dcp" / ".metadata",
+                destination / "training_state.dcp" / ".metadata",
+            )
+        )
+        ready_across_ranks = torch.tensor(int(local_ready), device=self.device, dtype=torch.int32)
+        if dist.is_initialized():
+            dist.all_reduce(ready_across_ranks, op=dist.ReduceOp.MIN)
+        if not bool(ready_across_ranks.item()):
+            raise RuntimeError(f"incomplete DPO checkpoint at {destination}")
+        if self.global_rank == 0:
+            ready = {
+                "step": batch.global_step, "model_weights": str(destination / "model_weights.dcp"),
+                "training_state": str(destination / "training_state.dcp"), "passed": True,
+            }
+            _write_json(destination / "CHECKPOINT_READY.json", ready)
+        if dist.is_initialized():
+            dist.barrier()
+
+    def on_train_end(self) -> None:
+        if len(self._metrics) != self._expected_updates:
+            raise RuntimeError(f"DPO completed {len(self._metrics)} rather than {self._expected_updates} updates")
+        if self.global_rank == 0:
+            _write_json(self._output_root / "global_compact.json", {"status": "passed", "steps": self._metrics, "surface": self._surface.__dict__})
+            _write_json(self._output_root / "DONE.json", {"status": "passed", "updates": len(self._metrics)})

--- a/nemo/collections/speechlm2/dpo/model.py
+++ b/nemo/collections/speechlm2/dpo/model.py
@@ -10,7 +10,7 @@ import math
 from contextlib import nullcontext
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 import torch
 import torch.distributed as dist
@@ -44,26 +44,44 @@ def _ids(value: Any) -> list[int]:
     return torch.as_tensor(value).detach().cpu().to(torch.long).reshape(-1).tolist()
 
 
-def _encode_completion(formatter: Any, *, prompt: str, completion: str, audio_tag: str, audio_tag_id: int) -> _EncodedCompletion:
-    prompt = prompt if audio_tag in prompt else f"{audio_tag}\n{prompt}"
+def _dialog_turns(prompt: str | Mapping[str, str], completion: str, audio_tag: str) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Create prompt-formatter turns without flattening structured system/user prompts."""
+
+    if isinstance(prompt, str):
+        system = None
+        user_text = prompt
+    elif isinstance(prompt, Mapping) and isinstance(prompt.get("system", ""), str) and isinstance(prompt.get("user"), str):
+        system = str(prompt.get("system", ""))
+        user_text = str(prompt["user"])
+    else:
+        raise ValueError("DPO prompt must be a nonempty string or {system, user} mapping")
+    user_text = user_text if audio_tag in user_text else f"{audio_tag}\n{user_text}"
+    context: list[dict[str, Any]] = []
+    if system is not None:
+        context.append({"role": "system", "slots": {"message": system}})
+    context.append({"role": "user", "slots": {"message": user_text}})
+    answered = [*context, {"role": "assistant", "slots": {"message": completion}}]
+    empty_answer = [*context, {"role": "assistant", "slots": {"message": ""}}]
+    return answered, empty_answer
+
+
+def _encode_completion(formatter: Any, *, prompt: str | Mapping[str, str], completion: str, audio_tag: str, audio_tag_id: int) -> _EncodedCompletion:
+    answered, empty_answer = _dialog_turns(prompt, completion, audio_tag)
     failures: list[str] = []
-    for style, user, assistant, empty in (
-        ("slots", {"role": "user", "slots": {"message": prompt}}, {"role": "assistant", "slots": {"message": completion}}, {"role": "assistant", "slots": {"message": ""}}),
-        ("content", {"role": "user", "content": prompt}, {"role": "assistant", "content": completion}, {"role": "assistant", "content": ""}),
-    ):
+    for style, turns, prefix_turns in (("slots", answered, empty_answer),):
         try:
             try:
-                encoded = formatter.encode_dialog(turns=[user, assistant], enable_thinking=False)
+                encoded = formatter.encode_dialog(turns=turns, enable_thinking=False)
             except TypeError:
-                encoded = formatter.encode_dialog(turns=[user, assistant])
+                encoded = formatter.encode_dialog(turns=turns)
             input_ids = _ids(_field(encoded, ("input_ids",)))
             raw_mask = _field(encoded, ("mask", "loss_mask", "answer_mask", "labels_mask"))
             mask = [] if raw_mask is None else [bool(x) for x in torch.as_tensor(raw_mask).detach().cpu().reshape(-1).tolist()]
             if len(mask) != len(input_ids) or not any(mask):
                 try:
-                    prefix = formatter.encode_dialog(turns=[user, empty], enable_thinking=False)
+                    prefix = formatter.encode_dialog(turns=prefix_turns, enable_thinking=False)
                 except TypeError:
-                    prefix = formatter.encode_dialog(turns=[user, empty])
+                    prefix = formatter.encode_dialog(turns=prefix_turns)
                 prefix_ids = _ids(_field(prefix, ("input_ids",)))
                 shared = next((index for index, pair in enumerate(zip(input_ids, prefix_ids)) if pair[0] != pair[1]), min(len(input_ids), len(prefix_ids)))
                 mask = [index >= shared for index in range(len(input_ids))]

--- a/nemo/collections/speechlm2/dpo/model.py
+++ b/nemo/collections/speechlm2/dpo/model.py
@@ -20,7 +20,11 @@ from torch.distributed.tensor.parallel import loss_parallel
 from nemo.collections.common.prompts import PromptFormatter
 from nemo.collections.speechlm2.dpo.data import PreferenceBatch, PreferencePair
 from nemo.collections.speechlm2.dpo.objective import dpo_pair_objective
-from nemo.collections.speechlm2.dpo.surface import configure_partial_acoustic_surface, named_selected_parameters
+from nemo.collections.speechlm2.dpo.surface import (
+    configure_partial_acoustic_surface,
+    named_selected_parameters,
+    selected_parameter_names,
+)
 from nemo.collections.speechlm2.models.salm_automodel import SALMAutomodel
 
 
@@ -149,6 +153,41 @@ def _state_sample_digest(state: Mapping[str, Any]) -> str:
             sample = local.index_select(0, indices).contiguous().view(torch.uint8).cpu()
             digest.update(memoryview(sample.numpy()))
     return digest.hexdigest()
+
+
+def _gradient_layout(name: str, gradient: torch.Tensor) -> dict[str, Any]:
+    """Return a bounded, data-free selected-gradient DTensor receipt.
+
+    The receipt is recorded immediately after backward and before clipping. It
+    captures only type, shape, mesh and placement metadata; gradient values
+    never leave the GPU. This makes mixed-FSDP layout evidence reviewable when
+    an upstream clipping implementation is used.
+    """
+
+    local = _local(gradient)
+    mesh = getattr(gradient, "device_mesh", None)
+    if mesh is None:
+        mesh_record: dict[str, Any] = {"kind": "local"}
+    else:
+        mesh_tensor = getattr(mesh, "mesh", None)
+        mesh_ranks = []
+        if isinstance(mesh_tensor, torch.Tensor):
+            mesh_ranks = mesh_tensor.detach().cpu().reshape(-1).tolist()
+        mesh_record = {
+            "kind": "dtensor",
+            "mesh_dim_names": [str(item) for item in (mesh.mesh_dim_names or ())],
+            "mesh_shape": list(mesh_tensor.shape) if isinstance(mesh_tensor, torch.Tensor) else [int(mesh.size())],
+            "mesh_ranks": mesh_ranks,
+            "placements": [str(item) for item in getattr(gradient, "placements", ())],
+        }
+    return {
+        "name": name,
+        "tensor_type": f"{type(gradient).__module__}.{type(gradient).__qualname__}",
+        "global_shape": [int(item) for item in gradient.shape],
+        "local_shape": [int(item) for item in local.shape],
+        "dtype": str(gradient.dtype),
+        "layout": mesh_record,
+    }
 
 
 class DPOSALMAutomodel(SALMAutomodel):
@@ -337,6 +376,59 @@ class DPOSALMAutomodel(SALMAutomodel):
             digest.update(memoryview(value.numpy()))
         return digest.hexdigest()
 
+    def _write_selected_gradient_layout_receipt(self, step: int) -> None:
+        """Persist the per-tensor mixed-FSDP layout before the single clip.
+
+        This is an observability receipt, not an extra training operation: all
+        selected gradients already exist at this point. Every rank contributes
+        the same bounded 269-entry schema, and rank zero writes one JSON file.
+        """
+
+        entries = [
+            _gradient_layout(name, parameter.grad)
+            for name, parameter in zip(selected_parameter_names(), named_selected_parameters(self), strict=True)
+            if parameter.grad is not None
+        ]
+        if len(entries) != len(selected_parameter_names()):
+            raise RuntimeError("DPO gradient-layout receipt observed a missing selected gradient")
+        groups: dict[str, list[str]] = {}
+        for entry in entries:
+            signature = json.dumps(entry["layout"], sort_keys=True, separators=(",", ":"))
+            groups.setdefault(signature, []).append(entry["name"])
+        local_receipt = {
+            "rank": int(self.global_rank),
+            "tensor_count": len(entries),
+            "groups": [{"layout": json.loads(signature), "names": names} for signature, names in groups.items()],
+            "tensors": entries,
+        }
+        receipts: list[dict[str, Any] | None] = [None] * (dist.get_world_size() if dist.is_initialized() else 1)
+        if dist.is_initialized():
+            dist.all_gather_object(receipts, local_receipt)
+        else:
+            receipts[0] = local_receipt
+        if any(receipt is None or receipt["tensor_count"] != len(selected_parameter_names()) for receipt in receipts):
+            raise RuntimeError("DPO selected-gradient layout receipt is incomplete")
+        if self.global_rank == 0:
+            _write_json(
+                self._output_root / "gradient_layout" / f"s{step:02d}.json",
+                {
+                    "schema": "speechlm2.dpo.selected-gradient-layout.v1",
+                    "pre_clip": True,
+                    "rank_receipts": receipts,
+                },
+            )
+        if dist.is_initialized():
+            dist.barrier()
+
+    def _clip_selected_gradients(self, optimizer: Any) -> None:
+        """Apply the one historical norm-1 clip via inherited mesh-aware code."""
+
+        self.configure_gradient_clipping(
+            optimizer,
+            gradient_clip_val=float(self.cfg.dpo.gradient_clip_norm),
+            gradient_clip_algorithm="norm",
+        )
+
     def training_step(self, batch: PreferenceBatch, batch_idx: int):
         del batch_idx
         if batch.global_step != len(self._metrics) + 1:
@@ -373,7 +465,8 @@ class DPOSALMAutomodel(SALMAutomodel):
         grads = [parameter.grad for parameter in named_selected_parameters(self) if parameter.grad is not None]
         if not grads or not all(bool(torch.isfinite(_local(grad)).all()) for grad in grads):
             raise RuntimeError("DPO backward produced missing or nonfinite gradients")
-        self.clip_gradients(optimizer, gradient_clip_val=float(self.cfg.dpo.gradient_clip_norm), gradient_clip_algorithm="norm")
+        self._write_selected_gradient_layout_receipt(batch.global_step)
+        self._clip_selected_gradients(optimizer)
         optimizer.step()
         optimizer.zero_grad(set_to_none=True)
         self._force_reshard()

--- a/nemo/collections/speechlm2/dpo/objective.py
+++ b/nemo/collections/speechlm2/dpo/objective.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Small, explicit, reference-subtracted pairwise DPO objective."""
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+
+@dataclass(frozen=True)
+class DPOPairObjective:
+    """The un-reduced standard DPO values for one ordered pair."""
+
+    margin: torch.Tensor
+    loss: torch.Tensor
+
+
+def dpo_pair_objective(
+    *,
+    chosen_policy_logp: torch.Tensor,
+    rejected_policy_logp: torch.Tensor,
+    chosen_reference_logp: torch.Tensor,
+    rejected_reference_logp: torch.Tensor,
+    beta: float,
+) -> DPOPairObjective:
+    """Return ``-logsigmoid(beta * ((pi_c-ref_c) - (pi_r-ref_r)))``.
+
+    The caller controls reduction. Keeping this function pair-local makes the
+    distributed ownership scaling visible in the training module.
+    """
+
+    if not 0.0 < beta <= 10.0:
+        raise ValueError(f"beta must be in (0, 10], got {beta}")
+    values = (chosen_policy_logp, rejected_policy_logp, chosen_reference_logp, rejected_reference_logp)
+    if len({tuple(value.shape) for value in values}) != 1:
+        raise ValueError("DPO log-probability tensors must have equal shapes")
+    margin = (chosen_policy_logp - chosen_reference_logp) - (rejected_policy_logp - rejected_reference_logp)
+    return DPOPairObjective(margin=margin, loss=-F.logsigmoid(beta * margin))

--- a/nemo/collections/speechlm2/dpo/surface.py
+++ b/nemo/collections/speechlm2/dpo/surface.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+"""Declared Hero2 partial-acoustic DPO mutation surface.
+
+This is normal SpeechLM2 code.  It does not import or alter an installed
+dependency, rebind an imported implementation, or create an adapter.  The
+parameter selection is deliberately explicit because it is part of the AMI
+experiment's algorithmic contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import torch
+from torch.distributed.fsdp import MixedPrecisionPolicy
+
+
+ATTENTION_LAYERS = (5, 12, 19, 26, 33, 42)
+MAMBA_LAYERS = (0, 2, 4, 7, 9, 11, 14, 16, 18, 21, 23, 25, 28, 30, 32, 35, 37, 39, 41, 44, 46, 48, 50)
+ATTENTION_SUFFIXES = ("mixer.k_proj.weight", "mixer.o_proj.weight", "mixer.q_proj.weight", "mixer.v_proj.weight", "norm.weight")
+MAMBA_SUFFIXES = (
+    "mixer.A_log", "mixer.D", "mixer.conv1d.bias", "mixer.conv1d.weight", "mixer.dt_bias", "mixer.in_proj.weight",
+    "mixer.norm.weight", "mixer.out_proj.weight", "norm.weight",
+)
+HERO2_ENCODER_SUFFIXES = (
+    "norm1.weight", "norm1.bias", "attn.w_qkv.weight", "attn.out_proj.weight", "attn.out_proj.bias", "attn.q_norm.weight",
+    "attn.q_norm.bias", "attn.k_norm.weight", "attn.k_norm.bias", "norm2.weight", "norm2.bias", "ffn.net.0.weight",
+    "ffn.net.0.bias", "ffn.net.3.weight", "ffn.net.3.bias",
+)
+HERO2_ACOUSTIC_LAYERS = (30, 31)
+SELECTED_TENSOR_COUNT = 269
+SELECTED_SCALAR_COUNT = 1_074_327_616
+
+
+def canonical_name(name: str) -> str:
+    """Remove the state-dict-transparent activation-checkpoint wrapper token."""
+
+    return ".".join(part for part in name.split(".") if part != "_checkpoint_wrapped_module")
+
+
+def selected_parameter_names() -> tuple[str, ...]:
+    native: list[str] = []
+    for layer in range(52):
+        suffixes = ATTENTION_SUFFIXES if layer in ATTENTION_LAYERS else MAMBA_SUFFIXES if layer in MAMBA_LAYERS else ()
+        native.extend(f"llm.model.layers.{layer}.{suffix}" for suffix in suffixes)
+    acoustic = [f"perception.encoder.layers.{layer}.{suffix}" for layer in HERO2_ACOUSTIC_LAYERS for suffix in HERO2_ENCODER_SUFFIXES]
+    names = tuple(native + acoustic + ["perception.proj.weight", "perception.proj.bias"])
+    if len(names) != SELECTED_TENSOR_COUNT or len(set(names)) != len(names):
+        raise RuntimeError("Hero2 DPO surface inventory drift")
+    return names
+
+
+def _local_tensor(value: torch.Tensor) -> torch.Tensor:
+    to_local = getattr(value, "to_local", None)
+    return to_local() if callable(to_local) else value
+
+
+@dataclass(frozen=True)
+class SurfaceInventory:
+    names: tuple[str, ...]
+    tensor_count: int
+    scalar_count: int
+    dtypes: tuple[str, ...]
+
+
+def inventory(model: torch.nn.Module) -> SurfaceInventory:
+    expected = set(selected_parameter_names())
+    found = {canonical_name(name): parameter for name, parameter in model.named_parameters() if canonical_name(name) in expected}
+    if set(found) != expected:
+        missing, unexpected = sorted(expected - set(found)), sorted(set(found) - expected)
+        raise RuntimeError(f"Hero2 DPO surface names differ: missing={missing[:4]} unexpected={unexpected[:4]}")
+    ordered = tuple(found[name] for name in selected_parameter_names())
+    scalars = sum(int(parameter.numel()) for parameter in ordered)
+    return SurfaceInventory(
+        names=selected_parameter_names(), tensor_count=len(ordered), scalar_count=scalars,
+        dtypes=tuple(sorted({str(parameter.dtype) for parameter in ordered})),
+    )
+
+
+def _replace_with_fp32(parameter: torch.nn.Parameter) -> None:
+    """Promote a selected FSDP parameter while preserving parameter identity."""
+
+    with torch.no_grad():
+        replacement = torch.nn.Parameter(parameter.to(dtype=torch.float32), requires_grad=parameter.requires_grad)
+        torch.utils.swap_tensors(parameter, replacement)
+
+
+def configure_partial_acoustic_surface(model: torch.nn.Module) -> SurfaceInventory:
+    """Freeze all but the declared 269 FP32 Hero2 DPO tensors.
+
+    This is the r2 mutation contract expressed as a normal model capability.
+    The FSDP refresh is necessary after the acoustic child tensors are promoted
+    to FP32; it uses the normal PyTorch FSDP object associated with the model.
+    """
+
+    before = inventory(model)
+    modules = dict(model.named_modules())
+    selected_before = {canonical_name(name): parameter for name, parameter in model.named_parameters()}
+    for parameter in model.parameters():
+        parameter.requires_grad_(False)
+    for layer in sorted(set(ATTENTION_LAYERS) | set(MAMBA_LAYERS)):
+        modules[f"llm.model.layers.{layer}"].to(dtype=torch.float32)
+    for name in selected_parameter_names():
+        if name.startswith("perception."):
+            _replace_with_fp32(selected_before[name])
+    after = inventory(model)
+    if after.tensor_count != SELECTED_TENSOR_COUNT or after.scalar_count != SELECTED_SCALAR_COUNT:
+        raise RuntimeError(f"Hero2 DPO surface count drift: {after}")
+    selected_after = {canonical_name(name): parameter for name, parameter in model.named_parameters()}
+    for name in after.names:
+        selected_after[name].requires_grad_(True)
+    if set(after.dtypes) != {"torch.float32"}:
+        raise RuntimeError(f"Hero2 DPO surface must be FP32, got {after.dtypes}")
+    perception = modules["perception"]
+    get_state = getattr(perception, "_get_fsdp_state", None)
+    if callable(get_state):
+        state = get_state()
+        group = getattr(state, "_fsdp_param_group", None)
+        if group is not None:
+            policy = MixedPrecisionPolicy(
+                param_dtype=torch.bfloat16, reduce_dtype=torch.float32, output_dtype=torch.bfloat16, cast_forward_inputs=True
+            )
+            state._mp_policy = policy
+            group.mp_policy = policy
+            acoustic_ids = {id(selected_after[name]) for name in after.names if name.startswith("perception.")}
+            for fsdp_parameter in group.fsdp_params:
+                if id(fsdp_parameter.sharded_param) in acoustic_ids:
+                    fsdp_parameter.reset_sharded_param()
+    final = inventory(model)
+    if final != after:
+        raise RuntimeError("FSDP surface refresh altered the declared DPO surface")
+    return final
+
+
+def named_selected_parameters(model: torch.nn.Module) -> Iterable[torch.nn.Parameter]:
+    mapping = {canonical_name(name): parameter for name, parameter in model.named_parameters()}
+    for name in selected_parameter_names():
+        yield mapping[name]

--- a/nemo/collections/speechlm2/dpo/surface.py
+++ b/nemo/collections/speechlm2/dpo/surface.py
@@ -31,7 +31,17 @@ HERO2_ENCODER_SUFFIXES = (
 )
 HERO2_ACOUSTIC_LAYERS = (30, 31)
 SELECTED_TENSOR_COUNT = 269
-SELECTED_SCALAR_COUNT = 1_074_327_616
+# Read directly from the preserved historical-r5 r2 s01 DCP metadata, not
+# from hand arithmetic.  The 269 selected names/shapes total 1,074,318,016
+# scalars.  The old compatibility program declared 1,074,327,616 (9,600 too
+# high) but never dynamically asserted that value.
+SELECTED_SCALAR_COUNT = 1_074_318_016
+
+# SHA256 of newline-joined ``name|shape|numel`` records from the immutable r2
+# checkpoint metadata.  It is provenance for the count above; the live
+# inventory remains the authoritative runtime check.
+HISTORICAL_R2_SURFACE_INVENTORY_SHA256 = "20cd5cb3a3fbdaa5a91e430e7a65dfdc53c463b72382e0d62a56039b4a7f9dfc"
+HISTORICAL_R2_SURFACE_NAMES_SHA256 = "b7066381abcfd73486e7bcd2e56cec6798b70bc8a3ba6afe46a702848e440cc2"
 
 
 def canonical_name(name: str) -> str:

--- a/tests/collections/speechlm2/test_dpo_export.py
+++ b/tests/collections/speechlm2/test_dpo_export.py
@@ -81,4 +81,6 @@ def test_r22_server_entrypoint_uses_a_verified_staged_package_artifact():
     assert "--verify-r22-package-install" in script
     assert "python3 -m venv \"$target/venv\"" in script
     assert "R22_PACKAGE_INSTALL_RECEIPT" in script
+    assert "pip-install.log" in script
+    assert "write_install_receipt false pip_install" in script
     assert "PYTHONPATH" not in script

--- a/tests/collections/speechlm2/test_dpo_export.py
+++ b/tests/collections/speechlm2/test_dpo_export.py
@@ -80,4 +80,5 @@ def test_r22_server_entrypoint_uses_a_verified_staged_package_artifact():
     assert "--force-reinstall \"$R22_STAGE_ROOT/source\"" in script
     assert "--verify-r22-package-install" in script
     assert "python3 -m venv \"$target/venv\"" in script
+    assert "R22_PACKAGE_INSTALL_RECEIPT" in script
     assert "PYTHONPATH" not in script

--- a/tests/collections/speechlm2/test_dpo_export.py
+++ b/tests/collections/speechlm2/test_dpo_export.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from nemo.collections.speechlm2.dpo.export import TensorSpec, check_serving_contract, read_surface_contract, shard_plan
+from nemo.collections.speechlm2.dpo.surface import selected_parameter_names
+
+
+def _spec(dtype: torch.dtype) -> TensorSpec:
+    return TensorSpec(shape=(2, 3), dtype=dtype, payload_bytes=2 * 3 * torch.empty((), dtype=dtype).element_size())
+
+
+def _trajectory() -> dict:
+    return {
+        "lora": False,
+        "surface": {
+            "names": list(selected_parameter_names()),
+            "tensor_count": 269,
+            "scalar_count": 1_074_318_016,
+            "dtypes": ["torch.float32"],
+        },
+    }
+
+
+def test_read_surface_contract_requires_the_declared_historical_surface(tmp_path: Path):
+    path = tmp_path / "TRAJECTORY.json"
+    path.write_text(__import__("json").dumps(_trajectory()), encoding="utf-8")
+    assert read_surface_contract(path) == selected_parameter_names()
+    invalid = _trajectory()
+    invalid["surface"]["names"] = invalid["surface"]["names"][:-1]
+    path.write_text(__import__("json").dumps(invalid), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="exact Hero2 DPO FP32 surface"):
+        read_surface_contract(path)
+
+
+def test_export_contract_accepts_only_the_declared_bf16_to_fp32_surface():
+    selected = selected_parameter_names()
+    baseline = {name: _spec(torch.bfloat16) for name in selected}
+    baseline["frozen"] = _spec(torch.bfloat16)
+    candidate = {name: _spec(torch.float32) for name in selected}
+    candidate["frozen"] = _spec(torch.bfloat16)
+    report = check_serving_contract(candidate=candidate, baseline=baseline, selected_fp32=selected)
+    assert report["serving_tensor_count"] == 270
+    assert report["fp32_surface_tensor_count"] == 269
+
+
+def test_export_contract_rejects_precision_drift_outside_selected_surface():
+    selected = selected_parameter_names()
+    baseline = {name: _spec(torch.bfloat16) for name in selected}
+    baseline["frozen"] = _spec(torch.bfloat16)
+    candidate = {name: _spec(torch.float32) for name in selected}
+    candidate["frozen"] = _spec(torch.float32)
+    with pytest.raises(RuntimeError, match="outside declared"):
+        check_serving_contract(candidate=candidate, baseline=baseline, selected_fp32=selected)
+
+
+def test_shard_plan_is_ordered_bounded_and_exhaustive():
+    specs = {
+        "a": TensorSpec((2,), torch.float32, 8),
+        "b": TensorSpec((3,), torch.float32, 12),
+        "c": TensorSpec((1,), torch.float32, 4),
+    }
+    assert shard_plan(specs, 16) == [["a"], ["b", "c"]]
+    with pytest.raises(ValueError, match="positive"):
+        shard_plan(specs, 0)

--- a/tests/collections/speechlm2/test_dpo_export.py
+++ b/tests/collections/speechlm2/test_dpo_export.py
@@ -66,3 +66,18 @@ def test_shard_plan_is_ordered_bounded_and_exhaustive():
     assert shard_plan(specs, 16) == [["a"], ["b", "c"]]
     with pytest.raises(ValueError, match="positive"):
         shard_plan(specs, 0)
+
+
+def test_r22_server_entrypoint_uses_a_verified_staged_package_artifact():
+    script = (
+        Path(__file__).resolve().parents[3]
+        / "examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh"
+    ).read_text(encoding="utf-8")
+    assert "R22_NEMO_SERVER_FINGERPRINT_SHA256" in script
+    assert "stage_verified_r22_package" in script
+    assert "! -name collections" in script
+    assert "-P 8 cp -a -t \"$stage_root/source/nemo/collections\"" in script
+    assert "--force-reinstall \"$R22_STAGE_ROOT/source\"" in script
+    assert "--verify-r22-package-install" in script
+    assert "python3 -m venv \"$target/venv\"" in script
+    assert "PYTHONPATH" not in script

--- a/tests/collections/speechlm2/test_dpo_objective.py
+++ b/tests/collections/speechlm2/test_dpo_objective.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+import math
+
+import torch
+
+from nemo.collections.speechlm2.dpo.objective import dpo_pair_objective
+from nemo.collections.speechlm2.dpo.surface import (
+    ATTENTION_LAYERS,
+    HERO2_ACOUSTIC_LAYERS,
+    MAMBA_LAYERS,
+    SELECTED_SCALAR_COUNT,
+    selected_parameter_names,
+)
+
+
+def test_dpo_initial_identity_has_log2_but_nonzero_preference_gradient():
+    chosen = torch.tensor(3.0, requires_grad=True)
+    rejected = torch.tensor(1.0, requires_grad=True)
+    objective = dpo_pair_objective(
+        chosen_policy_logp=chosen,
+        rejected_policy_logp=rejected,
+        chosen_reference_logp=torch.tensor(3.0),
+        rejected_reference_logp=torch.tensor(1.0),
+        beta=0.2,
+    )
+    assert objective.margin.item() == 0.0
+    assert math.isclose(objective.loss.item(), math.log(2.0), rel_tol=0, abs_tol=1e-7)
+    objective.loss.backward()
+    assert chosen.grad.item() < 0.0
+    assert rejected.grad.item() > 0.0
+
+
+def test_dpo_positive_margin_reduces_loss():
+    identity = dpo_pair_objective(
+        chosen_policy_logp=torch.tensor(0.0), rejected_policy_logp=torch.tensor(0.0),
+        chosen_reference_logp=torch.tensor(0.0), rejected_reference_logp=torch.tensor(0.0), beta=0.2,
+    )
+    improved = dpo_pair_objective(
+        chosen_policy_logp=torch.tensor(2.0), rejected_policy_logp=torch.tensor(0.0),
+        chosen_reference_logp=torch.tensor(0.0), rejected_reference_logp=torch.tensor(0.0), beta=0.2,
+    )
+    assert improved.margin.item() > 0.0
+    assert improved.loss.item() < identity.loss.item()
+
+
+def test_hero2_partial_acoustic_surface_contract_is_fixed():
+    names = selected_parameter_names()
+    assert len(names) == 269
+    assert len(set(names)) == len(names)
+    assert len(ATTENTION_LAYERS) == 6
+    assert len(MAMBA_LAYERS) == 23
+    assert HERO2_ACOUSTIC_LAYERS == (30, 31)
+    assert SELECTED_SCALAR_COUNT == 1_074_327_616
+    assert names[-2:] == ("perception.proj.weight", "perception.proj.bias")

--- a/tests/collections/speechlm2/test_dpo_objective.py
+++ b/tests/collections/speechlm2/test_dpo_objective.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
+import hashlib
 import math
 
 import torch
@@ -9,6 +10,8 @@ from nemo.collections.speechlm2.dpo.model import _state_contract_digest, _state_
 from nemo.collections.speechlm2.dpo.surface import (
     ATTENTION_LAYERS,
     HERO2_ACOUSTIC_LAYERS,
+    HISTORICAL_R2_SURFACE_INVENTORY_SHA256,
+    HISTORICAL_R2_SURFACE_NAMES_SHA256,
     MAMBA_LAYERS,
     SELECTED_SCALAR_COUNT,
     selected_parameter_names,
@@ -52,7 +55,12 @@ def test_hero2_partial_acoustic_surface_contract_is_fixed():
     assert len(ATTENTION_LAYERS) == 6
     assert len(MAMBA_LAYERS) == 23
     assert HERO2_ACOUSTIC_LAYERS == (30, 31)
-    assert SELECTED_SCALAR_COUNT == 1_074_327_616
+    assert SELECTED_SCALAR_COUNT == 1_074_318_016
+    assert hashlib.sha256("\n".join(names).encode()).hexdigest() == HISTORICAL_R2_SURFACE_NAMES_SHA256
+    # This digest is the preserved r2 DCP's complete `name|shape|numel`
+    # inventory.  It makes the historical source for the scalar count explicit
+    # without baking a duplicate 269-row shape table into the training code.
+    assert HISTORICAL_R2_SURFACE_INVENTORY_SHA256 == "20cd5cb3a3fbdaa5a91e430e7a65dfdc53c463b72382e0d62a56039b4a7f9dfc"
     assert names[-2:] == ("perception.proj.weight", "perception.proj.bias")
 
 

--- a/tests/collections/speechlm2/test_dpo_objective.py
+++ b/tests/collections/speechlm2/test_dpo_objective.py
@@ -5,6 +5,7 @@ import math
 import torch
 
 from nemo.collections.speechlm2.dpo.objective import dpo_pair_objective
+from nemo.collections.speechlm2.dpo.model import _state_contract_digest, _state_sample_digest
 from nemo.collections.speechlm2.dpo.surface import (
     ATTENTION_LAYERS,
     HERO2_ACOUSTIC_LAYERS,
@@ -53,3 +54,10 @@ def test_hero2_partial_acoustic_surface_contract_is_fixed():
     assert HERO2_ACOUSTIC_LAYERS == (30, 31)
     assert SELECTED_SCALAR_COUNT == 1_074_327_616
     assert names[-2:] == ("perception.proj.weight", "perception.proj.bias")
+
+
+def test_source_dcp_authority_receipt_distinguishes_temporary_construction_weights():
+    construction = {"perception.encoder.weight": torch.tensor([[1.0, 2.0], [3.0, 4.0]])}
+    source_dcp = {"perception.encoder.weight": torch.tensor([[5.0, 6.0], [7.0, 8.0]])}
+    assert _state_contract_digest(construction) == _state_contract_digest(source_dcp)
+    assert _state_sample_digest(construction) != _state_sample_digest(source_dcp)

--- a/tests/collections/speechlm2/test_dpo_recipe_config.py
+++ b/tests/collections/speechlm2/test_dpo_recipe_config.py
@@ -2,9 +2,11 @@
 
 from pathlib import Path
 
+import torch
+from lightning.pytorch.plugins.precision.half import HalfPrecision
 from omegaconf import OmegaConf
 
-from nemo.collections.speechlm2.dpo.data import rank_active_slots
+from nemo.collections.speechlm2.dpo.data import PreferenceBatch, PreferencePair, rank_active_slots
 
 
 def test_hero2_r5_dpo_config_has_explicit_finite_two_pass_accounting():
@@ -34,3 +36,22 @@ def test_435_pair_schedule_has_fixed_multirank_ownership_and_five_padding_slots(
     # same 55-slot local accumulation shape, instead of a rotating global
     # modulo partition caused by the 435 % 8 offset.
     assert [active for _ in range(10)] == [(55, 55, 55, 54, 54, 54, 54, 54)] * 10
+
+
+def test_preference_batch_accepts_stock_lightning_bf16_input_conversion():
+    """The normal Lightning precision plugin may reconstruct the batch."""
+
+    pair = PreferencePair(
+        pair_id="p", source_id="s", prompt="<audio>", chosen="yes", rejected="no",
+        audio=torch.ones(4, dtype=torch.float32), active=True,
+    )
+    batch = PreferenceBatch(global_step=1, dpo_pass=1, source_shard=1, pairs=(pair,))
+    converted = HalfPrecision("bf16-true").convert_input(batch)
+    assert converted.global_step == 1
+    assert converted.dpo_pass == 1 and converted.source_shard == 1
+    assert converted.pairs[0].pair_id == "p"
+    assert converted.pairs[0].prompt == "<audio>"
+    assert converted.pairs[0].audio.dtype is torch.bfloat16
+    # Conversion returns a framework-owned transport copy; loader-provided
+    # samples retain their original data for the model's reference cache.
+    assert batch.pairs[0].audio.dtype is torch.float32

--- a/tests/collections/speechlm2/test_dpo_recipe_config.py
+++ b/tests/collections/speechlm2/test_dpo_recipe_config.py
@@ -110,12 +110,14 @@ def test_selected_gradient_layout_receipt_is_data_free_for_local_tensors():
     }
 
 
-def test_r22_server_entrypoint_uses_direct_pinned_source_without_a_runtime_overlay():
+def test_r22_server_entrypoint_stages_pinned_source_without_a_runtime_overlay():
     root = Path(__file__).parents[3]
     script = (root / "examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh").read_text(encoding="utf-8")
     assert "R22_NEMO_SOURCE" in script
     assert "R22_TRANSFORMER_ENCODER_SHA256" in script
-    assert "pip install --no-deps \"$R22_NEMO_SOURCE\"" in script
+    assert "R22_NEMO_SERVER_FINGERPRINT_SHA256" in script
+    assert 'test "$source_fingerprint" = "$expected"' in script
+    assert 'test "$staged_fingerprint" = "$expected"' in script
+    assert 'python3 -m pip install --no-deps --force-reinstall "$R22_STAGE_ROOT/source"' in script
     assert "PYTHONPATH" not in script
-    assert "cp " not in script
     assert "\npatch " not in script

--- a/tests/collections/speechlm2/test_dpo_recipe_config.py
+++ b/tests/collections/speechlm2/test_dpo_recipe_config.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+
+from pathlib import Path
+
+from omegaconf import OmegaConf
+
+
+def test_hero2_r5_dpo_config_has_explicit_finite_two_pass_accounting():
+    root = Path(__file__).parents[3]
+    cfg = OmegaConf.load(root / "examples/speechlm2/conf/salm_dpo_hero2_ami_historical_r5.yaml")
+    assert cfg.trainer.devices == 8
+    assert cfg.trainer.num_nodes == 1
+    assert cfg.trainer.max_steps == 20
+    assert cfg.dpo.explicit_passes == 2
+    assert cfg.dpo.expected_updates == 20
+    assert cfg.dpo.pairs_per_update == 435
+    assert cfg.dpo.source_shards == 10
+    assert cfg.data.expected_rows == cfg.dpo.pairs_per_update * cfg.dpo.source_shards
+    assert cfg.data.shuffle is False and cfg.data.cycle is False
+    assert cfg.dpo.beta == 0.2
+    assert cfg.dpo.learning_rate == 2.5e-6
+    assert cfg.dpo.optimizer.betas == [0.9, 0.95]
+    assert cfg.dpo.lora is False and cfg.dpo.peft is False and cfg.dpo.adapters is False

--- a/tests/collections/speechlm2/test_dpo_recipe_config.py
+++ b/tests/collections/speechlm2/test_dpo_recipe_config.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from omegaconf import OmegaConf
 
+from nemo.collections.speechlm2.dpo.data import rank_active_slots
+
 
 def test_hero2_r5_dpo_config_has_explicit_finite_two_pass_accounting():
     root = Path(__file__).parents[3]
@@ -21,3 +23,14 @@ def test_hero2_r5_dpo_config_has_explicit_finite_two_pass_accounting():
     assert cfg.dpo.learning_rate == 2.5e-6
     assert cfg.dpo.optimizer.betas == [0.9, 0.95]
     assert cfg.dpo.lora is False and cfg.dpo.peft is False and cfg.dpo.adapters is False
+
+
+def test_435_pair_schedule_has_fixed_multirank_ownership_and_five_padding_slots():
+    active = rank_active_slots(pairs_per_update=435, world_size=8)
+    assert active == (55, 55, 55, 54, 54, 54, 54, 54)
+    assert sum(active) == 435
+    assert 8 * max(active) - sum(active) == 5
+    # Ownership restarts per source shard.  Therefore all ten shards have the
+    # same 55-slot local accumulation shape, instead of a rotating global
+    # modulo partition caused by the 435 % 8 offset.
+    assert [active for _ in range(10)] == [(55, 55, 55, 54, 54, 54, 54, 54)] * 10

--- a/tests/collections/speechlm2/test_dpo_recipe_config.py
+++ b/tests/collections/speechlm2/test_dpo_recipe_config.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -11,6 +12,8 @@ from lightning.pytorch.plugins.precision.half import HalfPrecision
 from omegaconf import OmegaConf
 
 from nemo.collections.speechlm2.dpo.data import PreferenceBatch, PreferencePair, rank_active_slots
+from nemo.collections.speechlm2.dpo.model import DPOSALMAutomodel, _gradient_layout
+from nemo.collections.speechlm2.models.salm_automodel import SALMAutomodel
 
 
 class _ManualClipModule(LightningModule):
@@ -76,3 +79,32 @@ def test_stock_lightning_accepts_historical_manual_clip_when_trainer_clip_is_nul
     module.weight.grad = torch.tensor([2.0])
     module.clip_gradients(optimizer, gradient_clip_val=1.0, gradient_clip_algorithm="norm")
     assert module.weight.grad.item() == pytest.approx(1.0, abs=1e-5)
+
+
+def test_dpo_uses_inherited_mesh_aware_clip_once_with_historical_norm():
+    """DPO must not bypass SALMAutomodel's existing mixed-DTensor handler."""
+
+    assert DPOSALMAutomodel.configure_gradient_clipping is SALMAutomodel.configure_gradient_clipping
+    calls = []
+
+    class Harness:
+        cfg = SimpleNamespace(dpo=SimpleNamespace(gradient_clip_norm=1.0))
+
+        def configure_gradient_clipping(self, optimizer, gradient_clip_val, gradient_clip_algorithm):
+            calls.append((optimizer, gradient_clip_val, gradient_clip_algorithm))
+
+    optimizer = object()
+    DPOSALMAutomodel._clip_selected_gradients(Harness(), optimizer)
+    assert calls == [(optimizer, 1.0, "norm")]
+
+
+def test_selected_gradient_layout_receipt_is_data_free_for_local_tensors():
+    entry = _gradient_layout("perception.proj.weight", torch.ones((2, 3), dtype=torch.float32))
+    assert entry == {
+        "name": "perception.proj.weight",
+        "tensor_type": "torch.Tensor",
+        "global_shape": [2, 3],
+        "local_shape": [2, 3],
+        "dtype": "torch.float32",
+        "layout": {"kind": "local"},
+    }

--- a/tests/collections/speechlm2/test_dpo_recipe_config.py
+++ b/tests/collections/speechlm2/test_dpo_recipe_config.py
@@ -2,11 +2,21 @@
 
 from pathlib import Path
 
+import pytest
+
 import torch
+from lightning import LightningModule
+from lightning.pytorch import Trainer
 from lightning.pytorch.plugins.precision.half import HalfPrecision
 from omegaconf import OmegaConf
 
 from nemo.collections.speechlm2.dpo.data import PreferenceBatch, PreferencePair, rank_active_slots
+
+
+class _ManualClipModule(LightningModule):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor([2.0]))
 
 
 def test_hero2_r5_dpo_config_has_explicit_finite_two_pass_accounting():
@@ -15,6 +25,7 @@ def test_hero2_r5_dpo_config_has_explicit_finite_two_pass_accounting():
     assert cfg.trainer.devices == 8
     assert cfg.trainer.num_nodes == 1
     assert cfg.trainer.max_steps == 20
+    assert cfg.trainer.gradient_clip_val is None
     assert cfg.dpo.explicit_passes == 2
     assert cfg.dpo.expected_updates == 20
     assert cfg.dpo.pairs_per_update == 435
@@ -55,3 +66,13 @@ def test_preference_batch_accepts_stock_lightning_bf16_input_conversion():
     # Conversion returns a framework-owned transport copy; loader-provided
     # samples retain their original data for the model's reference cache.
     assert batch.pairs[0].audio.dtype is torch.float32
+
+
+def test_stock_lightning_accepts_historical_manual_clip_when_trainer_clip_is_null():
+    trainer = Trainer(accelerator="cpu", devices=1, gradient_clip_val=None, logger=False, enable_checkpointing=False)
+    module = _ManualClipModule()
+    module._trainer = trainer
+    optimizer = torch.optim.AdamW(module.parameters())
+    module.weight.grad = torch.tensor([2.0])
+    module.clip_gradients(optimizer, gradient_clip_val=1.0, gradient_clip_algorithm="norm")
+    assert module.weight.grad.item() == pytest.approx(1.0, abs=1e-5)

--- a/tests/collections/speechlm2/test_dpo_recipe_config.py
+++ b/tests/collections/speechlm2/test_dpo_recipe_config.py
@@ -108,3 +108,14 @@ def test_selected_gradient_layout_receipt_is_data_free_for_local_tensors():
         "dtype": "torch.float32",
         "layout": {"kind": "local"},
     }
+
+
+def test_r22_server_entrypoint_uses_direct_pinned_source_without_a_runtime_overlay():
+    root = Path(__file__).parents[3]
+    script = (root / "examples/speechlm2/serve_salm_dpo_hero2_vllm_r22.sh").read_text(encoding="utf-8")
+    assert "R22_NEMO_SOURCE" in script
+    assert "R22_TRANSFORMER_ENCODER_SHA256" in script
+    assert "pip install --no-deps \"$R22_NEMO_SOURCE\"" in script
+    assert "PYTHONPATH" not in script
+    assert "cp " not in script
+    assert "\npatch " not in script


### PR DESCRIPTION
Adds the verified finite direct-Lhotse SpeechLM2 DPO implementation, export path, and focused tests.

The mechanically verified recipe is preserved exactly at `00e617e2e5dc7ac79e18c92b73e6e56083af7ccb` and is also published on `codex/ami-dpo-verified-recipe`. The PR tip adds only a stale-test assertion correction so the tests describe the already-verified fingerprinted package-staging behavior; there are no post-verification changes under `examples/` or `nemo/`.

The experiment-facing data-generation-through-validation runbook is proposed separately in `pzelasko/canary-dev!24`. Evaluation uses Kunal's standard `burst_eval_vllm.py` path rather than a DPO-specific evaluator.

Focused result: 16 tests passed.