### PR TITLE
fix: merge_int_intervals returns floats for single interval

### DIFF
--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -731,7 +731,7 @@ def merge_int_intervals(intervals_in: List[List[int]]) -> List[List[int]]:
     if num_intervals == 0:
         return []
     elif num_intervals == 1:
-        return intervals_in
+        return [[int(intervals_in[0][0]), int(intervals_in[0][1])]]
     else:
         merged_list: List[List[int]] = []
         stt2: int = 0


### PR DESCRIPTION
I am unsure if this is a problematic issue or not but I thought I would socialize this in case it is. This PR addresses the following issue in `nemo/collections/asr/parts/utils/speaker_utils.py`: merge_int_intervals returns floats for single interval.

## Changes
- `nemo/collections/asr/parts/utils/speaker_utils.py`: merge_int_intervals returns floats for single interval.

## Details
```diff
--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -1,2 +1,2 @@
-    elif num_intervals == 1:
-        return intervals_in
+    elif num_intervals == 1:
+        return [[int(intervals_in[0][0]), int(intervals_in[0][1])]]
```

## Tests
- `tests/collections/asr/utils/test_speaker_utils_merge_int_intervals.py`

```diff
diff --git a/tests/collections/asr/utils/test_speaker_utils_merge_int_intervals.py b/tests/collections/asr/utils/test_speaker_utils_merge_int_intervals.py
new file mode 100644
--- /dev/null
+++ b/tests/collections/asr/utils/test_speaker_utils_merge_int_intervals.py
@@ -0,0 +1,9 @@
+import pytest
+
+from nemo.collections.asr.parts.utils.speaker_utils import merge_int_intervals
+
+
+def test_merge_int_intervals_converts_single_float_interval_to_ints():
+    result = merge_int_intervals([[1.9, 4.2]])
+    assert result == [[1, 4]]
```