### PR TITLE
fix: IndexError when cut has no supervisions

### DIFF
--- a/nemo/collections/common/prompts/canary2.py
+++ b/nemo/collections/common/prompts/canary2.py
@@ -202,6 +202,10 @@ def canary2(cut: Cut, prompt: Canary2PromptFormatter) -> dict[str, torch.Tensor]
     turns = [dict(role="user", slots=slots)]
     # If data has no transcript, create empty response with <eos> only.
     text = ' '.join(s.text for s in cut.supervisions if s.text is not None)
+    if not cut.supervisions:
+        raise RuntimeError(
+            f"Cut {cut.id} has no supervisions; cannot create the assistant turn without a language hint."
+        )
     turns.append(
         dict(
             role="assistant",

--- a/tests/collections/common/prompts/test_canary2_supervisions.py
+++ b/tests/collections/common/prompts/test_canary2_supervisions.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+from unittest.mock import patch
+
+from nemo.collections.common.prompts import canary2 as canary2_mod
+from nemo.collections.common.prompts.canary2 import canary2
+
+
+class _MonoCut: ...
+class _MixedCut: ...
+
+
+class _FakePrompt:
+    PROMPT_LANGUAGE_SLOT = "prompt_language"
+    tokenizer = None
+
+    def encode_dialog(self, turns):
+        return {"answer_ids": torch.tensor([1])}
+
+
+def test_canary2_raises_on_empty_supervisions():
+    with patch.object(canary2_mod, "MonoCut", _MonoCut), patch.object(
+        canary2_mod, "MixedCut", _MixedCut
+    ):
+        cut = _MonoCut()
+        cut.id = "empty"
+        cut.custom = {"source_lang": "en", "target_lang": "en"}
+        cut.supervisions = []
+        with pytest.raises(RuntimeError, match="has no supervisions"):
+            canary2(cut, _FakePrompt())


### PR DESCRIPTION
This PR addresses the following issue in `nemo/collections/common/prompts/canary2.py`: IndexError when cut has no supervisions.

## Changes
- `nemo/collections/common/prompts/canary2.py`: IndexError when cut has no supervisions.

## Details
```diff
--- a/nemo/collections/common/prompts/canary2.py
+++ b/nemo/collections/common/prompts/canary2.py
@@ -1,3 +1,7 @@
-    # If data has no transcript, create empty response with <eos> only.
-    text = ' '.join(s.text for s in cut.supervisions if s.text is not None)
-    turns.append(
+    # If data has no transcript, create empty response with <eos> only.
+    text = ' '.join(s.text for s in cut.supervisions if s.text is not None)
+    if not cut.supervisions:
+        raise RuntimeError(
+            f"Cut {cut.id} has no supervisions; cannot create the assistant turn without a language hint."
+        )
+    turns.append(
```

## Tests
- `tests/collections/common/prompts/test_canary2_supervisions.py`

```diff
--- /dev/null
+++ b/tests/collections/common/prompts/test_canary2_supervisions.py
@@ -0,0 +1,30 @@
+import pytest
+import torch
+from unittest.mock import patch
+
+from nemo.collections.common.prompts import canary2 as canary2_mod
+from nemo.collections.common.prompts.canary2 import canary2
+
+
+class _MonoCut: ...
+class _MixedCut: ...
+
+
+class _FakePrompt:
+    PROMPT_LANGUAGE_SLOT = "prompt_language"
+    tokenizer = None
+
+    def encode_dialog(self, turns):
+        return {"answer_ids": torch.tensor([1])}
+
+
+def test_canary2_raises_on_empty_supervisions():
+    with patch.object(canary2_mod, "MonoCut", _MonoCut), patch.object(
+        canary2_mod, "MixedCut", _MixedCut
+    ):
+        cut = _MonoCut()
+        cut.id = "empty"
+        cut.custom = {"source_lang": "en", "target_lang": "en"}
+        cut.supervisions = []
+        with pytest.raises(RuntimeError, match="has no supervisions"):
+            canary2(cut, _FakePrompt())
```