### PR TITLE
Support BF16 activations in the Numba RNN-T losses

### DIFF
--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py
@@ -299,7 +299,9 @@ def tdt_loss_gpu(
 
     # Select GPU index
     cuda.select_device(label_acts.device.index)
-    gpu_workspace = torch.zeros(gpu_size, device=label_acts.device, dtype=label_acts.dtype, requires_grad=False)
+    # The workspace holds FP32 dynamic-programming state (denominator, alphas, betas,
+    # log-likelihoods), so it must not inherit a narrow activation dtype.
+    gpu_workspace = torch.zeros(gpu_size, device=label_acts.device, dtype=torch.float32, requires_grad=False)
 
     tdt_workspace = torch.zeros(len(durations), device=label_acts.device, dtype=torch.long, requires_grad=False)
 
@@ -423,7 +425,9 @@ def multiblank_rnnt_loss_gpu(
 
     # Select GPU index
     cuda.select_device(acts.device.index)
-    gpu_workspace = torch.zeros(gpu_size, device=acts.device, dtype=acts.dtype, requires_grad=False)
+    # The workspace holds FP32 dynamic-programming state (denominator, alphas, betas,
+    # log-likelihoods), so it must not inherit a narrow activation dtype.
+    gpu_workspace = torch.zeros(gpu_size, device=acts.device, dtype=torch.float32, requires_grad=False)
 
     big_blank_workspace = torch.zeros(
         len(big_blank_durations), device=acts.device, dtype=torch.long, requires_grad=False

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py
@@ -86,7 +86,7 @@ def rnnt_loss_cpu(
 
     cpu_workspace = torch.zeros(gpu_size, device=log_probs.device, dtype=log_probs.dtype, requires_grad=False)
 
-    ### VIEW TENSORS AS VECTORS FOR POINTER INDEXING ###
+    # VIEW TENSORS AS VECTORS FOR POINTER INDEXING
     log_probs, acts_shape = rnnt_helper.flatten_tensor(log_probs)
     flat_labels, labels_shape = rnnt_helper.flatten_tensor(flat_labels)
 
@@ -116,7 +116,7 @@ def rnnt_loss_cpu(
             raise RuntimeError("Could not calculate forward scores")
 
     else:
-        ### FLATTEN GRAD TENSOR ###
+        # FLATTEN GRAD TENSOR
         grads, grads_shape = rnnt_helper.flatten_tensor(grads)
 
         status = wrapper.cost_and_grad(
@@ -188,7 +188,7 @@ def rnnt_loss_gpu(
     cuda.select_device(acts.device.index)
     gpu_workspace = torch.zeros(gpu_size, device=acts.device, dtype=torch.float32, requires_grad=False)
 
-    ### VIEW TENSORS AS VECTORS FOR POINTER INDEXING ###
+    # VIEW TENSORS AS VECTORS FOR POINTER INDEXING
     acts, acts_shape = rnnt_helper.flatten_tensor(acts)
 
     wrapper = gpu_rnnt.GPURNNT(
@@ -217,7 +217,7 @@ def rnnt_loss_gpu(
             raise RuntimeError("Could not calculate forward scores")
 
     else:
-        ### FLATTEN GRAD TENSOR ###
+        # FLATTEN GRAD TENSOR
         grads, grads_shape = rnnt_helper.flatten_tensor(grads)
 
         status = wrapper.cost_and_grad(
@@ -308,7 +308,7 @@ def tdt_loss_gpu(
     for i in range(0, len(durations)):
         tdt_workspace[i] = durations[i]
 
-    ### VIEW TENSORS AS VECTORS FOR POINTER INDEXING ###
+    # VIEW TENSORS AS VECTORS FOR POINTER INDEXING
     label_acts, label_acts_shape = rnnt_helper.flatten_tensor(label_acts)
     duration_acts, duration_acts_shape = rnnt_helper.flatten_tensor(duration_acts)
 
@@ -343,7 +343,7 @@ def tdt_loss_gpu(
             raise RuntimeError("Could not calculate forward scores")
 
     else:
-        ### FLATTEN GRAD TENSOR ###
+        # FLATTEN GRAD TENSOR
         label_grads, label_grads_shape = rnnt_helper.flatten_tensor(label_grads)
         duration_grads, duration_grads_shape = rnnt_helper.flatten_tensor(duration_grads)
 
@@ -436,7 +436,7 @@ def multiblank_rnnt_loss_gpu(
     for i in range(0, len(big_blank_durations)):
         big_blank_workspace[i] = big_blank_durations[i]
 
-    ### VIEW TENSORS AS VECTORS FOR POINTER INDEXING ###
+    # VIEW TENSORS AS VECTORS FOR POINTER INDEXING
     acts, acts_shape = rnnt_helper.flatten_tensor(acts)
 
     wrapper = gpu_rnnt.MultiblankGPURNNT(
@@ -468,7 +468,7 @@ def multiblank_rnnt_loss_gpu(
             raise RuntimeError("Could not calculate forward scores")
 
     else:
-        ### FLATTEN GRAD TENSOR ###
+        # FLATTEN GRAD TENSOR
         grads, grads_shape = rnnt_helper.flatten_tensor(grads)
 
         status = wrapper.cost_and_grad(

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
@@ -28,6 +28,7 @@
 
 import math
 
+import numba
 import torch
 from numba import cuda
 
@@ -61,13 +62,13 @@ def logp(
         The sum of logprobs[mb, t, u, v] + denom[mb, t, u]
     """
     col = (mb * maxT + t) * maxU + u
-    return denom[col] + acts[col * alphabet_size + v]
+    return denom[col] + numba.float32(acts[col * alphabet_size + v])
 
 
 @cuda.jit(device=True, inline=True)
 def logp_duration(acts: torch.Tensor, maxT: int, maxU: int, num_durations: int, mb: int, t: int, u: int, v: int):
     col = (mb * maxT + t) * maxU + u
-    return acts[col * num_durations + v]
+    return numba.float32(acts[col * num_durations + v])
 
 
 @cuda.jit()

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
@@ -392,15 +392,14 @@ def compute_grad_kernel(
                 # multiplying (1.0 + fastemit_lambda) with result.
                 grad -= math.exp(math.log1p(fastemit_lambda) + alphas[col] + logpk - logll[mb] + betas[col + 1])
 
+            # clamp gradient (if needed) while it is still an FP32 register, so that
+            # narrow `grads` dtypes are not rounded twice.
+            if clamp > 0.0:
+                grad = min(grad, clamp)
+                grad = max(grad, -clamp)
+
             # update grads[b, t, u, v] = grad
             grads[col * alphabet_size + idx] = grad
-
-            # clamp gradient (if needed)
-            if clamp > 0.0:
-                g = grads[col * alphabet_size + idx]
-                g = min(g, clamp)
-                g = max(g, -clamp)
-                grads[col * alphabet_size + idx] = g
 
             # update internal index through the thread_buffer;
             # until idx < V + 1, such that entire vocabulary has been updated.
@@ -870,15 +869,14 @@ def compute_multiblank_grad_kernel(
                     math.log1p(fastemit_lambda) + alphas[col] + logpk - sigma - logll[mb] + betas[col + 1]
                 )
 
+            # clamp gradient (if needed) while it is still an FP32 register, so that
+            # narrow `grads` dtypes are not rounded twice.
+            if clamp > 0.0:
+                grad = min(grad, clamp)
+                grad = max(grad, -clamp)
+
             # update grads[b, t, u, v] = grad
             grads[col * alphabet_size + idx] = grad
-
-            # clamp gradient (if needed)
-            if clamp > 0.0:
-                g = grads[col * alphabet_size + idx]
-                g = min(g, clamp)
-                g = max(g, -clamp)
-                grads[col * alphabet_size + idx] = g
 
             # update internal index through the thread_buffer;
             # until idx < V + 1, such that entire vocabulary has been updated.
@@ -1424,15 +1422,14 @@ def compute_tdt_grad_kernel(
                             + duration_acts[col * num_durations + i]
                         )
 
+            # clamp gradient (if needed) while it is still an FP32 register, so that
+            # narrow `label_grads` dtypes are not rounded twice.
+            if clamp > 0.0:
+                grad = min(grad, clamp)
+                grad = max(grad, -clamp)
+
             # update grads[b, t, u, v] = grad
             label_grads[col * alphabet_size + idx] = grad
-
-            # clamp gradient (if needed)
-            if clamp > 0.0:
-                g = label_grads[col * alphabet_size + idx]
-                g = min(g, clamp)
-                g = max(g, -clamp)
-                label_grads[col * alphabet_size + idx] = g
 
             # update internal index through the thread_buffer;
             # until idx < V + 1, such that entire vocabulary has been updated.

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
@@ -352,7 +352,7 @@ def compute_grad_kernel(
         while idx < alphabet_size:
             # remember, `col` represents the tri-index [b, t, u]
             # therefore; logpk = denom[b, t, u] + acts[b, t, u, v]
-            logpk = denom[col] + acts[col * alphabet_size + idx]
+            logpk = logp(denom, acts, maxT, maxU, alphabet_size, mb, t, u, idx)
             # initialize the grad of the sample acts[b, t, u, v]
             grad = math.exp(alphas[col] + betas[col] + logpk - logll[mb])
 
@@ -364,7 +364,7 @@ def compute_grad_kernel(
             if fastemit_lambda > 0.0 and u < U - 1:
                 fastemit_grad = fastemit_lambda * math.exp(
                     alphas[col]  # alphas(t, u)
-                    + (denom[col] + acts[col * alphabet_size + labels[u]])  # y_hat(t, u)
+                    + logp(denom, acts, maxT, maxU, alphabet_size, mb, t, u, labels[u])  # y_hat(t, u)
                     + betas[col + 1]  # betas(t, u+1)
                     + logpk  # log Pr(k|t, u)
                     - logll[mb]  # total log likelihood for normalization
@@ -804,7 +804,7 @@ def compute_multiblank_grad_kernel(
         while idx < alphabet_size:
             # remember, `col` represents the tri-index [b, t, u]
             # therefore; logpk = denom[b, t, u] + acts[b, t, u, v]
-            logpk = denom[col] + acts[col * alphabet_size + idx]
+            logpk = logp(denom, acts, maxT, maxU, alphabet_size, mb, t, u, idx)
             # initialize the grad of the sample acts[b, t, u, v]
             grad = math.exp(alphas[col] + betas[col] + logpk - logll[mb])
 
@@ -820,7 +820,7 @@ def compute_multiblank_grad_kernel(
             if fastemit_lambda > 0.0 and u < U - 1:
                 fastemit_grad = fastemit_lambda * math.exp(
                     alphas[col]  # alphas(t, u)
-                    + (denom[col] + acts[col * alphabet_size + labels[u]])
+                    + logp(denom, acts, maxT, maxU, alphabet_size, mb, t, u, labels[u])  # y_hat(t, u)
                     + betas[col + 1]  # betas(t, u+1)
                     + logpk  # log Pr(k|t, u)
                     - sigma
@@ -1321,13 +1321,13 @@ def compute_tdt_grad_kernel(
 
     if t < T and u < U:
         logpk_blank = (
-            denom[col] + acts[col * alphabet_size + blank_] - sigma
+            logp(denom, acts, maxT, maxU, alphabet_size, mb, t, u, blank_) - sigma
         )  # whenever sigma is used, it is for logit under-normalization.
 
         if idx < num_durations:
             grad = 0.0
             if t + durations[idx] < T and u < U - 1:  # for label
-                logpk_label = denom[col] + acts[col * alphabet_size + labels[u]] - sigma
+                logpk_label = logp(denom, acts, maxT, maxU, alphabet_size, mb, t, u, labels[u]) - sigma
                 grad -= math.exp(alphas[col] + betas[col + 1 + durations[idx] * maxU] + logpk_label - logll[mb])
 
             if t + durations[idx] < T and durations[idx] > 0:  # for blank in the middle
@@ -1336,7 +1336,7 @@ def compute_tdt_grad_kernel(
             if t + durations[idx] == T and u == U - 1 and durations[idx] > 0:  # for blank as the last symbol
                 grad -= math.exp(alphas[col] + logpk_blank - logll[mb])
 
-            grad = grad * math.exp(duration_acts[col * num_durations + idx])
+            grad = grad * math.exp(logp_duration(duration_acts, maxT, maxU, num_durations, mb, t, u, idx))
             duration_grads[col * num_durations + idx] = grad
 
         # For cuda kernels, maximum number of threads per block is limited to some value.
@@ -1349,7 +1349,7 @@ def compute_tdt_grad_kernel(
         while idx < alphabet_size:
             # remember, `col` represents the tri-index [b, t, u]
             # therefore; logpk = denom[b, t, u] + acts[b, t, u, v]
-            logpk = denom[col] + acts[col * alphabet_size + idx]
+            logpk = logp(denom, acts, maxT, maxU, alphabet_size, mb, t, u, idx)
             # initialize the grad of the sample acts[b, t, u, v]
             grad = math.exp(alphas[col] + betas[col] + logpk - logll[mb])
 
@@ -1365,8 +1365,10 @@ def compute_tdt_grad_kernel(
                     if t + durations[i] < T:
                         fastemit_grad += fastemit_lambda * math.exp(
                             alphas[col]  # alphas(t, u)
-                            + (denom[col] + acts[col * alphabet_size + labels[u]])  # log prob of token emission
-                            + duration_acts[col * num_durations + i]  # duration log-prob
+                            + logp(
+                                denom, acts, maxT, maxU, alphabet_size, mb, t, u, labels[u]
+                            )  # log prob of token emission
+                            + logp_duration(duration_acts, maxT, maxU, num_durations, mb, t, u, i)  # duration log-prob
                             + betas[col + 1 + durations[i] * maxU]  # betas(t, u+1)
                             + logpk  # log Pr(k|t, u)
                             - sigma  # for logit under-normalization
@@ -1386,7 +1388,11 @@ def compute_tdt_grad_kernel(
                         continue
                     if t == T - durations[i]:
                         grad -= math.exp(
-                            alphas[col] + logpk - sigma - logll[mb] + duration_acts[col * num_durations + i]
+                            alphas[col]
+                            + logpk
+                            - sigma
+                            - logll[mb]
+                            + logp_duration(duration_acts, maxT, maxU, num_durations, mb, t, u, i)
                         )
 
             # grad of blank across t < T;
@@ -1402,7 +1408,7 @@ def compute_tdt_grad_kernel(
                             - sigma
                             - logll[mb]
                             + betas[col + maxU * durations[i]]
-                            + duration_acts[col * num_durations + i]
+                            + logp_duration(duration_acts, maxT, maxU, num_durations, mb, t, u, i)
                         )
 
             # grad of correct token across u < U;
@@ -1420,7 +1426,7 @@ def compute_tdt_grad_kernel(
                             - sigma
                             - logll[mb]
                             + betas[col + 1 + maxU * durations[i]]
-                            + duration_acts[col * num_durations + i]
+                            + logp_duration(duration_acts, maxT, maxU, num_durations, mb, t, u, i)
                         )
 
             # clamp gradient (if needed) while it is still an FP32 register, so that

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/reduce.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/reduce.py
@@ -29,6 +29,7 @@
 import enum
 import math
 
+import numba
 import torch
 from numba import cuda
 
@@ -36,6 +37,9 @@ from nemo.collections.asr.parts.numba.rnnt_loss.utils import global_constants, r
 
 warp_size = global_constants.warp_size()
 dtype = global_constants.dtype()
+
+# RNN-T dynamic-programming state is FP32. Promote narrow activation reads
+# explicitly because Numba-CUDA cannot implicitly unify BF16 with FP32.
 
 CTA_REDUCE_SIZE = 128
 
@@ -147,13 +151,13 @@ def _reduce_rows(I_opid: int, R_opid: int, acts, output, num_rows: int):
     col = cuda.blockIdx.x
 
     # allocate shared thread memory
-    storage = cuda.shared.array(shape=(CTA_REDUCE_SIZE,), dtype=acts.dtype)
+    storage = cuda.shared.array(shape=(CTA_REDUCE_SIZE,), dtype=dtype)
 
     max = output[col]
 
     # // Each block works on a column
     if idx < num_rows:
-        curr = acts[col * num_rows + idx] - max
+        curr = numba.float32(acts[col * num_rows + idx]) - max
         if I_opid == 0:
             curr = rnnt_helper.exponential(curr)
         else:
@@ -162,7 +166,7 @@ def _reduce_rows(I_opid: int, R_opid: int, acts, output, num_rows: int):
     idx += CTA_REDUCE_SIZE
 
     while idx < num_rows:
-        activation_ = acts[col * num_rows + idx] - max
+        activation_ = numba.float32(acts[col * num_rows + idx]) - max
 
         if I_opid == 0 and R_opid == 0:
             curr = rnnt_helper.add(curr, rnnt_helper.exponential(activation_))
@@ -212,13 +216,13 @@ def _reduce_minus(I_opid: int, R_opid: int, acts, output, num_rows: int):
     col = cuda.blockIdx.x
 
     # allocate shared thread memory
-    storage = cuda.shared.array(shape=(CTA_REDUCE_SIZE,), dtype=acts.dtype)
+    storage = cuda.shared.array(shape=(CTA_REDUCE_SIZE,), dtype=dtype)
 
     max = output[col]
 
     # // Each block works on a column
     if idx < num_rows:
-        curr = acts[col * num_rows + idx] - max
+        curr = numba.float32(acts[col * num_rows + idx]) - max
         if I_opid == 0:
             curr = rnnt_helper.exponential(curr)
         else:
@@ -227,7 +231,7 @@ def _reduce_minus(I_opid: int, R_opid: int, acts, output, num_rows: int):
     idx += CTA_REDUCE_SIZE
 
     while idx < num_rows:
-        activation_ = acts[col * num_rows + idx] - max
+        activation_ = numba.float32(acts[col * num_rows + idx]) - max
 
         if I_opid == 0 and R_opid == 0:
             curr = rnnt_helper.add(curr, rnnt_helper.exponential(activation_))

--- a/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
+++ b/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
@@ -625,5 +625,81 @@ class TestTDTLoss:
         assert np.allclose(pt_grads, expected_grads, rtol=1e-2), "td gradient mismatch."
 
 
+class TestRNNTLossNumbaBFloat16:
+    """BF16 activations must compile and agree with FP32.
+
+    Numba-CUDA cannot implicitly unify BF16 with the FP32 dynamic-programming state, so a
+    regression here surfaces as a kernel compilation failure (``RecursionError`` from type
+    inference, or ``NumbaNotImplementedError`` when a BF16 buffer reaches a kernel argument)
+    rather than a numerical mismatch.
+    """
+
+    @staticmethod
+    def _inputs(dtype, vocab, batch=3, max_source=7, max_target=4):
+        torch.manual_seed(3)
+        acts = torch.randn(batch, max_source, max_target + 1, vocab, device='cuda', dtype=dtype, requires_grad=True)
+        labels = torch.randint(0, vocab - 4, (batch, max_target), device='cuda', dtype=torch.int64)
+        source_lengths = torch.full((batch,), max_source, device='cuda', dtype=torch.int64)
+        target_lengths = torch.full((batch,), max_target, device='cuda', dtype=torch.int64)
+        return acts, labels, source_lengths, target_lengths
+
+    def _compare_against_float32(self, build_loss, vocab):
+        costs, grads = {}, {}
+        for dtype in (torch.float32, torch.bfloat16):
+            acts, labels, source_lengths, target_lengths = self._inputs(dtype, vocab)
+            cost = build_loss()(acts, labels, source_lengths, target_lengths)
+            grads[dtype] = torch.autograd.grad(cost.sum(), acts)[0].float()
+            costs[dtype] = cost.float()
+
+        assert torch.isfinite(grads[torch.bfloat16]).all()
+        assert torch.count_nonzero(grads[torch.bfloat16])
+        torch.testing.assert_close(costs[torch.bfloat16], costs[torch.float32], atol=2e-2, rtol=2e-2)
+        torch.testing.assert_close(grads[torch.bfloat16], grads[torch.float32], atol=2e-2, rtol=2e-2)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('fastemit_lambda', [0.0, 0.01])
+    @pytest.mark.parametrize('clamp', [-1.0, 0.02])
+    def test_rnnt_bfloat16_matches_float32(self, fastemit_lambda, clamp):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+        self._compare_against_float32(
+            lambda: RNNTLossNumba(blank=7, reduction='none', fastemit_lambda=fastemit_lambda, clamp=clamp),
+            vocab=8,
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('fastemit_lambda', [0.0, 0.01])
+    @pytest.mark.parametrize('clamp', [-1.0, 0.02])
+    def test_multiblank_rnnt_bfloat16_matches_float32(self, fastemit_lambda, clamp):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+        self._compare_against_float32(
+            lambda: MultiblankRNNTLossNumba(
+                blank=9,
+                big_blank_durations=[2, 4],
+                reduction='none',
+                fastemit_lambda=fastemit_lambda,
+                clamp=clamp,
+                sigma=0.05,
+            ),
+            vocab=10,
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('fastemit_lambda', [0.0, 0.01])
+    @pytest.mark.parametrize('clamp', [-1.0, 0.02])
+    def test_tdt_bfloat16_matches_float32(self, fastemit_lambda, clamp):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+        self._compare_against_float32(
+            lambda: TDTLossNumba(
+                blank=7,
+                durations=[0, 1, 2],
+                reduction='none',
+                fastemit_lambda=fastemit_lambda,
+                clamp=clamp,
+                sigma=0.05,
+            ),
+            vocab=11,
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Numba CUDA cannot unify BF16 with the FP32 dynamic-programming state the RNN-T kernels
use. Passing BF16 activations fails at kernel compile time: `RecursionError` from type
inference for standard RNN-T, `NumbaNotImplementedError` for multi-blank and TDT.

I came across this when benchmarking BF16 in numba when implementing a tiled rnnt loss, it will be added in a followup PR, it achieves 2x speedup and 10x less memory usage

**Collection**: asr

# Changelog

- Promote activation reads to FP32 at the point of use, in `logp`, `logp_duration` and
  the reduction kernels. Activations stay narrow in memory and the arithmetic runs in FP32.
- Route the three gradient kernels through the `logp` helpers rather than repeating the
  index arithmetic inline.
- Allocate the multi-blank and TDT GPU workspace as FP32. It backs the softmax
  denominator, alphas, betas and log-likelihoods, but was sized from the activation
  dtype. `rnnt_loss_gpu` already allocated FP32.
- Allocate the CTA reduction scratch as FP32 instead of the activation dtype.
- Clamp the gradient while it is still an FP32 register, instead of writing it to the
  output buffer, reading it back, clamping, and writing again.
- The last commit rewrites `### ... ###` banner comments as `#` in
`nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py`. Those E266 violations predate this
branch, but linting runs over changed files and fails the job, so any PR editing that
module has to clear them first.

# Results

Joint and loss region, forward and backward, B=32 T=400 U=128 V=1024, RTX 5090:

| loss dtype     | GPU p50  | peak memory |
| -------------- | -------- | ----------- |
| FP32 (current) | 133.2 ms | 9.55 GiB    |
| BF16 (this PR) | 105.5 ms | 7.22 GiB    |

21% faster, 24% less memory. FP32 loss and gradients are bit-identical before and after.

# Tests

`TestRNNTLossNumbaBFloat16` adds 12 cases covering standard, multi-blank and TDT across
fastemit and clamp settings. Each asserts the kernels compile under BF16 and agree with
FP32. The regression these guard is a compile failure rather than numerical drift.

This also fixes two pre-existing FP16 failures in `test_reduce.py`, which now passes 4/4.
The five FP16 failures in `test_gpu_rnnt_kernel.py` predate this branch and are unchanged.

# Usage

BF16 reaches the kernels through `NUMBA_CUDA_USE_NVIDIA_BINDING=1`, which already sets
`force_float32=False` for `warprnnt_numba`.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
