### PR TITLE
fix: get_new_cursor_for_update can index past list start

### DIFF
--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -1213,7 +1213,7 @@ def get_new_cursor_for_update(
     cursor_for_old_segments = frame_start
     cursor_index: int = len(segment_range_ts)
     count = 0
-    while True and len(segment_range_ts) > 0:
+    while len(segment_range_ts) > 0 and count < len(segment_range_ts):
         t_range = segment_range_ts[-1 * (count + 1)]
         if frame_start <= t_range[1]:
             count += 1

--- a/tests/collections/asr/utils/test_speaker_utils_online_cursor.py
+++ b/tests/collections/asr/utils/test_speaker_utils_online_cursor.py
@@ -1,0 +1,11 @@
+import pytest
+
+from nemo.collections.asr.parts.utils.speaker_utils import get_new_cursor_for_update
+
+
+def test_get_new_cursor_handles_all_overlapping_segments():
+    frame_start = 0.0
+    segment_range_ts = [[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]]
+    cursor, index = get_new_cursor_for_update(frame_start, segment_range_ts)
+    assert cursor == 0.0
+    assert index == 0


### PR DESCRIPTION
This PR addresses the following issue in `nemo/collections/asr/parts/utils/speaker_utils.py`: get_new_cursor_for_update can index past list start.

## Changes
- `nemo/collections/asr/parts/utils/speaker_utils.py`: get_new_cursor_for_update can index past list start.

## Details
```diff
--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -1,7 +1,7 @@
-    while True and len(segment_range_ts) > 0:
-        t_range = segment_range_ts[-1 * (count + 1)]
-        if frame_start <= t_range[1]:
-            count += 1
-            cursor_for_old_segments = t_range[0]
-        else:
-            break
+    while len(segment_range_ts) > 0 and count < len(segment_range_ts):
+        t_range = segment_range_ts[-1 * (count + 1)]
+        if frame_start <= t_range[1]:
+            count += 1
+            cursor_for_old_segments = t_range[0]
+        else:
+            break
```

## Tests
- `tests/collections/asr/utils/test_speaker_utils_online_cursor.py`

```diff
diff --git a/tests/collections/asr/utils/test_speaker_utils_online_cursor.py b/tests/collections/asr/utils/test_speaker_utils_online_cursor.py
new file mode 100644
--- /dev/null
+++ b/tests/collections/asr/utils/test_speaker_utils_online_cursor.py
@@ -0,0 +1,11 @@
+import pytest
+
+from nemo.collections.asr.parts.utils.speaker_utils import get_new_cursor_for_update
+
+
+def test_get_new_cursor_handles_all_overlapping_segments():
+    frame_start = 0.0
+    segment_range_ts = [[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]]
+    cursor, index = get_new_cursor_for_update(frame_start, segment_range_ts)
+    assert cursor == 0.0
+    assert index == 0
```