### PR TITLE
fix: get_subsegments drops valid short segments

### DIFF
--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -992,7 +992,8 @@ def get_subsegments(
         slices = np.ceil(num_feat_frames / int(feat_per_sec * shift)).astype(int)
         slice_end = start + shift * slices
     else:
-        slices = np.ceil(1 + (duration - window) / shift).astype(int)
+        base = math.ceil((duration - window) / shift)
+        slices = 1 if base < 0 else base + 1
     if slices == 1:
         if min(duration, window) >= min_subsegment_duration:
             subsegments.append([start, min(duration, window)])

--- a/tests/collections/asr/utils/test_speaker_utils_subsegments.py
+++ b/tests/collections/asr/utils/test_speaker_utils_subsegments.py
@@ -1,0 +1,18 @@
+import pytest
+
+from nemo.collections.asr.parts.utils.speaker_utils import get_subsegments
+
+
+def test_get_subsegments_returns_segments_between_shift_and_window():
+    result = get_subsegments(
+        offset=0.0,
+        window=2.0,
+        shift=0.5,
+        duration=0.6,
+        min_subsegment_duration=0.01,
+        decimals=2,
+    )
+    assert len(result) == 1
+    start, dur = result[0]
+    assert start == pytest.approx(0.0)
+    assert dur == pytest.approx(0.6)


### PR DESCRIPTION
This PR addresses the following issue in `nemo/collections/asr/parts/utils/speaker_utils.py`: get_subsegments drops valid short segments.

## Changes
- `nemo/collections/asr/parts/utils/speaker_utils.py`: get_subsegments drops valid short segments.

## Details
```diff
--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -1,3 +1,4 @@
-    else:
-        slices = np.ceil(1 + (duration - window) / shift).astype(int)
-    if slices == 1:
+    else:
+        base = math.ceil((duration - window) / shift)
+        slices = 1 if base < 0 else base + 1
+    if slices == 1:
```

## Tests
- `tests/collections/asr/utils/test_speaker_utils_subsegments.py`

```diff
diff --git a/tests/collections/asr/utils/test_speaker_utils_subsegments.py b/tests/collections/asr/utils/test_speaker_utils_subsegments.py
new file mode 100644
--- /dev/null
+++ b/tests/collections/asr/utils/test_speaker_utils_subsegments.py
@@ -0,0 +1,18 @@
+import pytest
+
+from nemo.collections.asr.parts.utils.speaker_utils import get_subsegments
+
+
+def test_get_subsegments_returns_segments_between_shift_and_window():
+    result = get_subsegments(
+        offset=0.0,
+        window=2.0,
+        shift=0.5,
+        duration=0.6,
+        min_subsegment_duration=0.01,
+        decimals=2,
+    )
+    assert len(result) == 1
+    start, dur = result[0]
+    assert start == pytest.approx(0.0)
+    assert dur == pytest.approx(0.6)
```