### PR TITLE
Keep the configured RNN-T loss across `change_vocabulary`

### DIFF
--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
@@ -321,7 +321,10 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
         self.decoder = EncDecHybridRNNTCTCBPEModel.from_config_dict(new_decoder_config)
 
         del self.loss
-        self.loss = RNNTLoss(num_classes=self.joint.num_classes_with_blank - 1)
+        loss_name, loss_kwargs = self.extract_rnnt_loss_cfg(self.cfg.get('loss', None))
+        self.loss = RNNTLoss(
+            num_classes=self.joint.num_classes_with_blank - 1, loss_name=loss_name, loss_kwargs=loss_kwargs
+        )
 
         if decoding_cfg is None:
             # Assume same decoding config as before

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -338,7 +338,10 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
         self.decoder = EncDecRNNTBPEModel.from_config_dict(new_decoder_config)
 
         del self.loss
-        self.loss = RNNTLoss(num_classes=self.joint.num_classes_with_blank - 1)
+        loss_name, loss_kwargs = self.extract_rnnt_loss_cfg(self.cfg.get('loss', None))
+        self.loss = RNNTLoss(
+            num_classes=self.joint.num_classes_with_blank - 1, loss_name=loss_name, loss_kwargs=loss_kwargs
+        )
 
         if decoding_cfg is None:
             # Assume same decoding config as before

--- a/tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe.py
+++ b/tests/collections/asr/test_asr_hybrid_rnnt_ctc_model_bpe.py
@@ -286,6 +286,27 @@ class TestEncDecHybridRNNTCTCBPEModel:
         reason='RNNTLoss has not been compiled with appropriate numba version.',
     )
     @pytest.mark.unit
+    def test_vocab_change_preserves_loss_config(self, test_data_dir, hybrid_asr_model):
+        """change_vocabulary rebuilds the loss, which must not silently drop its configuration."""
+        expected = hybrid_asr_model.loss._loss.fastemit_lambda
+        assert expected == hybrid_asr_model.cfg.loss.warprnnt_numba_kwargs.fastemit_lambda
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_tokenizer_dir = os.path.join(test_data_dir, "asr", "tokenizers", "an4_wpe_128", 'vocab.txt')
+            new_tokenizer_dir = os.path.join(tmpdir, 'tokenizer')
+            os.makedirs(new_tokenizer_dir, exist_ok=True)
+            shutil.copy2(old_tokenizer_dir, new_tokenizer_dir)
+
+            hybrid_asr_model.change_vocabulary(new_tokenizer_dir=new_tokenizer_dir, new_tokenizer_type='wpe')
+
+        assert hybrid_asr_model.loss._loss.fastemit_lambda == expected
+
+    @pytest.mark.with_downloads()
+    @pytest.mark.skipif(
+        not NUMBA_RNNT_LOSS_AVAILABLE,
+        reason='RNNTLoss has not been compiled with appropriate numba version.',
+    )
+    @pytest.mark.unit
     def test_decoding_change(self, hybrid_asr_model):
         assert isinstance(hybrid_asr_model.decoding.decoding, greedy_decode.GreedyBatchedRNNTInfer)
 

--- a/tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py
@@ -322,6 +322,27 @@ class TestEncDecRNNTBPEModel:
         reason='RNNTLoss has not been compiled with appropriate numba version.',
     )
     @pytest.mark.unit
+    def test_vocab_change_preserves_loss_config(self, test_data_dir, asr_model):
+        """change_vocabulary rebuilds the loss, which must not silently drop its configuration."""
+        expected = asr_model.loss._loss.fastemit_lambda
+        assert expected == asr_model.cfg.loss.warprnnt_numba_kwargs.fastemit_lambda
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            old_tokenizer_dir = os.path.join(test_data_dir, "asr", "tokenizers", "an4_wpe_128", 'vocab.txt')
+            new_tokenizer_dir = os.path.join(tmpdir, 'tokenizer')
+            os.makedirs(new_tokenizer_dir, exist_ok=True)
+            shutil.copy2(old_tokenizer_dir, new_tokenizer_dir)
+
+            asr_model.change_vocabulary(new_tokenizer_dir=new_tokenizer_dir, new_tokenizer_type='wpe')
+
+        assert asr_model.loss._loss.fastemit_lambda == expected
+
+    @pytest.mark.with_downloads()
+    @pytest.mark.skipif(
+        not NUMBA_RNNT_LOSS_AVAILABLE,
+        reason='RNNTLoss has not been compiled with appropriate numba version.',
+    )
+    @pytest.mark.unit
     def test_decoding_change(self, asr_model):
         assert isinstance(asr_model.decoding.decoding, greedy_decode.GreedyBatchedRNNTInfer)
 


### PR DESCRIPTION
`change_vocabulary` rebuilds the loss because the blank index moves with the vocabulary, but the BPE and hybrid BPE models rebuilt it with `RNNTLoss` defaults. Any configured `loss_name` and kwargs -- `fastemit_lambda`, `clamp`, or a non-default loss entirely -- were discarded, and training carried on with a silently different objective.

`EncDecRNNTModel.change_vocabulary` already reads the configuration back through `extract_rnnt_loss_cfg`; do the same in the two BPE paths.

Both test fixtures already configure `fastemit_lambda=0.001`, so the regression reproduces as `assert 0.0 == 0.001` without the fix.

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
