### PR TITLE
cp: `Fix SALM Automodel rc0 compatibility (#15992)` into `r3.0.0`

### DIFF
--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -15,7 +15,7 @@ import os
 
 import torch
 from lightning.pytorch import Trainer, seed_everything
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.speechlm2 import SALM, DataModule, SALMDataset
 from nemo.core.config import hydra_runner
@@ -26,8 +26,10 @@ if torch.cuda.is_available():
     torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
 
-def _create_salm_dataset(tokenizer, data_cfg):
+def _create_salm_dataset(tokenizer, data_cfg: DictConfig | dict) -> SALMDataset:
+    """Build SALMDataset without forwarding unset options to legacy NeMo packages."""
     multispeaker_cfg = data_cfg.get("multispeaker_cfg", None)
+    # TODO(Dongji): Remove after all release images ship SALMDataset with multispeaker_cfg support.
     if multispeaker_cfg is None:
         return SALMDataset(tokenizer=tokenizer)
     return SALMDataset(tokenizer=tokenizer, multispeaker_cfg=multispeaker_cfg)

--- a/examples/speechlm2/salm_train.py
+++ b/examples/speechlm2/salm_train.py
@@ -26,6 +26,13 @@ if torch.cuda.is_available():
     torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
 
+def _create_salm_dataset(tokenizer, data_cfg):
+    multispeaker_cfg = data_cfg.get("multispeaker_cfg", None)
+    if multispeaker_cfg is None:
+        return SALMDataset(tokenizer=tokenizer)
+    return SALMDataset(tokenizer=tokenizer, multispeaker_cfg=multispeaker_cfg)
+
+
 @hydra_runner(config_path="conf", config_name="salm")
 def train(cfg):
     OmegaConf.resolve(cfg)
@@ -46,7 +53,7 @@ def train(cfg):
     with trainer.init_module():
         model = model_cls(OmegaConf.to_container(cfg.model, resolve=True))
 
-    dataset = SALMDataset(tokenizer=model.tokenizer)
+    dataset = _create_salm_dataset(model.tokenizer, cfg.data)
     datamodule = DataModule(cfg.data, tokenizer=model.tokenizer, dataset=dataset)
 
     trainer.fit(model, datamodule)

--- a/nemo/collections/speechlm2/parts/automodel_compat.py
+++ b/nemo/collections/speechlm2/parts/automodel_compat.py
@@ -45,24 +45,29 @@ def remove_automodel_backend_for_hf_fallback(
     try:
         from nemo_automodel._transformers.model_init import get_is_hf_model
         from transformers import AutoConfig
-    except (ImportError, AttributeError) as error:
-        logger.warning("Could not resolve Automodel implementation; leaving backend unchanged: %s", error)
-        return False
 
-    config = kwargs.get("config")
-    if config is None:
-        config_kwargs = {key: kwargs[key] for key in _HF_CONFIG_KWARGS if key in kwargs}
-        config = AutoConfig.from_pretrained(
-            model_path_or_name,
-            trust_remote_code=trust_remote_code,
-            **config_kwargs,
+        config = kwargs.get("config")
+        if config is None:
+            config_kwargs = {key: kwargs[key] for key in _HF_CONFIG_KWARGS if key in kwargs}
+            config = AutoConfig.from_pretrained(
+                model_path_or_name,
+                trust_remote_code=trust_remote_code,
+                **config_kwargs,
+            )
+
+        uses_hf_model = kwargs.get("quantization_config") is not None or get_is_hf_model(
+            config,
+            force_hf=bool(kwargs.get("force_hf", False)),
         )
-
-    if not get_is_hf_model(config, force_hf=bool(kwargs.get("force_hf", False))):
+    except Exception as error:
+        logger.warning("Could not determine Automodel implementation; leaving backend unchanged: %s", error)
         return False
 
-    kwargs.pop("backend")
+    if not uses_hf_model:
+        return False
+
     # TODO(Dongji): Remove after Automodel consumes backend before entering its HF fallback.
+    kwargs.pop("backend")
     logger.warning("Ignoring Automodel backend configuration for Hugging Face fallback model %s", model_path_or_name)
     return True
 

--- a/nemo/collections/speechlm2/parts/automodel_compat.py
+++ b/nemo/collections/speechlm2/parts/automodel_compat.py
@@ -20,6 +20,51 @@ from torch import nn
 logger = logging.getLogger(__name__)
 
 _COMPATIBILITY_MARKER = "_nemo_speech_nemotron_h_layer_compatibility"
+_HF_CONFIG_KWARGS = ("cache_dir", "revision", "token", "local_files_only", "subfolder")
+
+
+def remove_automodel_backend_for_hf_fallback(
+    model_path_or_name: str,
+    kwargs: dict,
+    *,
+    trust_remote_code: bool = False,
+) -> bool:
+    """Remove Automodel-only backend configuration before its Hugging Face fallback.
+
+    Automodel consumes ``backend`` for native model implementations but
+    forwards it to Hugging Face model constructors on the fallback path. Those
+    constructors do not accept this Automodel-specific keyword. Resolve the same
+    native-vs-HF choice up front and remove only the incompatible fallback kwarg.
+
+    Returns:
+        ``True`` when ``backend`` was removed; otherwise ``False``.
+    """
+    if "backend" not in kwargs:
+        return False
+
+    try:
+        from nemo_automodel._transformers.model_init import get_is_hf_model
+        from transformers import AutoConfig
+    except (ImportError, AttributeError) as error:
+        logger.warning("Could not resolve Automodel implementation; leaving backend unchanged: %s", error)
+        return False
+
+    config = kwargs.get("config")
+    if config is None:
+        config_kwargs = {key: kwargs[key] for key in _HF_CONFIG_KWARGS if key in kwargs}
+        config = AutoConfig.from_pretrained(
+            model_path_or_name,
+            trust_remote_code=trust_remote_code,
+            **config_kwargs,
+        )
+
+    if not get_is_hf_model(config, force_hf=bool(kwargs.get("force_hf", False))):
+        return False
+
+    kwargs.pop("backend")
+    # TODO(Dongji): Remove after Automodel consumes backend before entering its HF fallback.
+    logger.warning("Ignoring Automodel backend configuration for Hugging Face fallback model %s", model_path_or_name)
+    return True
 
 
 class _ModuleDictLayersAdapter:

--- a/nemo/collections/speechlm2/parts/pretrained.py
+++ b/nemo/collections/speechlm2/parts/pretrained.py
@@ -87,9 +87,17 @@ def load_pretrained_automodel_llm(
     """
     from nemo_automodel import NeMoAutoModelForCausalLM
 
-    from nemo.collections.speechlm2.parts.automodel_compat import install_nemotron_h_layer_compatibility
+    from nemo.collections.speechlm2.parts.automodel_compat import (
+        install_nemotron_h_layer_compatibility,
+        remove_automodel_backend_for_hf_fallback,
+    )
 
     install_nemotron_h_layer_compatibility()
+    remove_automodel_backend_for_hf_fallback(
+        model_path_or_name,
+        kwargs,
+        trust_remote_code=trust_remote_code,
+    )
 
     if pretrained_weights:
         return NeMoAutoModelForCausalLM.from_pretrained(model_path_or_name, torch_dtype=dtype, **kwargs)

--- a/tests/collections/speechlm2/test_automodel_compat.py
+++ b/tests/collections/speechlm2/test_automodel_compat.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
 import torch.nn as nn
 
 _COMPAT_PATH = Path(__file__).resolve().parents[3] / "nemo/collections/speechlm2/parts/automodel_compat.py"
@@ -70,6 +71,58 @@ def _install_fake_legacy_automodel(monkeypatch, *, has_upstream_fix=False, has_s
     monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed", distributed)
     monkeypatch.setitem(sys.modules, "nemo_automodel.components.distributed.parallelizer", parallelizer)
     return parallelizer
+
+
+def _install_fake_model_selection(monkeypatch, *, is_hf_model):
+    class FakeAutoConfig:
+        @classmethod
+        def from_pretrained(cls, model_path_or_name, **kwargs):
+            return object()
+
+    transformers = ModuleType("transformers")
+    transformers.AutoConfig = FakeAutoConfig
+
+    model_init = ModuleType("nemo_automodel._transformers.model_init")
+    model_init.get_is_hf_model = lambda config, force_hf: force_hf or is_hf_model
+    automodel_transformers = ModuleType("nemo_automodel._transformers")
+    automodel_transformers.model_init = model_init
+    automodel = ModuleType("nemo_automodel")
+    automodel._transformers = automodel_transformers
+
+    monkeypatch.setitem(sys.modules, "transformers", transformers)
+    monkeypatch.setitem(sys.modules, "nemo_automodel", automodel)
+    monkeypatch.setitem(sys.modules, "nemo_automodel._transformers", automodel_transformers)
+    monkeypatch.setitem(sys.modules, "nemo_automodel._transformers.model_init", model_init)
+
+
+def test_hf_fallback_drops_automodel_backend(monkeypatch):
+    _install_fake_model_selection(monkeypatch, is_hf_model=True)
+
+    class Qwen3ForCausalLM:
+        def __init__(self, config):
+            self.config = config
+
+    backend = object()
+    kwargs = {"backend": backend}
+    with pytest.raises(TypeError, match="unexpected keyword argument 'backend'"):
+        Qwen3ForCausalLM(object(), **kwargs)
+
+    assert _COMPAT_MODULE.remove_automodel_backend_for_hf_fallback("Qwen/Qwen3-1.7B", kwargs) is True
+    assert "backend" not in kwargs
+    Qwen3ForCausalLM(object(), **kwargs)
+
+
+def test_native_automodel_preserves_backend(monkeypatch):
+    _install_fake_model_selection(monkeypatch, is_hf_model=False)
+
+    backend = object()
+    kwargs = {"backend": backend}
+
+    assert (
+        _COMPAT_MODULE.remove_automodel_backend_for_hf_fallback("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", kwargs)
+        is False
+    )
+    assert kwargs["backend"] is backend
 
 
 def test_legacy_parallelizer_supports_native_nemotron_v3(monkeypatch):

--- a/tests/collections/speechlm2/test_automodel_compat.py
+++ b/tests/collections/speechlm2/test_automodel_compat.py
@@ -125,6 +125,43 @@ def test_native_automodel_preserves_backend(monkeypatch):
     assert kwargs["backend"] is backend
 
 
+def test_native_automodel_with_bnb_quantization_drops_backend(monkeypatch):
+    _install_fake_model_selection(monkeypatch, is_hf_model=False)
+
+    backend = object()
+    quantization_config = object()
+    kwargs = {"backend": backend, "quantization_config": quantization_config}
+
+    assert _COMPAT_MODULE.remove_automodel_backend_for_hf_fallback("native-model", kwargs) is True
+    assert "backend" not in kwargs
+    assert kwargs["quantization_config"] is quantization_config
+
+
+def test_model_selection_failure_preserves_backend(monkeypatch, caplog):
+    _install_fake_model_selection(monkeypatch, is_hf_model=True)
+
+    class BrokenAutoConfig:
+        @classmethod
+        def from_pretrained(cls, model_path_or_name, **kwargs):
+            raise RuntimeError("config resolution failed")
+
+    monkeypatch.setattr(sys.modules["transformers"], "AutoConfig", BrokenAutoConfig)
+    backend = object()
+    kwargs = {"backend": backend}
+
+    with caplog.at_level(logging.WARNING):
+        assert _COMPAT_MODULE.remove_automodel_backend_for_hf_fallback("unavailable-model", kwargs) is False
+
+    assert kwargs["backend"] is backend
+    assert "Could not determine Automodel implementation" in caplog.text
+
+
+def test_installed_automodel_model_selection_accepts_force_hf_keyword():
+    model_init = pytest.importorskip("nemo_automodel._transformers.model_init")
+
+    assert model_init.get_is_hf_model(object(), force_hf=True) is True
+
+
 def test_legacy_parallelizer_supports_native_nemotron_v3(monkeypatch):
     parallelizer = _install_fake_legacy_automodel(monkeypatch)
 

--- a/tests/collections/speechlm2/test_salm_automodel.py
+++ b/tests/collections/speechlm2/test_salm_automodel.py
@@ -63,6 +63,7 @@ def model():
     cfg = {
         **resolve_pretrained_models(),
         "pretrained_weights": False,
+        "automodel_backend": {"dispatcher": "torch"},
         "prompt_format": PROMPT,
         "audio_locator_tag": AUDIO_LOCATOR_TAG,
         "perception": {

--- a/tests/collections/speechlm2/test_salm_automodel.py
+++ b/tests/collections/speechlm2/test_salm_automodel.py
@@ -63,6 +63,7 @@ def model():
     cfg = {
         **resolve_pretrained_models(),
         "pretrained_weights": False,
+        # Exercise backend preservation for native fixtures and removal for HF fixtures.
         "automodel_backend": {"dispatcher": "torch"},
         "prompt_format": PROMPT,
         "audio_locator_tag": AUDIO_LOCATOR_TAG,

--- a/tests/collections/speechlm2/test_salm_train.py
+++ b/tests/collections/speechlm2/test_salm_train.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+from contextlib import nullcontext
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+_SALM_TRAIN_PATH = Path(__file__).parents[3] / "examples" / "speechlm2" / "salm_train.py"
+_SPEC = importlib.util.spec_from_file_location("salm_train_for_test", _SALM_TRAIN_PATH)
+_SALM_TRAIN = importlib.util.module_from_spec(_SPEC)
+with patch("torch.cuda.is_available", return_value=False):
+    _SPEC.loader.exec_module(_SALM_TRAIN)
+
+
+@pytest.mark.unit
+def test_create_salm_dataset_omits_unset_multispeaker_config(monkeypatch):
+    class LegacySALMDataset:
+        def __init__(self, tokenizer):
+            self.tokenizer = tokenizer
+
+    tokenizer = object()
+    monkeypatch.setattr(_SALM_TRAIN, "SALMDataset", LegacySALMDataset)
+
+    dataset = _SALM_TRAIN._create_salm_dataset(tokenizer, {})
+
+    assert dataset.tokenizer is tokenizer
+
+
+@pytest.mark.unit
+def test_create_salm_dataset_forwards_configured_multispeaker_config(monkeypatch):
+    multispeaker_cfg = {"num_speakers": 2}
+
+    class MultiSpeakerSALMDataset:
+        def __init__(self, tokenizer, multispeaker_cfg=None):
+            self.tokenizer = tokenizer
+            self.multispeaker_cfg = multispeaker_cfg
+
+    tokenizer = object()
+    monkeypatch.setattr(_SALM_TRAIN, "SALMDataset", MultiSpeakerSALMDataset)
+
+    dataset = _SALM_TRAIN._create_salm_dataset(tokenizer, {"multispeaker_cfg": multispeaker_cfg})
+
+    assert dataset.tokenizer is tokenizer
+    assert dataset.multispeaker_cfg is multispeaker_cfg
+
+
+@pytest.mark.unit
+def test_train_uses_compatible_dataset_factory(monkeypatch, tmp_path):
+    tokenizer = object()
+    dataset = object()
+    calls = []
+
+    class FakeSALM:
+        def __init__(self, model_cfg):
+            self.tokenizer = tokenizer
+
+    class FakeTrainer:
+        def __init__(self, **kwargs):
+            pass
+
+        def init_module(self):
+            return nullcontext()
+
+        def fit(self, model, datamodule):
+            pass
+
+    class FakeDataModule:
+        def __init__(self, data_cfg, tokenizer, dataset):
+            pass
+
+    def create_salm_dataset(tokenizer_arg, data_cfg):
+        calls.append((tokenizer_arg, data_cfg))
+        return dataset
+
+    monkeypatch.setattr(_SALM_TRAIN, "SALM", FakeSALM)
+    monkeypatch.setattr(_SALM_TRAIN, "Trainer", FakeTrainer)
+    monkeypatch.setattr(_SALM_TRAIN, "DataModule", FakeDataModule)
+    monkeypatch.setattr(_SALM_TRAIN, "_create_salm_dataset", create_salm_dataset)
+    monkeypatch.setattr(_SALM_TRAIN, "seed_everything", lambda seed: None)
+    monkeypatch.setattr(_SALM_TRAIN, "resolve_trainer_cfg", lambda cfg: {})
+    monkeypatch.setattr(_SALM_TRAIN, "exp_manager", lambda trainer, cfg: tmp_path)
+    monkeypatch.setattr(_SALM_TRAIN.OmegaConf, "save", lambda cfg, path: None)
+    monkeypatch.setattr(_SALM_TRAIN.torch.cuda, "is_available", lambda: False)
+
+    cfg = _SALM_TRAIN.OmegaConf.create(
+        {
+            "data": {"train_ds": {"seed": 0}},
+            "model": {},
+            "trainer": {},
+        }
+    )
+    _SALM_TRAIN.train.__wrapped__(cfg)
+
+    assert calls == [(tokenizer, cfg.data)]


### PR DESCRIPTION
Manual cherry-pick of #15992 into `r3.0.0`.

## Cherry-picked commits

- `f8c2ef794` → `a2bd0fa00`: Fix SALM backend forwarding to HF models
- `a2d42111e` → `100a8f9ab`: Fix SALM dataset construction compatibility
- `128a7f7f3` → `ffe280bc2`: Harden SALM compatibility probes

All commits retain their DCO sign-offs and include `cherry-pick -x` source references.

## Conflict resolution

The only conflict was in `examples/speechlm2/salm_train.py`. The release branch constructed `SALMDataset` with the legacy-safe tokenizer-only call, while #15992 introduced `_create_salm_dataset()` to support both the legacy constructor and explicit multispeaker configurations. The resolution keeps that compatibility helper and routes dataset construction through it.

## Validation

Validated against `nvcr.io/nvidian/nemo-speech:26.07.rc0`:

- `tests/collections/speechlm2/test_automodel_compat.py`: 10 passed
- `tests/collections/speechlm2/test_salm_train.py`: 3 passed
- Black: passed
- isort: passed
- `git diff --check`: passed

## Follow-up

After merge, the Speech release image must be rebuilt so the `nemo/` package changes reach QA runtime, followed by validation on the original 8× H200 configuration from NVBug 6533347.
